### PR TITLE
Add Domain Operations Phase 0–1 execution package

### DIFF
--- a/docs/domain-operations/README.md
+++ b/docs/domain-operations/README.md
@@ -1,0 +1,24 @@
+# DNS Ops — Domain Operations Phase 0–1
+
+This directory contains the approved product context and execution artifacts for the internal Domain Operations Phase 0–1 outcome.
+
+## Authority order
+
+1. [`phase-0-1-execution-contract-v4.1.md`](./phase-0-1-execution-contract-v4.1.md) — **authoritative execution contract**. Scope, budget, gates, exclusions and completion criteria are binding.
+2. [`controlled-test-assets-runbook-v4.1.md`](./controlled-test-assets-runbook-v4.1.md) — authoritative runbook for seeded failures and controlled non-production mutations.
+3. [`day-0-worksheet.md`](./day-0-worksheet.md) — must be completed before implementation begins.
+4. [`product-and-mcp-discussion-brief.md`](./product-and-mcp-discussion-brief.md) — long-term product thesis and commercial option context. It is **not** implementation scope for Phase 0–1.
+
+## Operating rule
+
+> DNS Ops should be useful without AI, more powerful with an agent, and never less trustworthy because an agent is involved.
+
+## Phase 0–1 classification
+
+- Internal infrastructure first.
+- Maximum 15 focused engineering days.
+- Maximum three calendar weeks.
+- Maximum 24 founder hours.
+- No RUA ingestion, hypothesis graph, built-in analyst, Buzz integration, OAuth product, provider writes from DNS Ops, or commercial features.
+
+The implementation owner must establish the exact authority SHA before changing product behavior and must not reopen decisions marked closed in the execution contract.

--- a/docs/domain-operations/controlled-test-assets-runbook-v4.1.md
+++ b/docs/domain-operations/controlled-test-assets-runbook-v4.1.md
@@ -1,0 +1,310 @@
+# DNS Ops — Controlled Test Asset Runbook V4.1
+
+**Applies to:** DNS Ops Lean Phase 0–1 Execution Contract V4.1  
+**Purpose:** make LIVE-01, LIVE-02 and LIVE-03 repeatable without giving DNS Ops or MCP any provider-write capability.
+
+---
+
+# 1. Authority boundary
+
+Provider-side mutations are performed only by the deterministic fault-injection harness.
+
+```text
+Implementing/reviewing agent
+        ↓ invokes
+Deterministic fault harness
+        ↓ reads runtime secret
+Test-zone provider API
+```
+
+The agent may run the harness. It must never receive or print the provider token.
+
+The following are prohibited:
+
+- direct provider API calls by the agent;
+- provider credentials in prompts, logs, MCP results or Git;
+- mutations outside the designated test zone;
+- production or client-domain mutations;
+- using the test credential from DNS Ops application code or MCP;
+- manually editing the baseline while a fault run is active.
+
+---
+
+# 2. Required test assets and secrets
+
+```text
+DNSOPS_TEST_DOMAIN
+DNSOPS_TEST_WEB_HOST
+DNSOPS_TEST_MAIL_SUBDOMAIN
+DNSOPS_TEST_ZONE_ID
+DNSOPS_TEST_PROVIDER_KIND
+DNSOPS_TEST_PROVIDER_TOKEN
+```
+
+The provider credential must:
+
+- be scoped to exactly `DNSOPS_TEST_ZONE_ID`;
+- allow only the minimum zone-read and DNS-record mutation operations;
+- be stored as a runtime secret;
+- be represented in configuration and logs only by a non-secret identifier or SHA-256 fingerprint;
+- be revoked after the controlled-test phase.
+
+The harness must allowlist the exact mutable names and record types before any mutation.
+
+Example allowlist shape:
+
+```ts
+export type TestMutationAllowlist = {
+  zoneId: string;
+  records: Array<{
+    name: string;
+    types: Array<"A" | "AAAA" | "CNAME" | "TXT">;
+    mutationIds: Array<"LIVE-01" | "LIVE-02" | "LIVE-03">;
+  }>;
+};
+```
+
+---
+
+# 3. Deterministic harness contract
+
+The implementation may choose file names and internals, but the repository must expose equivalent operator commands for:
+
+```text
+status      Show test-zone identity, allowlist and credential fingerprint.
+prepare     Capture baseline, validate TTLs and prove rollback capability.
+apply       Apply one named seeded fault.
+verify      Verify provider state and authoritative DNS/HTTP evidence.
+restore     Restore the exact captured baseline.
+run         Execute a complete named LIVE scenario.
+recover     Retry restoration from a recovery artifact.
+```
+
+Every command must emit a structured artifact containing:
+
+```ts
+export type FaultRunArtifact = {
+  runId: string;
+  mutationId: "LIVE-01" | "LIVE-02" | "LIVE-03";
+  zoneId: string;
+  targetNames: string[];
+  baselineHash: string;
+  providerCredentialFingerprint: string;
+  appliedAt?: string;
+  restoredAt?: string;
+  providerResponses: string[];
+  authoritativeEvidenceIds: string[];
+  recursiveEvidenceIds: string[];
+  scanTaskIds: string[];
+  signalIds: string[];
+  caseIds: string[];
+  auditEventIds: string[];
+  result: "PASS" | "FAIL" | "RECOVERY_REQUIRED";
+  recoveryInstructions?: string;
+};
+```
+
+Secrets and full provider response headers must be redacted.
+
+---
+
+# 4. One-time TTL preparation
+
+For each mutable DNS record:
+
+1. Read and record the current value and TTL.
+2. Set TTL to `60` through the harness.
+3. Wait at least the **previous TTL plus 60 seconds** before capturing the healthy test baseline.
+4. Query the authoritative nameservers directly and verify TTL `60` is being served.
+5. Save the original value and TTL in the rollback artifact.
+
+Do not begin LIVE-03 while the previous longer TTL may still be present in recursive caches.
+
+A recursive answer may be observed, but it is not authoritative pass/fail evidence for a DNS mutation test.
+
+---
+
+# 5. Authoritative freshness for live DNS tests
+
+For every DNS mutation and restoration, query the zone’s authoritative nameservers directly.
+
+Persist:
+
+- queried nameserver;
+- query name and type;
+- timestamp;
+- response code;
+- answer;
+- TTL;
+- AA flag when available;
+- raw or normalized trace reference;
+- any limitation in proving authority.
+
+For registered test assets, `scan_request` must include this authoritative vantage even when ordinary portfolio scans operate with degraded authoritative evidence.
+
+A stale recursive result cannot independently cause LIVE-03 to pass or fail.
+
+---
+
+# 6. RFC 9989 deterministic fixture resolver
+
+All unit/integration fixtures for DMARC discovery use a stubbed resolver. They never use live DNS.
+
+Required resolver contract:
+
+```ts
+export type DnsFixtureResponse =
+  | { kind: "ANSWER"; values: string[] }
+  | { kind: "NODATA" }
+  | { kind: "NXDOMAIN" }
+  | { kind: "SERVFAIL" }
+  | { kind: "TIMEOUT" };
+
+export interface DmarcFixtureResolver {
+  resolveTxt(name: string): Promise<DnsFixtureResponse>;
+  readonly queryTrace: string[];
+}
+```
+
+Required assertions:
+
+- exact ordered query trace;
+- no network access;
+- no more than eight tree-walk queries;
+- deterministic NODATA/NXDOMAIN/SERVFAIL/timeout behavior;
+- deterministic `psd=y`, `psd=n`, `np` and inherited-policy cases;
+- multiple-record error behavior.
+
+---
+
+# 7. LIVE-01 — Redirect regression
+
+## Prepare
+
+- Verify `DNSOPS_TEST_WEB_HOST` has the expected canonical redirect.
+- Capture healthy HTTP/HTTPS and apex/`www` matrix.
+- Capture baseline hash.
+
+## Fault
+
+- Use the harness to apply the allowlisted redirect fault.
+- Run MCP `scan_request`.
+- Require `REDIRECT_TOPOLOGY_REGRESSION`.
+- Open or retrieve the canonical case through MCP.
+- Set disposition to acknowledged.
+
+## Restore
+
+- Restore the exact baseline through the harness.
+- Run MCP `scan_request`.
+- Require fresh evidence and case resolution.
+
+## Reopen proof
+
+- Apply the same fault again.
+- Run MCP `scan_request`.
+- Require the existing operational condition to reopen without duplicate active cases or alerts.
+- Restore again and verify healthy state.
+
+---
+
+# 8. LIVE-02 — Indexability regression
+
+## Prepare
+
+- Verify the test page is expected to be indexable.
+- Capture HTML, response headers and canonical baseline.
+
+## Fault
+
+- Introduce an allowlisted `noindex` response/header condition using the test harness or deterministic test-host deployment fixture.
+- Run MCP `scan_request`.
+- Require `HOMEPAGE_INDEXABILITY_REGRESSION`.
+
+## Restore
+
+- Restore baseline.
+- Run MCP `scan_request`.
+- Require fresh evidence and resolution.
+
+No production page may be used.
+
+---
+
+# 9. LIVE-03 — Mail DNS configuration regression
+
+## Prepare
+
+- Use only `DNSOPS_TEST_MAIL_SUBDOMAIN`.
+- Confirm no real mail flow depends on it.
+- Confirm TTL `60` has fully propagated.
+- Capture TXT baseline and authoritative evidence.
+
+## Fault
+
+- Apply the allowlisted SPF or DMARC test-record mutation through the harness.
+- Verify the provider accepted it.
+- Query authoritative NS directly.
+- Run MCP `scan_request`.
+- Require `MAIL_DNS_CONFIGURATION_REGRESSION`.
+
+## Restore
+
+- Restore the exact baseline.
+- Query authoritative NS directly.
+- Run MCP `scan_request`.
+- Require fresh evidence and resolution.
+
+The result proves only published DNS configuration regression. It must not claim real sender authentication or traffic failure.
+
+---
+
+# 10. Failure and recovery
+
+On any interruption:
+
+1. Stop further mutations.
+2. Execute harness `restore`.
+3. Query authoritative NS or the test web endpoint.
+4. Compare current state with `baselineHash`.
+5. If restoration fails, emit `RECOVERY_REQUIRED` with exact provider, zone, records, desired values and operator commands.
+6. Do not continue Gate 3 until baseline restoration is proven.
+
+The test provider token must be revoked after final review or immediately after suspected exposure.
+
+---
+
+# 11. Fresh reviewer use
+
+The fresh reviewer may execute LIVE scenarios only through the deterministic harness.
+
+The reviewer receives:
+
+- exact SHA;
+- V4.1 contract;
+- this runbook;
+- test-asset identifiers;
+- permission to invoke the harness;
+- no plaintext provider token;
+- no builder session or claims before verdict.
+
+The reviewer must verify restoration before returning a verdict.
+
+---
+
+# 12. Completion evidence
+
+Gate 3 evidence must include:
+
+- TTL preparation artifact;
+- baseline hash;
+- provider credential fingerprint;
+- allowlist;
+- direct authoritative traces;
+- recursive traces where collected;
+- mutation and restoration provider responses;
+- MCP `scan_request` task IDs;
+- signal, alert and case IDs;
+- audit IDs;
+- reopen proof;
+- final baseline-restored proof.

--- a/docs/domain-operations/day-0-worksheet.md
+++ b/docs/domain-operations/day-0-worksheet.md
@@ -1,0 +1,166 @@
+# DNS Ops — Day 0 Worksheet
+
+**Complete before the implementation agent changes code.**  
+**Founder budget:** 2 hours for portfolio/manual baseline + 1.5 hours for purpose/criticality + 1 hour for test-asset authorization.
+
+---
+
+# A. Decision record
+
+- Date:
+- Authority SHA supplied to agent:
+- Founder/operator:
+- Maximum portfolio size: **30 domains**
+- Selected test DNS provider:
+- Selected non-production test zone:
+- Test credential created and scoped only to that zone: [ ]
+- Credential stored as runtime secret, not in Git: [ ]
+
+---
+
+# B. Current manual-work baseline
+
+Use actual observed time where possible. The success gate requires at least four named checks to become automated or materially shorter.
+
+| ID | Manual check | Current method/tool | Frequency per month | Minutes per run | Domains per run | Current evidence location | Keep/replace target |
+|---|---|---|---:|---:|---:|---|---|
+| MAN-01 | Domain expiration | Registrar dashboards / notes |  |  |  |  |  |
+| MAN-02 | Nameserver/delegation and key DNS records | `dig`, provider UI |  |  |  |  |  |
+| MAN-03 | SPF/DKIM/DMARC published configuration | Manual DNS/provider inspection |  |  |  |  |  |
+| MAN-04 | TLS validity and expiration | Browser/provider/manual checker |  |  |  |  |  |
+| MAN-05 | HTTP availability | Browser/curl/uptime tool |  |  |  |  |  |
+| MAN-06 | HTTP/HTTPS + apex/`www` redirects | Browser/curl |  |  |  |  |  |
+| MAN-07 | Homepage noindex/X-Robots-Tag/canonical | Source/headers/browser |  |  |  |  |  |
+| MAN-08 | MTA-STS/TLS-RPT published configuration | DNS/manual checker |  |  |  |  |  |
+| MAN-09 | Portfolio inventory/ownership notes | Sheets/docs/memory |  |  |  |  |  |
+| MAN-10 | Other: |  |  |  |  |  |  |
+
+## Baseline totals
+
+```text
+Estimated manual checks per month:
+Estimated manual minutes per month:
+Checks selected for replacement in Phase 0–1:
+1.
+2.
+3.
+4.
+Optional 5.
+```
+
+---
+
+# C. Initial portfolio — up to 30 domains
+
+The rows below are starter candidates from known projects. Verify ownership/operational responsibility before including them. Planned or inactive domains should normally be excluded from the first live portfolio unless they test a specific `PARKED`/`UNKNOWN` case.
+
+Allowed purpose:
+
+```text
+WEB | MAIL | WEB_AND_MAIL | REDIRECT | PARKED | UNKNOWN
+```
+
+Allowed criticality:
+
+```text
+HIGH | NORMAL | LOW
+```
+
+| # | Domain/host candidate | Include? | Purpose | Criticality | Responsible actor | Production/client? | Notes / why included |
+|---:|---|:---:|---|---|---|---|---|
+| 1 | computin.dev |  |  |  | Antonio |  |  |
+| 2 | portail.cl |  |  |  | Antonio |  |  |
+| 3 | producit.cl |  |  |  | Antonio |  |  |
+| 4 | convertirleads.cl |  |  |  | Antonio |  |  |
+| 5 | computincloudhosting.com |  |  |  | Antonio |  |  |
+| 6 | domu.cl |  |  |  | Antonio |  |  |
+| 7 | cafetape.cl |  |  |  |  |  |  |
+| 8 | patagoniavirgin.com |  |  |  |  |  |  |
+| 9 | cms.patagoniavirgin.com |  |  |  |  |  |  |
+| 10 | nvnm.cl |  |  |  |  |  | Google Workspace/domain-role context |
+| 11 | faunaprod.cl |  |  |  |  |  |  |
+| 12 | fest.faunaprod.cl |  |  |  |  |  | SES sending subdomain |
+| 13 | faunaprimaverafest.cl |  |  |  |  |  | Redirect/website context |
+| 14 | jdf.cl |  |  |  |  |  | Mimecast/Microsoft 365 context |
+| 15 | hilaria.cl |  |  |  |  | Client |  |
+| 16 | corporativo.hilaria.cl |  |  |  |  | Client |  |
+| 17 | matrimonios.hilaria.events |  |  |  |  | Client |  |
+| 18 | agenciavio.cl |  |  |  |  | Client/candidate | Verify current operational responsibility |
+| 19 | nivelando.cl |  |  |  | Antonio | Planned | Exclude if not registered/live |
+| 20 | tufichamedia.cl |  |  |  | Antonio | Planned | Exclude if not registered/live |
+| 21 |  |  |  |  |  |  |  |
+| 22 |  |  |  |  |  |  |  |
+| 23 |  |  |  |  |  |  |  |
+| 24 |  |  |  |  |  |  |  |
+| 25 |  |  |  |  |  |  |  |
+| 26 |  |  |  |  |  |  |  |
+| 27 |  |  |  |  |  |  |  |
+| 28 |  |  |  |  |  |  |  |
+| 29 |  |  |  |  |  |  |  |
+| 30 |  |  |  |  |  |  |  |
+
+## Selection rules
+
+- Include only assets Computin is actually responsible for monitoring.
+- Prefer registrable domains; include a subdomain separately only when it has a distinct operational purpose or provider path.
+- Do not include planned domains merely to reach 30.
+- Keep the first portfolio smaller when ownership or purpose is uncertain.
+- Mark client/production assets as observation-only; they are never fault-injection targets.
+
+---
+
+# D. Controlled test assets
+
+These must be non-production and have no client or real mail dependency.
+
+| Variable | Selected value | Verified safe? | Notes |
+|---|---|:---:|---|
+| `DNSOPS_TEST_DOMAIN` |  |  |  |
+| `DNSOPS_TEST_WEB_HOST` |  |  |  |
+| `DNSOPS_TEST_MAIL_SUBDOMAIN` |  |  |  |
+| `DNSOPS_TEST_ZONE_ID` |  |  |  |
+| `DNSOPS_TEST_PROVIDER_KIND` |  |  |  |
+| Provider token secret name |  |  | Do not paste token value |
+| Token fingerprint |  |  |  |
+
+## Safety confirmations
+
+- [ ] No production traffic.
+- [ ] No customer traffic.
+- [ ] No real inbound/outbound mail dependency.
+- [ ] Token restricted to exactly one test zone.
+- [ ] Token has only minimum zone-read and DNS-mutation permission.
+- [ ] Exact mutable hostnames/record types allowlisted.
+- [ ] Baseline and rollback path documented.
+- [ ] TTL 60 preparation can begin before Gate 3.
+- [ ] Token revocation owner identified.
+
+---
+
+# E. Playbook calibration slots
+
+The agent drafts; Antonio approves the operational truth.
+
+| Playbook | Reviewer notes | Approved? |
+|---|---|:---:|
+| `domain-expiry.md` |  |  |
+| `tls-regression.md` |  |  |
+| `redirect-regression.md` |  |  |
+| `indexability-regression.md` |  |  |
+| `mail-dns-configuration-regression.md` |  |  |
+| `unknown-evidence.md` |  |  |
+
+---
+
+# F. Day 0 completion gate
+
+Do not start implementation until:
+
+- [ ] At least four manual checks have real frequency and time estimates.
+- [ ] The initial portfolio is selected; it does not need to contain 30 domains.
+- [ ] Every included domain has purpose and criticality.
+- [ ] Observation-only production/client domains are marked.
+- [ ] Non-production test assets are selected.
+- [ ] The scoped provider token is created and stored safely.
+- [ ] The previous TTL values are known so TTL-60 propagation can be scheduled.
+- [ ] Authority SHA is recorded.

--- a/docs/domain-operations/phase-0-1-execution-contract-v4.1.md
+++ b/docs/domain-operations/phase-0-1-execution-contract-v4.1.md
@@ -1,0 +1,25 @@
+# DNS Ops — Lean Phase 0–1 Execution Contract V4.1
+
+This file is the canonical entrypoint for the approved execution contract.
+
+The complete contract is stored in four ordered parts. **All four parts together are authoritative** and must be read before implementation:
+
+1. [`phase-0-1/01-outcome-budget-scope.md`](./phase-0-1/01-outcome-budget-scope.md)
+2. [`phase-0-1/02-correctness-remediation-operations.md`](./phase-0-1/02-correctness-remediation-operations.md)
+3. [`phase-0-1/03-seeded-tests-and-mcp.md`](./phase-0-1/03-seeded-tests-and-mcp.md)
+4. [`phase-0-1/04-review-gates-and-agent-prompt.md`](./phase-0-1/04-review-gates-and-agent-prompt.md)
+
+Supporting execution artifacts:
+
+- [`controlled-test-assets-runbook-v4.1.md`](./controlled-test-assets-runbook-v4.1.md)
+- [`day-0-worksheet.md`](./day-0-worksheet.md)
+
+## Authority rule
+
+The implementation agent must not reopen decisions marked closed in Part 1. The hard caps are authoritative:
+
+- 15 focused engineering days;
+- three calendar weeks;
+- 24 founder hours.
+
+The long-term product thesis in [`product-and-mcp-discussion-brief.md`](./product-and-mcp-discussion-brief.md) is context only and does not expand Phase 0–1 scope.

--- a/docs/domain-operations/phase-0-1/01-outcome-budget-scope.md
+++ b/docs/domain-operations/phase-0-1/01-outcome-budget-scope.md
@@ -1,0 +1,308 @@
+# DNS Ops — Lean Phase 0–1 Execution Contract V4.1
+
+**Date:** 2026-07-28  
+**Repository:** `computindev/dns-ops`  
+**Status:** execution-ready after adversarial budget and test-runbook review  
+**Primary classification:** internal infrastructure  
+**Commercial status:** option value only  
+**Hard cap:** 15 focused engineering days, 3 calendar weeks, 24 founder hours
+
+---
+
+# 1. Outcome
+
+Own a maximum-fifteen-day internal infrastructure outcome for `computindev/dns-ops`.
+
+Make the existing DNS and mail evidence trustworthy, add the smallest useful domain/TLS/web-health operating loop, make every uncertainty actionable, and expose those same application contracts through a minimal internal MCP endpoint proven first by a deterministic harness.
+
+Do not build the commercial Domain Operations vision.
+
+The result must answer:
+
+> Can DNS Ops replace a defined set of manual domain checks, detect seeded failures without false-green results, drive one minimal disposition loop, and prove the same behavior through MCP within three weeks?
+
+---
+
+# 2. Decisions are closed before implementation
+
+The following choices are authoritative. The implementation agent must not reopen them.
+
+| Topic | Decision |
+|---|---|
+| SPF lookup analysis | **Degrade now.** Keep first-level inspection only. Do not build recursive SPF evaluation in this outcome. |
+| DMARC RFC 9989 discovery | **Implement now.** DNS tree walk with a maximum of eight queries is required. |
+| MCP fresh evidence | **Include now.** `scan_request` is a required Phase 1 MCP command. |
+| Hypothesis graph | Deferred. Use human playbooks only. |
+| DMARC RUA ingestion | Deferred to a separate outcome. |
+| Agent analyst | Deferred. Human-operated first. |
+| Buzz | Deferred until the deterministic MCP harness passes. |
+| MCP deployment | `/mcp` inside `apps/web`, behind the internal edge boundary. |
+| MCP authorization | Static token-to-principal/scope map. No OAuth, no management UI. |
+| Coverage gaps | Separate setup/evidence queue. They do not auto-create signals or cases. |
+| Legacy alerts | Must converge on signals or be silenced for migrated conditions. No parallel notification path. |
+| Generic remediation | Downgrade to non-executable playbook prose. Never expose a generic record as a ready-to-apply mutation. |
+| Controlled provider mutations | Executed only by the deterministic test-fault harness using a credential scoped to the designated test zone. DNS Ops product and MCP retain zero provider-write capability. |
+| DNS mutation freshness | Mutable test records use pre-propagated TTL 60, and pass/fail evidence comes from direct authoritative-NS queries rather than recursive cache alone. |
+| RFC 9989 fixtures | All tree-walk fixtures use a stubbed resolver with fixed responses and no live-network dependency. |
+
+The hard budget is authoritative both for time and for these scope decisions.
+
+---
+
+# 3. Hard budget
+
+## 3.1 Engineering budget
+
+| Workstream | Maximum |
+|---|---:|
+| Repository truth and baseline | 3 days |
+| DNS/mail correctness foundation | 5 days |
+| Minimal internal operating loop | 4 days |
+| MCP endpoint and deterministic harness | 3 days |
+| **Total** | **15 days** |
+
+These are caps, not targets.
+
+## 3.2 Calendar budget
+
+- Three calendar weeks maximum.
+- No automatic extension.
+- Any deferred subsystem requires a new outcome contract and budget.
+- Work that cannot fit must be represented honestly as deferred or blocked.
+
+## 3.3 Founder-attention budget
+
+Exactly 24 hours are reserved:
+
+| Founder activity | Budget |
+|---|---:|
+| Day 0 portfolio and current-manual-work baseline | 2.0 h |
+| Select and authorize non-production fault-injection assets | 1.0 h |
+| Declare purpose/criticality for up to 30 domains | 1.5 h |
+| Review and calibrate six playbooks drafted by the agent | 4.0 h |
+| Four gate reviews | 3.0 h |
+| Review UNKNOWN language and setup UX | 2.0 h |
+| Fresh-review setup and adjudication | 2.5 h |
+| Standards/product decisions that genuinely require authority | 3.0 h |
+| Final internal acceptance on representative domains | 3.0 h |
+| Contingency | 2.0 h |
+| **Total** | **24.0 h** |
+
+The agent must not consume founder time for implementation-order, naming, file-selection or test decisions it can resolve from the repository.
+
+---
+
+# 4. Day 0 inputs supplied by the founder
+
+These are bounded founder duties, not agent blockers to rediscover.
+
+## 4.1 Internal portfolio
+
+Select a maximum of 30 domains for the initial portfolio.
+
+For each:
+
+```ts
+export type DomainPurpose =
+  | "WEB"
+  | "MAIL"
+  | "WEB_AND_MAIL"
+  | "REDIRECT"
+  | "PARKED"
+  | "UNKNOWN";
+
+export type InternalDomainProfile = {
+  domainId: string;
+  purpose: DomainPurpose;
+  responsibleActorId?: string;
+  criticality: "HIGH" | "NORMAL" | "LOW";
+};
+```
+
+No additional commercial ownership roles are authorized.
+
+## 4.2 Controlled test assets
+
+Designate:
+
+```text
+DNSOPS_TEST_DOMAIN
+DNSOPS_TEST_WEB_HOST
+DNSOPS_TEST_MAIL_SUBDOMAIN
+DNSOPS_TEST_ZONE_ID
+DNSOPS_TEST_PROVIDER_KIND
+DNSOPS_TEST_PROVIDER_TOKEN
+```
+
+Requirements:
+
+- non-production;
+- no customer traffic;
+- no real inbound or outbound mail dependency;
+- explicit authorization to mutate during the test;
+- baseline configuration captured before mutation;
+- rollback procedure available;
+- changes limited to the seeded-fault matrix in this contract;
+- all changes audited.
+
+### Test-provider credential carve-out
+
+`DNSOPS_TEST_PROVIDER_TOKEN` is a test-harness credential, not a DNS Ops product capability.
+
+It must:
+
+- be scoped to the single designated test zone;
+- have only the minimum zone-read and DNS-record mutation permissions needed by the fixtures;
+- be stored as a runtime secret and never committed;
+- never be returned by MCP, logged, placed in prompts or exposed to the implementing/reviewing agent as plaintext;
+- be usable only through the deterministic fault-injection harness;
+- be rejected by the harness for record names outside the allowlisted test hosts;
+- support deterministic restoration to the captured baseline;
+- be revoked when the test phase ends.
+
+The agent and fresh reviewer may run the harness. They may not call the provider API directly.
+
+Controlled mutations on these test assets through that harness are authorized. Production or client mutations are not.
+
+If controlled test assets are not available by Gate 1, report:
+
+```text
+BLOCKED_BY_TEST_ASSET
+```
+
+Do not substitute a production domain.
+
+## 4.3 Manual-work baseline
+
+Before implementation, record the current manual checks.
+
+Suggested starting set:
+
+| Manual check | Current method | Frequency | Minutes per run | Domains covered |
+|---|---|---:|---:|---:|
+| Domain expiration | Registrar dashboards / notes |  |  |  |
+| DNS delegation and key records | `dig`, provider UI |  |  |  |
+| SPF/DKIM/DMARC configuration | Manual DNS inspection |  |  |  |
+| TLS validity and expiration | Browser/provider/manual checker |  |  |  |
+| HTTP availability and canonical redirects | Browser/curl |  |  |  |
+| Homepage noindex/canonical | Source/headers/browser |  |  |  |
+
+The baseline must record:
+
+```ts
+export type ManualCheckBaseline = {
+  checkId: string;
+  description: string;
+  frequencyPerMonth: number;
+  minutesPerRun: number;
+  domainsPerRun: number;
+  currentEvidenceLocation: string;
+};
+```
+
+Phase success measures replacement or reduction of these named checks—not a subjective sense of time saved.
+
+---
+
+# 5. Scope
+
+## 5.1 Included
+
+- exact repository authority SHA and baseline;
+- authoritative DNS truth or explicit limitation;
+- rule-evaluation failure visibility;
+- DMARC RFC 9989 parser and policy discovery;
+- first-level SPF analysis with an explicit limited scope;
+- removal/downgrade of unsafe generic remediation;
+- minimal domain purpose/profile;
+- RDAP/expiration evidence when available;
+- TLS validity and expiration;
+- HTTP reachability;
+- HTTP/HTTPS and apex/`www` redirect matrix;
+- homepage `noindex`, `X-Robots-Tag` and canonical where applicable;
+- deterministic snapshot comparison;
+- six bounded operational signals;
+- minimal case/disposition lifecycle;
+- actionable UNKNOWN/setup queue;
+- legacy-alert convergence;
+- six human playbooks;
+- `/mcp` inside `apps/web`;
+- ten required MCP tools;
+- static MCP principals/scopes;
+- deterministic MCP harness;
+- seeded-fault evaluation;
+- independent clean-context review.
+
+## 5.2 Explicitly excluded
+
+- recursive SPF evaluation;
+- RFC 9990 RUA ingestion;
+- RFC 9991 failure-report ingestion;
+- formal hypothesis graph;
+- built-in Lead Domain Analyst;
+- Buzz integration;
+- OAuth product;
+- MCP management UI;
+- public MCP onboarding;
+- client portal;
+- white label;
+- commercial role routing;
+- DNS/registrar/hosting/mail-provider writes from the DNS Ops product or MCP; the isolated test-harness carve-out in §4.2 is the only exception;
+- deep crawling;
+- Lighthouse;
+- CrUX;
+- broad accessibility analysis;
+- privacy compliance;
+- WebMCP;
+- billing;
+- commercial launch.
+
+---
+
+# 6. Repository-truth gate
+
+Before changing product behavior, establish:
+
+- exact authority SHA;
+- repository-native validation commands;
+- passing/failing test baseline;
+- production/runtime architecture;
+- current authoritative DNS behavior;
+- current SPF and DMARC behavior;
+- current alert-generation paths;
+- current suggestion/remediation paths;
+- current probe boundaries;
+- stale or contradictory documentation.
+
+Repository code, tests and migrations override prose claims.
+
+## Gate 1 — End of engineering day 3
+
+Required evidence:
+
+- authority SHA;
+- baseline report;
+- test-asset authorization;
+- manual-work baseline;
+- legacy alert/remediation map;
+- remaining twelve-day implementation scope.
+
+A legacy condition map is required:
+
+```ts
+export type LegacyConditionDisposition =
+  | "MAPPED_TO_SIGNAL"
+  | "LEGACY_ONLY"
+  | "DISABLED";
+
+export type LegacyConditionMapEntry = {
+  conditionId: string;
+  disposition: LegacyConditionDisposition;
+  replacementSignalKind?: InternalSignalKind;
+  notificationPath: "SIGNAL_ALERT" | "LEGACY_ALERT" | "NONE";
+};
+```
+
+Invariant:
+
+> No condition may produce both a legacy notification and a signal-derived notification.

--- a/docs/domain-operations/phase-0-1/02-correctness-remediation-operations.md
+++ b/docs/domain-operations/phase-0-1/02-correctness-remediation-operations.md
@@ -1,0 +1,362 @@
+# 7. Correctness foundation
+
+## 7.1 Rule errors cannot disappear
+
+A rule exception must not be reduced to a console log followed by an apparently clean result.
+
+Required behavior:
+
+```text
+Rule evaluation failure
+→ explicit evaluation error
+→ affected check UNKNOWN
+→ snapshot partial or equivalent incomplete state
+→ retry/setup action
+→ visible in UI, API and MCP
+```
+
+Tests must prove that an intentionally throwing rule cannot generate a false-green posture.
+
+## 7.2 SPF decision: first-level only
+
+Do not build recursive SPF evaluation.
+
+The current outcome may:
+
+- parse the published SPF record;
+- identify direct mechanisms and modifiers;
+- count direct terms that cause DNS lookups;
+- identify syntactic or directly visible dangerous behavior;
+- show includes and redirect targets as unresolved dependencies.
+
+It may not claim:
+
+- complete SPF evaluation;
+- compliance with the global ten-term limit;
+- absence of cycles;
+- void-lookup compliance;
+- validity of nested includes;
+- real sender authorization.
+
+Required result:
+
+```ts
+export type SpfAnalysisScope = "FIRST_LEVEL_ONLY";
+
+export type FirstLevelSpfAssessment = {
+  scope: SpfAnalysisScope;
+  directDnsLookupTerms: number;
+  includeDomains: string[];
+  redirectDomain?: string;
+  status:
+    | "DIRECT_SYNTAX_VALID"
+    | "DIRECT_SYNTAX_INVALID"
+    | "UNKNOWN";
+  completeEvaluation: false;
+  limitation: string;
+};
+```
+
+Rename ambiguous functions where practical, for example:
+
+```text
+countSPFLookups
+→ countDirectSpfLookupTerms
+```
+
+No green label may say “SPF is within the 10 lookup limit.”
+
+Recursive SPF evaluation becomes a separately budgeted backlog outcome.
+
+## 7.3 DMARC decision: RFC 9989 tree walk is required
+
+The outcome must implement current policy discovery, not only parse new tags.
+
+### Parser
+
+Model:
+
+- `p`
+- `sp`
+- `np`
+- `psd`
+- `t`
+- `rua`
+- `ruf`
+- `fo`
+- `adkim`
+- `aspf`
+
+Legacy tags such as `pct`, `rf` and `ri` may be retained only as legacy observations/warnings. They must not drive current policy behavior.
+
+### Policy discovery
+
+Implement:
+
+- direct `_dmarc` query;
+- bounded DNS tree walk;
+- maximum eight queries;
+- `psd=y`;
+- `psd=n`;
+- organizational-domain determination;
+- distinction among NODATA, NXDOMAIN, timeout, SERVFAIL and other transient errors;
+- traceable query evidence.
+
+The implementation may reuse existing DNS query primitives, but it may not defer tree walk while claiming RFC 9989 completion.
+
+### Shared primitive
+
+Create or identify one deterministic organizational-domain discovery primitive suitable for future relaxed-alignment use.
+
+This phase does not ingest message streams, but it must not preserve an old PSL-only assumption.
+
+### Required fixtures
+
+- explicit author-domain record;
+- inherited organizational policy;
+- `psd=y`;
+- `psd=n`;
+- deep hierarchy reaching the eight-query bound;
+- transient DNS error;
+- multiple DMARC records;
+- `np` behavior for a non-existent subdomain;
+- legacy tags;
+- strict and relaxed alignment helper cases.
+
+## Gate 2 — End of engineering day 8
+
+Must prove:
+
+- no silent rule failure;
+- no false authoritative certainty;
+- first-level SPF limitation is visible;
+- DMARC tree walk and fixtures pass;
+- generic remediation is no longer executable-looking;
+- no existing evaluator was weakened.
+
+Do not start additional product surfaces when this gate fails.
+
+---
+
+# 8. Remediation policy
+
+## 8.1 Generic suggestions
+
+Generic suggestions may not contain a record value that appears ready to copy or execute.
+
+Examples currently derived from assumptions about:
+
+- Google SPF;
+- generic reporting mailboxes;
+- unknown-provider MX;
+- placeholder DKIM keys;
+
+must be removed from executable-looking suggestion payloads.
+
+## 8.2 Downgrade target
+
+Downgrade generic guidance to:
+
+```text
+playbookRef + non-executable prose
+```
+
+Example:
+
+```ts
+export type GuidanceOnlySuggestion = {
+  kind: "GUIDANCE_ONLY";
+  title: string;
+  explanation: string;
+  playbookId: string;
+  requiresProviderConfirmation: boolean;
+  executableMutation: null;
+};
+```
+
+Playbooks may explain conceptual record shape in prose, clearly labeled as an example. They may not present a domain-specific value as approved or safe.
+
+## 8.3 Deterministic simulation
+
+Simulation remains available only when:
+
+- applicability is known;
+- required provider/domain context exists;
+- proposed values are complete;
+- no placeholder remains;
+- the action is still local simulation only.
+
+No external execution is included.
+
+---
+
+# 9. Coverage and UNKNOWN UX
+
+Risk and coverage remain independent.
+
+```text
+Risk posture = what current known evidence indicates
+Coverage = what the system was able to evaluate
+```
+
+## 9.1 Coverage gaps do not become signals
+
+Remove:
+
+```text
+EVIDENCE_COVERAGE_GAP
+```
+
+from `InternalSignalKind`.
+
+Coverage gaps:
+
+- appear in `Needs setup/evidence`;
+- include a resolution action;
+- affect coverage metrics;
+- do not auto-open cases;
+- do not generate operational alerts;
+- do not mix with regressions.
+
+An operator may later decide to create a manual case, but automatic conversion is outside this outcome.
+
+## 9.2 Required unknown model
+
+```ts
+export type UnknownReason =
+  | "PURPOSE_UNDECLARED"
+  | "EVIDENCE_STALE"
+  | "PROBE_FAILED"
+  | "AUTHORITATIVE_EVIDENCE_UNAVAILABLE"
+  | "PROVIDER_NOT_CONNECTED"
+  | "SELECTOR_NOT_DISCOVERED"
+  | "UNSUPPORTED_CHECK"
+  | "EXTERNAL_DECISION_REQUIRED";
+
+export type UnknownResolutionAction =
+  | "DECLARE_PURPOSE"
+  | "RUN_FRESH_SCAN"
+  | "RETRY_PROBE"
+  | "SUPPLY_SELECTOR"
+  | "CONNECT_PROVIDER"
+  | "REVIEW_MANUALLY"
+  | "NOT_CURRENTLY_OBSERVABLE";
+
+export type UnknownResolution = {
+  reason: UnknownReason;
+  explanation: string;
+  action: UnknownResolutionAction;
+  actionLabel: string;
+  blocking: boolean;
+};
+```
+
+## 9.3 UI lanes
+
+- Needs attention.
+- Needs setup/evidence.
+- Healthy with current evidence.
+- Accepted/not applicable.
+
+Acceptance test:
+
+> No `UNKNOWN` may render as healthy, and every `UNKNOWN` must have an action or an explicit “not currently observable” explanation.
+
+---
+
+# 10. Signals and cases
+
+## 10.1 Signal set
+
+```ts
+export type InternalSignalKind =
+  | "DOMAIN_EXPIRING_SOON"
+  | "TLS_CERTIFICATE_REGRESSION"
+  | "HTTP_ENDPOINT_UNAVAILABLE"
+  | "REDIRECT_TOPOLOGY_REGRESSION"
+  | "HOMEPAGE_INDEXABILITY_REGRESSION"
+  | "MAIL_DNS_CONFIGURATION_REGRESSION";
+```
+
+A signal represents:
+
+- a regression;
+- a threshold crossing;
+- a material conflict;
+- or an explicit operator-requested evaluation.
+
+## 10.2 Minimal case lifecycle
+
+```ts
+export type InternalCaseStatus =
+  | "OPEN"
+  | "ACKNOWLEDGED"
+  | "BLOCKED"
+  | "RESOLVED"
+  | "DISMISSED";
+```
+
+Required:
+
+- open from one signal;
+- deduplicate by stable signal/condition key;
+- acknowledge;
+- record disposition and note;
+- resolve only after fresh evidence;
+- reopen when a later scan reproduces the condition;
+- preserve audit history.
+
+## 10.3 Legacy alerts converge on signals
+
+Findings remain atomic analysis results.
+
+Signals become the canonical operational trigger for the six migrated conditions.
+
+Existing alerts remain the notification/delivery state, but for migrated conditions they must be produced from the canonical signal path.
+
+Required invariant:
+
+```text
+one condition
+→ one signal
+→ at most one active alert
+→ at most one active case
+```
+
+Direct finding-to-alert generation must be disabled for migrated conditions.
+
+Conditions not migrated must be explicitly marked `LEGACY_ONLY` or `DISABLED`.
+
+Tests must prove that one seeded fault does not produce duplicate alerts, cases or notifications.
+
+---
+
+# 11. Playbooks
+
+The implementation agent drafts; the founder calibrates and approves.
+
+Required playbooks:
+
+```text
+docs/playbooks/
+├── domain-expiry.md
+├── tls-regression.md
+├── redirect-regression.md
+├── indexability-regression.md
+├── mail-dns-configuration-regression.md
+└── unknown-evidence.md
+```
+
+Each contains:
+
+- what the condition proves;
+- what it does not prove;
+- deterministic evidence used;
+- expected domain-purpose applicability;
+- operator checks;
+- safe next action;
+- verification condition;
+- explicit escalation boundary;
+- non-executable examples where useful.
+
+These are human operating guides, not a formal hypothesis graph.

--- a/docs/domain-operations/phase-0-1/03-seeded-tests-and-mcp.md
+++ b/docs/domain-operations/phase-0-1/03-seeded-tests-and-mcp.md
@@ -1,0 +1,264 @@
+# 12. Seeded-fault evaluation
+
+Natural production failures are not required for Gate 3.
+
+The phase must use deterministic fixtures and controlled non-production mutations.
+
+## 12.1 Fixture matrix
+
+Required fixture failures:
+
+| ID | Seeded condition | Expected result |
+|---|---|---|
+| FIX-01 | Rule evaluator throws | Explicit UNKNOWN/partial; never healthy |
+| FIX-02 | Authoritative evidence unavailable | Coverage gap with retry/manual action |
+| FIX-03 | SPF nested include is present | First-level-only limitation; no complete ten-term claim |
+| FIX-04 | RFC 9989 inherited policy | Correct tree-walk result and trace |
+| FIX-05 | Stale TLS/HTTP evidence | Needs setup/evidence; not a signal |
+| FIX-06 | Duplicate observation/signal attempt | One canonical signal/alert/case |
+
+Required result:
+
+```text
+6 / 6 fixtures detected and classified correctly
+0 false-green outcomes
+0 duplicate operational objects
+```
+
+### Deterministic resolver requirement
+
+All RFC 9989/tree-walk fixtures run against a typed stub resolver with fixed scripted responses. They must not query live DNS.
+
+The fixture resolver must support:
+
+- TXT answer;
+- NODATA;
+- NXDOMAIN;
+- SERVFAIL;
+- timeout;
+- multiple DMARC records;
+- ordered query trace;
+- assertion that no tree walk exceeds eight queries.
+
+Live DNS is reserved for the separately authorized LIVE cases and is never a dependency of the deterministic unit/integration suite.
+
+## 12.2 Controlled live mutations
+
+Run on authorized non-production assets.
+
+### Execution authority
+
+All provider-side mutations and restorations are executed by the deterministic fault-injection harness using the scoped test-zone credential from §4.2. This capability is test infrastructure only and is not linked to MCP or normal DNS Ops application services.
+
+The harness must:
+
+- capture and hash the pre-test baseline;
+- refuse non-allowlisted zones, hosts, record types or mutation IDs;
+- write an audit record before and after each mutation;
+- verify the provider response;
+- restore the exact baseline on normal completion;
+- attempt restoration after test failure or interruption;
+- emit a manual recovery artifact if automatic restoration fails.
+
+### TTL and cache preparation
+
+For every mutable DNS record:
+
+- configure TTL `60` before the live-test window;
+- wait at least the previous TTL plus a safety margin before capturing the healthy baseline;
+- record the effective TTL in the test artifact;
+- do not begin LIVE-03 while an earlier, longer TTL may still be cached.
+
+### Authoritative freshness requirement
+
+For DNS mutation tests, recursive resolver output may be recorded but cannot be the sole pass/fail evidence.
+
+`scan_request` for registered test assets must include a direct query to the zone's authoritative nameservers and persist:
+
+- nameserver queried;
+- response code;
+- answer;
+- query timestamp;
+- AA flag when available;
+- trace or explicit limitation.
+
+This test-specific authoritative path is required even when general portfolio authoritative evidence remains in a degraded mode. A cached recursive answer cannot fail or pass LIVE-03 by itself.
+
+Required mutations:
+
+### LIVE-01 — Redirect regression
+
+- capture healthy baseline;
+- remove or break expected canonical redirect;
+- run `scan_request`;
+- detect `REDIRECT_TOPOLOGY_REGRESSION`;
+- open case;
+- acknowledge;
+- restore redirect;
+- run `scan_request`;
+- resolve from fresh evidence;
+- reintroduce fault;
+- run `scan_request`;
+- reopen the same operational condition without duplicate case creation.
+
+### LIVE-02 — Indexability regression
+
+- capture healthy baseline;
+- introduce `noindex` or `X-Robots-Tag: noindex`;
+- run `scan_request`;
+- detect `HOMEPAGE_INDEXABILITY_REGRESSION`;
+- restore;
+- verify resolution from fresh evidence.
+
+### LIVE-03 — Mail DNS configuration regression
+
+Use `DNSOPS_TEST_MAIL_SUBDOMAIN`, not a production mail domain.
+
+- capture baseline SPF/DMARC test configuration;
+- mutate an approved test record;
+- run `scan_request`;
+- detect `MAIL_DNS_CONFIGURATION_REGRESSION`;
+- restore;
+- verify resolution.
+
+No real email flow or sender-authentication claim is permitted.
+
+## 12.3 Gate 3 — End of engineering day 12
+
+Required:
+
+- 6/6 fixtures pass;
+- 3/3 controlled mutations detected;
+- 3/3 correct signal types;
+- 0 coverage gaps incorrectly promoted to signals;
+- LIVE-01 completes open → acknowledge → resolve → reopen;
+- no duplicate alert/case path;
+- manual-work baseline shows which named checks are now automated or shortened;
+- false-green count is zero.
+
+The absence of a naturally occurring production failure does not fail Gate 3.
+
+---
+
+# 13. MCP Phase 1
+
+## 13.1 Deployment
+
+- `/mcp` inside `apps/web`;
+- protected by Cloudflare Access or the existing internal edge boundary;
+- no separate Worker;
+- no public exposure;
+- no OAuth;
+- no management UI.
+
+## 13.2 Phase 1 authorization is deliberately primitive
+
+Use a static secret configuration mapping bearer-token hashes to principals.
+
+```ts
+export type Phase1McpScope =
+  | "DOMAIN_READ"
+  | "SIGNAL_READ"
+  | "CASE_READ"
+  | "CASE_WRITE"
+  | "SCAN_REQUEST";
+
+export type Phase1McpPrincipal = {
+  principalId: string;
+  actorId: string;
+  tenantId: string;
+  tokenSha256: string;
+  scopes: Phase1McpScope[];
+  enabled: boolean;
+};
+```
+
+Requirements:
+
+- long random bearer tokens;
+- only token hashes stored in the map;
+- map supplied through secret configuration;
+- actor and tenant derived from the matched principal, never from tool arguments;
+- application services re-check tenant and scope;
+- manual token creation/rotation;
+- no refresh tokens;
+- no delegated provider credentials;
+- no authorization framework beyond this map in Phase 1.
+
+Cloudflare Access authenticates the edge; the application map authorizes DNS Ops tools.
+
+## 13.3 Required tools
+
+Exactly ten tools:
+
+### Read
+
+```text
+domain_search
+domain_get_profile
+domain_get_posture
+snapshot_compare
+evidence_get
+signal_list
+case_get
+```
+
+### Commands
+
+```text
+case_open
+case_set_disposition
+scan_request
+```
+
+`scan_request` is mandatory because the full MCP loop must be exercised through MCP rather than through an application-service bypass.
+
+## 13.4 Command controls
+
+### `case_open`
+
+- requires `CASE_WRITE`;
+- stable deduplication key;
+- idempotency key;
+- returns existing active case for duplicate condition.
+
+### `case_set_disposition`
+
+- requires `CASE_WRITE`;
+- accepts `expectedVersion`;
+- rejects stale concurrent writes;
+- creates an audit event.
+
+### `scan_request`
+
+- requires `SCAN_REQUEST`;
+- accepts a registered domain ID, never an arbitrary URL;
+- enforces tenant membership;
+- has idempotency key;
+- applies rate limit;
+- returns a task/snapshot reference;
+- uses the same collector/probe safety boundaries as the UI.
+
+## 13.5 Internal MCP harness
+
+The first MCP consumer is a deterministic harness.
+
+It must test:
+
+- all ten schemas;
+- successful typed results;
+- invalid tool input;
+- invalid IDs;
+- disabled principal;
+- insufficient scope;
+- cross-tenant denial;
+- stale evidence;
+- duplicate `case_open`;
+- stale `expectedVersion`;
+- repeated `scan_request` idempotency;
+- rate limiting;
+- audit creation;
+- application-service/MCP parity;
+- no raw internal exception leakage.
+
+Buzz is not connected until this harness and independent review pass.

--- a/docs/domain-operations/phase-0-1/04-review-gates-and-agent-prompt.md
+++ b/docs/domain-operations/phase-0-1/04-review-gates-and-agent-prompt.md
@@ -1,0 +1,242 @@
+# 14. Fresh independent reviewer
+
+“Independent” has an explicit implementation.
+
+## 14.1 Reviewer setup
+
+Use a separate agent session with:
+
+- clean context;
+- a disposable checkout or read-only view at the exact final SHA;
+- no builder conversation;
+- no builder completion summary before verdict;
+- this V4 contract;
+- the repository’s authoritative references;
+- the falsification checklist below.
+
+Prefer a different model or harness when available, but clean context and exact-SHA isolation are mandatory.
+
+## 14.2 Reviewer authority
+
+The reviewer may:
+
+- inspect;
+- run tests;
+- use the internal MCP harness;
+- execute controlled non-production fault fixtures through the deterministic harness only;
+- use the harness-bound test-zone secret without receiving its plaintext value;
+- inspect database state;
+- compare UI/application/MCP behavior.
+
+The reviewer must not:
+
+- fix implementation;
+- weaken tests;
+- accept the builder’s claims without reproduction.
+
+After the verdict, the builder summary may be supplied only to investigate discrepancies.
+
+## 14.3 Fresh-review output
+
+```ts
+export type FreshReviewResult = {
+  verdict: "PASS" | "FAIL" | "BLOCKED";
+  reviewedSha: string;
+  evidence: string[];
+  falsificationAttempts: string[];
+  findings: Array<{
+    severity: "BLOCKER" | "HIGH" | "MEDIUM" | "LOW";
+    title: string;
+    evidence: string;
+  }>;
+  residualUncertainty: string[];
+  recommendedNextAction: string;
+};
+```
+
+Founder adjudication time is capped at 2.5 hours.
+
+---
+
+# 15. Adversarial review checklist
+
+The reviewer must try to prove:
+
+- a rule exception still looks healthy;
+- a failed query becomes absence rather than UNKNOWN;
+- authoritative DNS certainty is overstated;
+- SPF is described as completely evaluated;
+- direct SPF terms are confused with the ten-term recursive budget;
+- RFC 9989 discovery skips or exceeds its eight-query tree-walk bound;
+- legacy `pct`, `rf` or `ri` still drive current policy;
+- `psd=y`, `psd=n` or `np` behavior is wrong;
+- relaxed alignment still depends on an old PSL-only assumption;
+- an UNKNOWN renders green;
+- an UNKNOWN lacks a resolution action;
+- a coverage gap creates a signal or alert;
+- a case resolves without a fresh scan;
+- a resolved case fails to reopen;
+- one fault creates parallel legacy and signal notifications;
+- a generic remediation looks executable without sufficient context;
+- MCP trusts actor/tenant arguments from the model;
+- insufficient scopes are accepted;
+- cross-tenant evidence leaks;
+- duplicate MCP commands create duplicate state;
+- MCP behavior differs from application-service behavior;
+- `scan_request` accepts an arbitrary external target;
+- the implementation secretly includes RUA, a graph, an agent or commercial scope.
+
+PASS only when no realistic blocking counterexample remains on the exact reviewed SHA.
+
+---
+
+# 16. Gate 4 — End of engineering day 15
+
+Required evidence:
+
+- exact final SHA;
+- clean Git state;
+- repository-native validation green;
+- Gate 2 correctness proof;
+- Gate 3 seeded-fault proof;
+- ten MCP tools working;
+- static scope model working;
+- MCP negative tests green;
+- one canonical alert/signal path;
+- playbooks approved;
+- manual-work baseline comparison;
+- fresh independent review PASS.
+
+Buzz, production deployment and commercial work remain separately authorized decisions.
+
+---
+
+# 17. Success and continuation criteria
+
+## 17.1 Phase 0–1 passes when
+
+- all seeded faults are correctly detected;
+- no seeded failure is falsely green;
+- the live loop resolves and reopens correctly;
+- no duplicate operational pipeline exists;
+- UNKNOWN is actionable;
+- at least four named manual checks are automated or materially shortened;
+- the MCP harness proves the same loop through the public application contract;
+- maintenance cost appears bounded.
+
+## 17.2 Continue as internal infrastructure when
+
+During the next 30 days:
+
+- scheduled checks replace the named manual baseline;
+- signal noise remains acceptable;
+- unknown coverage trends downward or has understood causes;
+- verification remains reliable;
+- maintenance does not demand significant founder attention.
+
+A natural production incident is useful evidence but is not required to pass the implementation phase.
+
+## 17.3 Commercial discovery may begin only when
+
+- one second-human design partner uses it;
+- at least one responsibility handoff occurs;
+- one client-facing explanation is actually used;
+- repeated operational work is visible;
+- at least three potential pilots request continued use.
+
+No commercial feature should be built in advance of that evidence.
+
+## 17.4 Freeze expansion when
+
+- most output remains non-actionable;
+- false positives or unknowns dominate;
+- standards maintenance is unbounded;
+- manual work is not measurably reduced;
+- DNS Ops materially competes with higher-priority products for founder bandwidth.
+
+---
+
+# 18. Required evidence from the implementation owner
+
+Provide:
+
+- authority and final SHAs;
+- baseline command results;
+- manual-work baseline;
+- selected test assets;
+- legacy condition map;
+- RFC 9989 mapping and fixtures;
+- first-level SPF limitation evidence;
+- rule-failure/UNKNOWN evidence;
+- seeded-fault matrix results;
+- live mutation and rollback evidence;
+- case lifecycle database/audit evidence;
+- duplicate-path evidence;
+- UNKNOWN/setup UX evidence;
+- all ten MCP contract results;
+- scope and tenant negative tests;
+- idempotency/concurrency evidence;
+- playbook list and founder approval;
+- deferred-scope confirmation;
+- fresh-review verdict;
+- residual caveats;
+- approvals still required.
+
+---
+
+# 19. Stop conditions
+
+Stop and preserve a restartable checkpoint when:
+
+- the fifteen-day cap is reached;
+- the three-week cap is reached;
+- the founder’s 24-hour budget is exhausted;
+- controlled test assets are unavailable;
+- foundational correctness cannot fit the cap;
+- work requires recursive SPF evaluation;
+- work requires RUA ingestion;
+- work requires a formal graph;
+- work requires an agent;
+- work requires commercial scope;
+- work requires a production or client mutation.
+
+A difficult implementation problem alone is not a blocker, but the hard budget and closed scope decisions are authoritative.
+
+---
+
+# 20. Compact prompt for the implementation agent
+
+```text
+Own a maximum-fifteen-day internal infrastructure outcome for
+computindev/dns-ops.
+
+Make current DNS/mail evidence trustworthy, add the smallest useful
+domain/TLS/web-health loop, make every uncertainty actionable, and expose the
+same application contracts through an internal MCP endpoint proven first by a
+deterministic harness.
+
+The following scope decisions are final:
+- SPF remains first-level only; do not build recursive evaluation and do not
+  claim compliance with the ten-term recursive lookup budget.
+- Implement RFC 9989 DMARC DNS tree walk with a maximum of eight queries.
+- Include MCP scan_request so fresh-evidence resolution is tested through MCP.
+- Coverage gaps belong to setup/evidence and never auto-create signals or cases.
+- Use a static token-hash to tenant/actor/scope map for MCP; build nothing more.
+- Converge migrated legacy alerts on the signal path; no duplicate notification
+  system.
+- Downgrade generic remediations to non-executable playbook prose.
+- Use seeded fixtures and authorized non-production mutations; do not wait for
+  production to fail. Provider mutations run only through the deterministic
+  test harness with a credential scoped to the test zone; the product and MCP
+  have no provider-write capability.
+- Pre-propagate TTL 60 for mutable test DNS records and use direct authoritative
+  NS evidence for DNS mutation pass/fail; recursive cache alone is insufficient.
+- Run RFC 9989 fixtures against a stubbed resolver with fixed responses; never
+  make the deterministic suite depend on live DNS.
+- Do not build RUA ingestion, a hypothesis graph, an agent, Buzz integration,
+  OAuth, external writes or commercial features.
+
+The hard cap is fifteen engineering days, three calendar weeks and twenty-four
+founder hours. Continue until the evaluators and fresh independent review pass,
+or stop at the first authoritative cap or genuine external blocker.
+```

--- a/docs/domain-operations/product-and-mcp-discussion-brief.md
+++ b/docs/domain-operations/product-and-mcp-discussion-brief.md
@@ -1,0 +1,190 @@
+# DNS Ops — Domain Operations Product and MCP Discussion Brief
+
+## The idea
+
+DNS Ops should evolve from a DNS/mail workbench into a **Domain Operations Control Plane**.
+
+> It helps the person or agent responsible for many domains understand what changed, what matters, why it happened, who must act, what can be changed safely and whether the issue was truly resolved.
+
+This document is strategic context. It does not expand the authoritative Phase 0–1 scope.
+
+## Why
+
+A domain depends on many disconnected systems:
+
+```text
+Registrar
+DNS
+Hosting/CDN
+Certificates
+Email receiving
+Email senders
+Repositories
+Analytics
+Clients and owners
+```
+
+Most tools analyze only one layer. DNS Ops can correlate them and close the operational loop.
+
+## Product loop
+
+```text
+Inventory
+→ Observe
+→ Deterministic facts
+→ Policy evaluation
+→ Signal
+→ Investigation case
+→ Explain
+→ Simulate
+→ Approve
+→ Execute
+→ Verify
+```
+
+## Architectural rule
+
+- Software collects facts, detects signals, applies policy, simulates and verifies.
+- One Lead Domain Analyst may later investigate ambiguous cases end to end.
+- Narrow tools or subagents gather evidence, but do not make independent decisions.
+- Humans own risk, approvals, product rules and future graph changes.
+- Every result remains evidence-backed.
+- `UNKNOWN` is valid and must be actionable.
+- Every resolved case requires a fresh scan.
+
+## MCP
+
+DNS Ops should expose a remote MCP server so Buzz, ChatGPT, Claude, Codex and other agents can use it.
+
+MCP is an **adapter** over the product core, not the location of business logic.
+
+The approved Phase 0–1 MCP surface is narrower than the long-term option and is defined only by the execution contract.
+
+Long-term candidate capabilities include:
+
+```text
+portfolio_list
+domain_search
+domain_get_profile
+domain_get_posture
+snapshot_compare
+evidence_get
+signal_list
+case_get
+case_list
+case_open
+case_set_disposition
+scan_request
+simulation_request
+```
+
+External writes later require:
+
+- least-privilege scopes;
+- tenant isolation;
+- deterministic simulation;
+- durable approval;
+- idempotency;
+- audit;
+- fresh verification.
+
+WebMCP is separate and optional later.
+
+## Main conceptual pivot
+
+Move from:
+
+```text
+finding → generic suggestion
+```
+
+to:
+
+```text
+signal → accountable case → verified resolution
+```
+
+## First internal outcome
+
+An internal operator can:
+
+1. open the domain portfolio;
+2. see which cases need attention;
+3. understand the issue in simple language;
+4. inspect technical evidence;
+5. record the next action;
+6. request a rescan;
+7. prove the case resolved or reopened.
+
+First evidence surfaces:
+
+- RDAP/expiration;
+- DNS and mail;
+- TLS;
+- redirects;
+- availability;
+- selected headers;
+- homepage robots/canonical/indexability.
+
+## Commercial hypothesis
+
+Likely future ICP:
+
+- agencies;
+- consultants;
+- small MSPs;
+- internal digital teams;
+
+managing approximately 20–300 domains.
+
+They do not need another score. They need:
+
+- trusted signals;
+- one coherent case;
+- safe remediation;
+- client-ready explanations;
+- proof of resolution;
+- recurring operational evidence.
+
+Internal dogfooding cannot validate multi-human ownership, client communication or willingness to pay. Those require a later second-human design-partner pilot.
+
+## Differentiation
+
+DNS Ops can correlate across layers:
+
+- certificate versus CAA;
+- sender configuration versus SPF/DKIM/DMARC;
+- canonical versus redirect versus sitemap;
+- expiry versus renewal responsibility;
+- deployment versus `noindex`;
+- provider change versus regression;
+- remediation versus fresh verification.
+
+## What not to build now
+
+- generic SEO suite;
+- full attack-surface management;
+- deep crawler;
+- autonomous production writes;
+- universal score;
+- WebMCP requirement;
+- a swarm of specialized reasoning agents;
+- commercial ownership and client surfaces before external evidence.
+
+## Recommended sequence
+
+```text
+Repository truth
+→ trustworthy evidence
+→ human case loop
+→ deterministic MCP harness
+→ connect Buzz later
+→ one Lead Domain Analyst later
+→ internal proof
+→ controlled remediation
+→ commercial pilots
+```
+
+## Decision sentence
+
+> DNS Ops should be useful without AI, more powerful with an agent, and never less trustworthy because an agent is involved.


### PR DESCRIPTION
## What changed

Adds the approved Domain Operations documentation package under `docs/domain-operations/`:

- authority index and document hierarchy;
- Lean Phase 0–1 Execution Contract V4.1, preserved in four ordered parts behind one canonical entrypoint;
- controlled test-asset and fault-injection runbook;
- Day 0 worksheet for the manual-work baseline, initial portfolio and test assets;
- concise long-term product and MCP context, explicitly non-authoritative for Phase 0–1.

## Why

DNS Ops needs an execution-ready internal infrastructure outcome before implementation begins. The contract fixes the budget, closes scope decisions, defines deterministic failure fixtures, prevents false-green evidence, bounds MCP authorization, and separates the long-term commercial thesis from the funded Phase 0–1 work.

## Impact

Documentation only. No runtime, schema, dependency or deployment changes.

Implementation must not begin until the Day 0 worksheet completion gate is satisfied.

## Validation

- Compared branch against `master`.
- Diff contains nine new Markdown files only.
- No existing files modified.
- No code or configuration changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Domain Operations Phase 0–1 documentation package under `docs/domain-operations`, including the V4.1 execution contract (canonical entrypoint + four parts), the controlled test-asset runbook, and the Day 0 worksheet. Docs only; sets authority, scope, gates, and safety rules for the DNS Ops internal outcome.

- **Migration**
  - Do not start implementation until the Day 0 worksheet gate is completed.
  - Use `phase-0-1-execution-contract-v4.1.md` as the entrypoint; all four contract parts are authoritative and decisions are closed.
  - Live DNS tests run only via the deterministic fault-injection harness with a test-zone-scoped credential; the product and MCP have no provider-write capability.
  - For MAIL DNS tests, pre-propagate TTL 60 and require authoritative nameserver evidence (recursive cache alone is insufficient).

<sup>Written for commit 32dc8268ee8f38ce11513c3c9d2106bedf18f17a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

