### PR TITLE
Port validated DNS Ops Phase 0–1 implementation to master

### DIFF
--- a/apps/collector/src/delegation/integration.test.ts
+++ b/apps/collector/src/delegation/integration.test.ts
@@ -181,11 +181,18 @@ function patchResolver(target: unknown, resultsByQuery: Map<string, DNSQueryResu
     async (query: { name: string; type: string }, vantage: VantageInfo) => {
       const key = `${query.name}:${query.type}:${vantage.identifier}`;
       const fallbackKey = `${query.name}:${query.type}`;
-      return (
+      const canned =
         resultsByQuery.get(key) ??
         resultsByQuery.get(fallbackKey) ??
-        buildSuccessResult(query.name, query.type, [], vantage)
-      );
+        buildSuccessResult(query.name, query.type, [], vantage);
+      return {
+        ...canned,
+        vantage,
+        flags:
+          vantage.type === 'authoritative'
+            ? { aa: true, tc: false, rd: false, ra: false, ad: false, cd: false }
+            : canned.flags,
+      };
     }
   );
 }

--- a/apps/collector/src/dns/collector.authoritative.test.ts
+++ b/apps/collector/src/dns/collector.authoritative.test.ts
@@ -31,6 +31,7 @@ vi.mock('@dns-ops/db', () => ({
   SnapshotRepository: vi.fn().mockImplementation(function () {
     this.create = vi.fn().mockResolvedValue({ id: 'snapshot-1' });
     this.updateRulesetVersion = vi.fn().mockResolvedValue(undefined);
+    this.updateEvaluationCoverage = vi.fn().mockResolvedValue(undefined);
   }),
   ObservationRepository: vi.fn().mockImplementation(function () {
     this.createMany = vi.fn().mockResolvedValue([]);
@@ -52,7 +53,12 @@ vi.mock('@dns-ops/db', () => ({
 
 vi.mock('@dns-ops/rules', () => ({
   RulesEngine: vi.fn().mockImplementation(function () {
-    this.evaluate = vi.fn().mockReturnValue({ findings: [], suggestions: [] });
+    this.evaluate = vi.fn().mockReturnValue({
+      findings: [],
+      suggestions: [],
+      errors: [],
+      complete: true,
+    });
   }),
   authoritativeFailureRule: {
     id: 'auth-failure',

--- a/apps/collector/src/dns/collector.authoritative.test.ts
+++ b/apps/collector/src/dns/collector.authoritative.test.ts
@@ -184,6 +184,101 @@ describe('PR-07.6: Authoritative Collection', () => {
     });
   });
 
+  it('FIX-02: does not report complete when authoritative responses lack AA proof', () => {
+    const collector = new DNSCollector(baseConfig, mockDb);
+    const results: DNSQueryResult[] = [
+      {
+        query: { name: 'example.com', type: 'A' },
+        vantage: { type: 'public-recursive', identifier: '8.8.8.8' },
+        success: true,
+        responseCode: 0,
+        flags: { aa: false, tc: false, rd: true, ra: true, ad: false, cd: false },
+        answers: [{ name: 'example.com', type: 'A', ttl: 300, data: '192.0.2.1' }],
+        authority: [],
+        additional: [],
+        responseTime: 10,
+      },
+      {
+        query: { name: 'example.com', type: 'A' },
+        vantage: { type: 'authoritative', identifier: 'ns1.example.com' },
+        success: true,
+        responseCode: 0,
+        flags: { aa: false, tc: false, rd: false, ra: false, ad: false, cd: false },
+        answers: [{ name: 'example.com', type: 'A', ttl: 60, data: '192.0.2.1' }],
+        authority: [],
+        additional: [],
+        responseTime: 10,
+      },
+    ];
+
+    const state = (
+      collector as unknown as {
+        calculateResultState: (
+          queryResults: DNSQueryResult[],
+          errors: Array<{ queryName: string; queryType: string; vantage: string; error: string }>
+        ) => 'complete' | 'partial' | 'failed';
+      }
+    ).calculateResultState(results, []);
+
+    expect(state).toBe('partial');
+
+    const coverage = (
+      collector as unknown as {
+        getAuthoritativeEvidenceCoverage: (queryResults: DNSQueryResult[]) => {
+          state: string;
+          unknown?: { reason: string; action: string; blocking: boolean };
+        };
+      }
+    ).getAuthoritativeEvidenceCoverage(results);
+    expect(coverage).toMatchObject({
+      state: 'UNKNOWN',
+      unknown: {
+        reason: 'AUTHORITATIVE_EVIDENCE_UNAVAILABLE',
+        action: 'RETRY_PROBE',
+        blocking: true,
+      },
+    });
+  });
+
+  it('reports complete only when every direct nameserver response proves AA', () => {
+    const collector = new DNSCollector(baseConfig, mockDb);
+    const results: DNSQueryResult[] = [
+      {
+        query: { name: 'example.com', type: 'A' },
+        vantage: { type: 'public-recursive', identifier: '8.8.8.8' },
+        success: true,
+        responseCode: 0,
+        flags: { aa: false, tc: false, rd: true, ra: true, ad: false, cd: false },
+        answers: [{ name: 'example.com', type: 'A', ttl: 300, data: '192.0.2.1' }],
+        authority: [],
+        additional: [],
+        responseTime: 10,
+      },
+      {
+        query: { name: 'example.com', type: 'A' },
+        vantage: { type: 'authoritative', identifier: 'ns1.example.com' },
+        success: true,
+        responseCode: 0,
+        flags: { aa: true, tc: false, rd: false, ra: false, ad: false, cd: false },
+        answers: [{ name: 'example.com', type: 'A', ttl: 60, data: '192.0.2.1' }],
+        authority: [],
+        additional: [],
+        responseTime: 10,
+      },
+    ];
+
+    const state = (
+      collector as unknown as {
+        calculateResultState: (
+          queryResults: DNSQueryResult[],
+          errors: Array<{ queryName: string; queryType: string; vantage: string; error: string }>
+        ) => 'complete' | 'partial' | 'failed';
+      }
+    ).calculateResultState(results, []);
+
+    expect(state).toBe('complete');
+  });
+
   it('should return partial result when one authoritative server times out', async () => {
     const collector = new DNSCollector(baseConfig, mockDb);
 

--- a/apps/collector/src/dns/collector.ruleset-version.test.ts
+++ b/apps/collector/src/dns/collector.ruleset-version.test.ts
@@ -59,6 +59,7 @@ vi.mock('@dns-ops/db', () => ({
   SnapshotRepository: vi.fn().mockImplementation(function () {
     this.create = vi.fn().mockResolvedValue({ id: 'snapshot-1' });
     this.updateRulesetVersion = vi.fn().mockResolvedValue(undefined);
+    this.updateEvaluationCoverage = vi.fn().mockResolvedValue(undefined);
   }),
   ObservationRepository: vi.fn().mockImplementation(function () {
     this.createMany = vi.fn().mockResolvedValue([]);
@@ -80,7 +81,12 @@ vi.mock('@dns-ops/db', () => ({
 
 vi.mock('@dns-ops/rules', () => ({
   RulesEngine: vi.fn().mockImplementation(function () {
-    this.evaluate = vi.fn().mockReturnValue({ findings: [CANNED_FINDING], suggestions: [] });
+    this.evaluate = vi.fn().mockReturnValue({
+      findings: [CANNED_FINDING],
+      suggestions: [],
+      errors: [],
+      complete: true,
+    });
   }),
   authoritativeFailureRule: {
     id: 'auth-failure',
@@ -207,5 +213,80 @@ describe('TB-3 step 0: collector persists rulesetVersionId on findings', () => {
       expect(f.rulesetVersionId).toBe(RULESET_VERSION_ID);
       expect(f.rulesetVersionId).not.toBeNull();
     }
+  });
+
+  it('FIX-01: persists partial evaluation coverage when a rule is UNKNOWN', async () => {
+    const { RulesEngine } = await import('@dns-ops/rules');
+    vi.mocked(RulesEngine).mockImplementationOnce(function () {
+      this.evaluate = vi.fn().mockReturnValue({
+        findings: [],
+        suggestions: [],
+        complete: false,
+        errors: [
+          {
+            code: 'RULE_EXECUTION_FAILED',
+            ruleId: 'test.throwing-rule',
+            message: 'Rule test.throwing-rule could not be evaluated',
+            status: 'UNKNOWN',
+            unknown: {
+              reason: 'CHECK_EVALUATION_FAILED',
+              explanation: 'The check failed before it produced a trustworthy result.',
+              action: 'RUN_FRESH_SCAN',
+              actionLabel: 'Run a fresh scan',
+              blocking: true,
+            },
+          },
+        ],
+      });
+    } as unknown as typeof RulesEngine);
+
+    const collector = new DNSCollector(baseConfig, mockDb);
+    vi.spyOn(
+      collector as unknown as { discoverAuthoritativeServers: () => Promise<string[]> },
+      'discoverAuthoritativeServers'
+    ).mockResolvedValue([]);
+    vi.spyOn(
+      collector as unknown as {
+        collectFromVantage: (
+          queries: unknown[],
+          vantage: { type: string; identifier: string }
+        ) => Promise<unknown[]>;
+      },
+      'collectFromVantage'
+    ).mockResolvedValue([
+      {
+        query: { name: 'example.com', type: 'A' },
+        vantage: { type: 'public-recursive', identifier: '8.8.8.8' },
+        success: true,
+        answers: [{ name: 'example.com', type: 'A', ttl: 300, data: '192.0.2.1' }],
+        authority: [],
+        additional: [],
+        responseTime: 50,
+        responseCode: 0,
+      },
+    ]);
+
+    const collectionResult = await collector.collect();
+
+    expect(collectionResult.resultState).toBe('partial');
+
+    const { SnapshotRepository, FindingRepository } = await import('@dns-ops/db');
+    const snapshotInstances = vi.mocked(SnapshotRepository).mock.instances;
+    const snapshotRepo = snapshotInstances[snapshotInstances.length - 1] as {
+      updateEvaluationCoverage: ReturnType<typeof vi.fn>;
+    };
+    expect(snapshotRepo.updateEvaluationCoverage).toHaveBeenCalledWith(
+      'snapshot-1',
+      expect.objectContaining({
+        state: 'PARTIAL',
+        errors: [expect.objectContaining({ ruleId: 'test.throwing-rule', status: 'UNKNOWN' })],
+      })
+    );
+
+    const findingInstances = vi.mocked(FindingRepository).mock.instances;
+    const findingRepo = findingInstances[findingInstances.length - 1] as {
+      createMany: ReturnType<typeof vi.fn>;
+    };
+    expect(findingRepo.createMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/collector/src/dns/collector.ts
+++ b/apps/collector/src/dns/collector.ts
@@ -5,7 +5,7 @@
  * Evaluates rules and persists findings immediately after collection.
  */
 
-import { determineStatus } from '@dns-ops/contracts';
+import { type AuthoritativeEvidenceCoverage, determineStatus } from '@dns-ops/contracts';
 import type {
   IDatabaseAdapter,
   NewFinding,
@@ -400,6 +400,14 @@ export class DNSCollector {
     const successCount = results.filter((r) => r.success).length;
     const totalCount = results.length;
 
+    if (this.config.zoneManagement === 'managed') {
+      const authoritativeResults = results.filter((r) => r.vantage.type === 'authoritative');
+      const lacksAuthoritativeProof =
+        authoritativeResults.length === 0 ||
+        authoritativeResults.some((result) => result.success && result.flags?.aa !== true);
+      if (lacksAuthoritativeProof) return 'partial';
+    }
+
     if (successCount === totalCount) {
       return this.config.zoneManagement === 'unmanaged' ? 'partial' : 'complete';
     }
@@ -409,6 +417,37 @@ export class DNSCollector {
     }
 
     return 'failed';
+  }
+
+  private getAuthoritativeEvidenceCoverage(
+    results: DNSQueryResult[]
+  ): AuthoritativeEvidenceCoverage {
+    if (this.config.zoneManagement !== 'managed') {
+      return { state: 'NOT_REQUESTED', nameservers: [] };
+    }
+
+    const authoritative = results.filter((result) => result.vantage.type === 'authoritative');
+    const nameservers = [...new Set(authoritative.map((result) => result.vantage.identifier))];
+    const verified =
+      authoritative.length > 0 &&
+      authoritative.every((result) => result.success && result.flags?.aa === true);
+
+    if (verified) return { state: 'VERIFIED', nameservers };
+
+    return {
+      state: 'UNKNOWN',
+      nameservers,
+      unknown: {
+        reason: 'AUTHORITATIVE_EVIDENCE_UNAVAILABLE',
+        explanation:
+          authoritative.length === 0
+            ? 'No direct authoritative response was captured.'
+            : 'At least one direct nameserver response failed or lacked the authoritative-answer flag.',
+        action: 'RETRY_PROBE',
+        actionLabel: 'Retry authoritative DNS collection',
+        blocking: true,
+      },
+    };
   }
 
   /**
@@ -449,6 +488,7 @@ export class DNSCollector {
       metadata: {
         // Vantage identifiers (IPs/hostnames) for detailed tracking
         vantageIdentifiers: [...new Set(results.map((r) => r.vantage.identifier))],
+        authoritativeEvidence: this.getAuthoritativeEvidenceCoverage(results),
         // Delegation data if available (Bead 12, dns-ops-1j4.6.4)
         ...(delegationData
           ? {

--- a/apps/collector/src/dns/collector.ts
+++ b/apps/collector/src/dns/collector.ts
@@ -225,12 +225,12 @@ export class DNSCollector {
     const resultState = this.calculateResultState(allResults, errors);
 
     // Store results to database via domain/snapshot/observation repositories
-    const snapshotId = await this.storeResults(allResults, resultState, delegationData);
+    const stored = await this.storeResults(allResults, resultState, delegationData);
 
     return {
-      snapshotId,
+      snapshotId: stored.snapshotId,
       domain: this.config.domain,
-      resultState,
+      resultState: stored.resultState,
       observationCount: allResults.length,
       duration: Date.now() - startTime,
       errors,
@@ -418,7 +418,10 @@ export class DNSCollector {
     results: DNSQueryResult[],
     resultState: 'complete' | 'partial' | 'failed',
     delegationData?: import('../delegation/collector.js').DelegationSummary | null
-  ): Promise<string> {
+  ): Promise<{
+    snapshotId: string;
+    resultState: 'complete' | 'partial' | 'failed';
+  }> {
     const { tenantId, domain, zoneManagement, triggeredBy } = this.config;
     // Find or create domain within the current tenant scope.
     // The same normalized domain may legitimately exist in multiple tenant portfolios.
@@ -546,20 +549,24 @@ export class DNSCollector {
     // Evaluate rules and persist findings immediately
     // This ensures findings are available for portfolio views without
     // requiring a separate API call
-    const { findingsCount, suggestionsCount } = await this.evaluateAndPersistFindings(
-      snapshot.id,
-      domainRecord.id,
-      domain,
-      zoneManagement as 'managed' | 'unmanaged' | 'unknown',
-      createdObservations,
-      createdRecordSets
-    );
+    const { findingsCount, suggestionsCount, evaluationErrors } =
+      await this.evaluateAndPersistFindings(
+        snapshot.id,
+        domainRecord.id,
+        domain,
+        zoneManagement as 'managed' | 'unmanaged' | 'unknown',
+        createdObservations,
+        createdRecordSets
+      );
 
     if (findingsCount > 0) {
       logger.info('Persisted findings', { domain, findingsCount, suggestionsCount });
     }
 
-    return snapshot.id;
+    return {
+      snapshotId: snapshot.id,
+      resultState: evaluationErrors > 0 && resultState === 'complete' ? 'partial' : resultState,
+    };
   }
 
   /**
@@ -603,7 +610,7 @@ export class DNSCollector {
     zoneManagement: 'managed' | 'unmanaged' | 'unknown',
     observations: Observation[],
     recordSets: RecordSet[]
-  ): Promise<{ findingsCount: number; suggestionsCount: number }> {
+  ): Promise<{ findingsCount: number; suggestionsCount: number; evaluationErrors: number }> {
     try {
       // Create ruleset and engine
       const ruleset = createCombinedRuleset();
@@ -647,11 +654,16 @@ export class DNSCollector {
         rulesetVersion: ruleset.version,
       };
 
-      // Evaluate rules
-      const { findings, suggestions } = engine.evaluate(context);
+      // Evaluate rules. Per-rule failures are explicit UNKNOWN coverage, not
+      // absence of findings. Persist coverage before any early return.
+      const { findings, suggestions, errors, complete } = engine.evaluate(context);
+      await this.snapshotRepo.updateEvaluationCoverage(snapshotId, {
+        state: complete ? 'COMPLETE' : 'PARTIAL',
+        errors,
+      });
 
       if (findings.length === 0) {
-        return { findingsCount: 0, suggestionsCount: 0 };
+        return { findingsCount: 0, suggestionsCount: 0, evaluationErrors: errors.length };
       }
 
       // Persist findings
@@ -710,15 +722,37 @@ export class DNSCollector {
       return {
         findingsCount: persistedFindings.length,
         suggestionsCount: suggestionsToInsert.length,
+        evaluationErrors: errors.length,
       };
     } catch (error) {
-      // Log error but don't fail the collection
+      // Preserve a typed, sanitized UNKNOWN even when evaluation infrastructure
+      // fails outside an individual rule. The detailed exception stays in logs.
       logger.error(
         'Error evaluating and persisting findings',
         error instanceof Error ? error : new Error(String(error)),
         { domain: this.config.domain }
       );
-      return { findingsCount: 0, suggestionsCount: 0 };
+      await this.snapshotRepo
+        .updateEvaluationCoverage(snapshotId, {
+          state: 'PARTIAL',
+          errors: [
+            {
+              code: 'RULE_EXECUTION_FAILED',
+              ruleId: 'ruleset',
+              message: 'Ruleset evaluation could not be completed',
+              status: 'UNKNOWN',
+              unknown: {
+                reason: 'CHECK_EVALUATION_FAILED',
+                explanation: 'The ruleset failed before every check produced a trustworthy result.',
+                action: 'RUN_FRESH_SCAN',
+                actionLabel: 'Run a fresh scan',
+                blocking: true,
+              },
+            },
+          ],
+        })
+        .catch(() => undefined);
+      return { findingsCount: 0, suggestionsCount: 0, evaluationErrors: 1 };
     }
   }
 }

--- a/apps/collector/src/dns/dnssec-decode.test.ts
+++ b/apps/collector/src/dns/dnssec-decode.test.ts
@@ -9,7 +9,7 @@
 
 import * as dnsPacket from 'dns-packet';
 import { describe, expect, it } from 'vitest';
-import { decodeDnsResponse } from './dnssec-resolver.js';
+import { decodeDnsResponse, encodeDnsQuery } from './dnssec-resolver.js';
 
 function encodeResponse(
   answers: dnsPacket.Answer[] = [],
@@ -31,6 +31,24 @@ function encodeResponse(
   }
   return buf;
 }
+
+describe('encodeDnsQuery', () => {
+  it('sets recursion desired for recursive resolver queries', () => {
+    const packet = dnsPacket.decode(
+      encodeDnsQuery({ name: 'example.com', type: 'A' }, { recursionDesired: true })
+    );
+
+    expect((packet.flags ?? 0) & (dnsPacket.RECURSION_DESIRED as number)).not.toBe(0);
+  });
+
+  it('does not set recursion desired for authoritative queries', () => {
+    const packet = dnsPacket.decode(
+      encodeDnsQuery({ name: 'example.com', type: 'A' }, { recursionDesired: false })
+    );
+
+    expect((packet.flags ?? 0) & (dnsPacket.RECURSION_DESIRED as number)).toBe(0);
+  });
+});
 
 describe('decodeDnsResponse', () => {
   describe('real TTL + data formatting per record type', () => {

--- a/apps/collector/src/dns/dnssec-resolver.ts
+++ b/apps/collector/src/dns/dnssec-resolver.ts
@@ -68,14 +68,17 @@ export interface DnsResponseSections {
  * types Node does not support at all (DNSKEY/DS). Encodes a query, sends it via
  * sendDnsQuery (UDP with TCP fallback), then decodes the wire response.
  */
-export async function queryWithDnsPacket(
-  query: DNSQuery,
-  dnsServer: string = DEFAULT_DNS_SERVERS[0]
-): Promise<DnsResponseSections> {
-  const packetOut = dnsPacket.encode({
+export interface DnsQueryOptions {
+  recursionDesired?: boolean;
+}
+
+/** Encode a DNS query without performing I/O so recursion policy is testable. */
+export function encodeDnsQuery(query: DNSQuery, options: DnsQueryOptions = {}): Buffer {
+  const { recursionDesired = true } = options;
+  return dnsPacket.encode({
     type: 'query',
     id: Math.floor(Math.random() * 0xffff),
-    flags: dnsPacket.RECURSION_DESIRED as number,
+    flags: recursionDesired ? (dnsPacket.RECURSION_DESIRED as number) : 0,
     questions: [
       {
         type: DNS_TYPES[query.type] || query.type,
@@ -84,8 +87,14 @@ export async function queryWithDnsPacket(
       },
     ],
   });
+}
 
-  const response = await sendDnsQuery(packetOut, dnsServer, 53);
+export async function queryWithDnsPacket(
+  query: DNSQuery,
+  dnsServer: string = DEFAULT_DNS_SERVERS[0],
+  options: DnsQueryOptions = {}
+): Promise<DnsResponseSections> {
+  const response = await sendDnsQuery(encodeDnsQuery(query, options), dnsServer, 53);
   return decodeDnsResponse(response, query.type);
 }
 

--- a/apps/collector/src/dns/integration.test.ts
+++ b/apps/collector/src/dns/integration.test.ts
@@ -350,7 +350,16 @@ describe('DNS Collector Integration', () => {
     const resolver = (collector as unknown as { resolver: { query: unknown } }).resolver;
     resolver.query = vi.fn(async (query: { name: string; type: string }, vantage: VantageInfo) => {
       const key = `${query.name}:${query.type}`;
-      return resultsByQuery.get(key) ?? buildSuccessResult(query.name, query.type, [], vantage);
+      const canned =
+        resultsByQuery.get(key) ?? buildSuccessResult(query.name, query.type, [], vantage);
+      return {
+        ...canned,
+        vantage,
+        flags:
+          vantage.type === 'authoritative'
+            ? { aa: true, tc: false, rd: false, ra: false, ad: false, cd: false }
+            : canned.flags,
+      };
     });
 
     // Also suppress delegation collection to keep tests focused

--- a/apps/collector/src/dns/resolver.test.ts
+++ b/apps/collector/src/dns/resolver.test.ts
@@ -1,62 +1,47 @@
 /**
- * DNS Resolver Tests
+ * DNSResolver wire-evidence tests.
  *
- * A/AAAA are resolved via node:dns/promises with {ttl:true} (real TTL); the
- * other supported types are resolved via the dns-packet raw path
- * (queryWithDnsPacket, mocked here). Every record type must carry the REAL
- * answer TTL supplied by the mocked layer — never the fabricated 300.
+ * Every supported type uses the raw dns-packet path so TTLs, rcodes, and flags
+ * are never fabricated or discarded.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// vi.hoisted guarantees the mock fns exist when the hoisted vi.mock factories
-// run (factories cannot reference plain top-level consts due to TDZ).
 const mocks = vi.hoisted(() => ({
-  resolve4: vi.fn(),
-  resolve6: vi.fn(),
-  setServers: vi.fn(),
   queryWithDnsPacket: vi.fn(),
-}));
-
-vi.mock('node:dns/promises', () => ({
-  Resolver: class {
-    resolve4 = mocks.resolve4;
-    resolve6 = mocks.resolve6;
-    setServers = mocks.setServers;
-  },
 }));
 
 vi.mock('./dnssec-resolver.js', () => ({
   queryWithDnsPacket: mocks.queryWithDnsPacket,
 }));
 
-// Local aliases for readability in the test body.
-const mockResolve4 = mocks.resolve4;
-const mockResolve6 = mocks.resolve6;
-const mockSetServers = mocks.setServers;
-const mockQueryWithDnsPacket = mocks.queryWithDnsPacket;
-
 import { DNSResolver } from './resolver.js';
 import type { DNSAnswer, VantageInfo } from './types.js';
 
-/** Build a dns-packet-shaped response with real TTLs per answer. */
-function packetResponse(answers: DNSAnswer[], responseCode = 0) {
+function packetResponse(
+  answers: DNSAnswer[],
+  options: {
+    responseCode?: number;
+    flags?: { aa: boolean; tc: boolean; rd: boolean; ra: boolean; ad: boolean; cd: boolean };
+  } = {}
+) {
   return {
     answers,
     authority: [] as DNSAnswer[],
     additional: [] as DNSAnswer[],
-    flags: { aa: false, tc: false, rd: true, ra: true, ad: false, cd: false },
-    responseCode,
+    flags: options.flags ?? { aa: false, tc: false, rd: true, ra: true, ad: false, cd: false },
+    responseCode: options.responseCode ?? 0,
   };
 }
 
+const recursiveVantage: VantageInfo = { type: 'public-recursive', identifier: '8.8.8.8' };
+const authoritativeVantage: VantageInfo = {
+  type: 'authoritative',
+  identifier: 'ns1.example.com',
+};
+
 describe('DNSResolver', () => {
   let resolver: DNSResolver;
-  const recursiveVantage: VantageInfo = { type: 'public-recursive', identifier: '8.8.8.8' };
-  const authoritativeVantage: VantageInfo = {
-    type: 'authoritative',
-    identifier: 'ns1.example.com',
-  };
 
   beforeEach(() => {
     resolver = new DNSResolver();
@@ -67,231 +52,98 @@ describe('DNSResolver', () => {
     vi.resetAllMocks();
   });
 
-  describe('Vantage Configuration', () => {
-    it('sets servers for public-recursive vantage (A query)', async () => {
-      mockResolve4.mockResolvedValue([{ address: '192.0.2.1', ttl: 300 }]);
-      await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(mockSetServers).toHaveBeenCalledWith(['8.8.8.8']);
-    });
+  it('queries recursive vantages with recursion desired and preserves wire flags', async () => {
+    mocks.queryWithDnsPacket.mockResolvedValue(
+      packetResponse([{ name: 'example.com', type: 'A', ttl: 86400, data: '192.0.2.1' }])
+    );
 
-    it('sets servers for authoritative vantage (A query)', async () => {
-      mockResolve4.mockResolvedValue([{ address: '192.0.2.1', ttl: 300 }]);
-      await resolver.query({ name: 'example.com', type: 'A' }, authoritativeVantage);
-      expect(mockSetServers).toHaveBeenCalledWith(['ns1.example.com']);
+    const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
+
+    expect(mocks.queryWithDnsPacket).toHaveBeenCalledWith(
+      { name: 'example.com', type: 'A' },
+      '8.8.8.8',
+      { recursionDesired: true }
+    );
+    expect(result.answers[0]).toMatchObject({ ttl: 86400, data: '192.0.2.1' });
+    expect(result.flags).toMatchObject({ aa: false, rd: true, ra: true });
+  });
+
+  it('queries authoritative nameserver hostnames with recursion disabled and preserves AA', async () => {
+    mocks.queryWithDnsPacket.mockResolvedValue(
+      packetResponse([{ name: 'example.com', type: 'A', ttl: 60, data: '192.0.2.1' }], {
+        flags: { aa: true, tc: false, rd: false, ra: false, ad: false, cd: false },
+      })
+    );
+
+    const result = await resolver.query({ name: 'example.com', type: 'A' }, authoritativeVantage);
+
+    expect(mocks.queryWithDnsPacket).toHaveBeenCalledWith(
+      { name: 'example.com', type: 'A' },
+      'ns1.example.com',
+      { recursionDesired: false }
+    );
+    expect(result.flags).toEqual({
+      aa: true,
+      tc: false,
+      rd: false,
+      ra: false,
+      ad: false,
+      cd: false,
     });
   });
 
-  describe('Real TTLs (no fabrication)', () => {
-    it('A: carries the answer TTL from {ttl:true}, not 300', async () => {
-      mockResolve4.mockResolvedValue([
-        { address: '192.0.2.1', ttl: 86400 },
-        { address: '192.0.2.2', ttl: 86400 },
-      ]);
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.success).toBe(true);
-      expect(result.answers).toHaveLength(2);
-      expect(result.answers[0]).toMatchObject({ type: 'A', ttl: 86400, data: '192.0.2.1' });
-      expect(result.answers[1].ttl).toBe(86400);
-    });
+  it.each([
+    ['AAAA', '2001:db8::1', 3600],
+    ['MX', '10 mail.example.com', 1800],
+    ['TXT', 'v=spf1 include:_spf.example ~all', 600],
+    ['NS', 'ns1.example.com', 7200],
+    ['CNAME', 'target.example.com', 120],
+    ['SOA', 'ns1.example.com admin.example.com 1 3600 900 604800 86400', 3600],
+    ['CAA', '0 issue "letsencrypt.org"', 3600],
+  ])('preserves real %s answer data and TTL', async (type, data, ttl) => {
+    mocks.queryWithDnsPacket.mockResolvedValue(
+      packetResponse([{ name: 'example.com', type, ttl, data }])
+    );
 
-    it('AAAA: carries the answer TTL, not 300', async () => {
-      mockResolve6.mockResolvedValue([{ address: '2001:db8::1', ttl: 3600 }]);
-      const result = await resolver.query({ name: 'example.com', type: 'AAAA' }, recursiveVantage);
-      expect(result.answers[0]).toMatchObject({ type: 'AAAA', ttl: 3600, data: '2001:db8::1' });
-    });
+    const result = await resolver.query({ name: 'example.com', type }, recursiveVantage);
 
-    it('MX: real TTL via dns-packet, formatted "pref exchange"', async () => {
-      mockQueryWithDnsPacket.mockResolvedValue(
-        packetResponse([
-          { name: 'example.com', type: 'MX', ttl: 1800, data: '10 mail.example.com' },
-          { name: 'example.com', type: 'MX', ttl: 1800, data: '20 backup.example.com' },
-        ])
-      );
-      const result = await resolver.query({ name: 'example.com', type: 'MX' }, recursiveVantage);
-      expect(mockQueryWithDnsPacket).toHaveBeenCalledWith(
-        { name: 'example.com', type: 'MX' },
-        '8.8.8.8'
-      );
-      expect(result.success).toBe(true);
-      expect(result.answers[0]).toMatchObject({
-        type: 'MX',
-        ttl: 1800,
-        data: '10 mail.example.com',
-      });
-      expect(result.answers[1].data).toBe('20 backup.example.com');
-      expect(result.answers.every((a) => a.ttl !== 300)).toBe(true);
-    });
-
-    it('TXT: real TTL via dns-packet, joined value for SPF matching', async () => {
-      mockQueryWithDnsPacket.mockResolvedValue(
-        packetResponse([
-          {
-            name: 'example.com',
-            type: 'TXT',
-            ttl: 600,
-            data: 'v=spf1 include:_spf.google.com ~all',
-          },
-        ])
-      );
-      const result = await resolver.query({ name: 'example.com', type: 'TXT' }, recursiveVantage);
-      expect(result.answers[0]).toMatchObject({ type: 'TXT', ttl: 600 });
-      expect(result.answers[0].data).toBe('v=spf1 include:_spf.google.com ~all');
-    });
-
-    it('NS: real TTL via dns-packet', async () => {
-      mockQueryWithDnsPacket.mockResolvedValue(
-        packetResponse([
-          { name: 'example.com', type: 'NS', ttl: 7200, data: 'ns1.example.com' },
-          { name: 'example.com', type: 'NS', ttl: 7200, data: 'ns2.example.com' },
-        ])
-      );
-      const result = await resolver.query({ name: 'example.com', type: 'NS' }, recursiveVantage);
-      expect(result.answers[0]).toMatchObject({ type: 'NS', ttl: 7200, data: 'ns1.example.com' });
-      expect(result.answers[1].data).toBe('ns2.example.com');
-    });
-
-    it('CNAME: real TTL via dns-packet', async () => {
-      mockQueryWithDnsPacket.mockResolvedValue(
-        packetResponse([
-          { name: 'alias.example.com', type: 'CNAME', ttl: 120, data: 'target.example.com' },
-        ])
-      );
-      const result = await resolver.query(
-        { name: 'alias.example.com', type: 'CNAME' },
-        recursiveVantage
-      );
-      expect(result.answers[0]).toMatchObject({
-        name: 'alias.example.com',
-        type: 'CNAME',
-        ttl: 120,
-        data: 'target.example.com',
-      });
-    });
-
-    it('SOA: real RECORD TTL (not the SOA minimum field)', async () => {
-      // Record TTL 3600; the SOA minimum (86400) appears only inside data.
-      mockQueryWithDnsPacket.mockResolvedValue(
-        packetResponse([
-          {
-            name: 'example.com',
-            type: 'SOA',
-            ttl: 3600,
-            data: 'ns1.example.com admin.example.com 2024010101 3600 900 604800 86400',
-          },
-        ])
-      );
-      const result = await resolver.query({ name: 'example.com', type: 'SOA' }, recursiveVantage);
-      expect(result.answers[0].ttl).toBe(3600);
-      expect(result.answers[0].data).toBe(
-        'ns1.example.com admin.example.com 2024010101 3600 900 604800 86400'
-      );
-    });
-
-    it('CAA: real TTL via dns-packet', async () => {
-      mockQueryWithDnsPacket.mockResolvedValue(
-        packetResponse([
-          { name: 'example.com', type: 'CAA', ttl: 3600, data: '0 issue "letsencrypt.org"' },
-        ])
-      );
-      const result = await resolver.query({ name: 'example.com', type: 'CAA' }, recursiveVantage);
-      expect(result.success).toBe(true);
-      expect(result.answers[0]).toMatchObject({ type: 'CAA', ttl: 3600 });
-      expect(result.answers[0].data).toBe('0 issue "letsencrypt.org"');
-    });
-
-    it('dns-packet types do not call the Node resolver', async () => {
-      mockQueryWithDnsPacket.mockResolvedValue(packetResponse([]));
-      await resolver.query({ name: 'example.com', type: 'TXT' }, recursiveVantage);
-      expect(mockResolve4).not.toHaveBeenCalled();
-      expect(mockResolve6).not.toHaveBeenCalled();
-    });
+    expect(result.success).toBe(true);
+    expect(result.answers[0]).toMatchObject({ type, ttl, data });
   });
 
-  describe('Error Handling', () => {
-    it('maps dns-packet NXDOMAIN rcode to failure', async () => {
-      mockQueryWithDnsPacket.mockResolvedValue(packetResponse([], 3));
-      const result = await resolver.query(
-        { name: 'nope.example.com', type: 'TXT' },
-        recursiveVantage
-      );
-      expect(result.success).toBe(false);
-      expect(result.responseCode).toBe(3); // NXDOMAIN
-      expect(result.error).toBeDefined();
-    });
+  it('maps a wire NXDOMAIN to a failed result without converting it to absence', async () => {
+    mocks.queryWithDnsPacket.mockResolvedValue(packetResponse([], { responseCode: 3 }));
 
-    it('handles ENOTFOUND as NXDOMAIN (A record)', async () => {
-      mockResolve4.mockRejectedValue(new Error('getaddrinfo ENOTFOUND example.com'));
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.success).toBe(false);
-      expect(result.responseCode).toBe(3);
-      expect(result.error).toContain('ENOTFOUND');
-    });
+    const result = await resolver.query(
+      { name: 'missing.example.com', type: 'TXT' },
+      recursiveVantage
+    );
 
-    it('handles ECONNREFUSED as REFUSED', async () => {
-      mockResolve4.mockRejectedValue(new Error('connect ECONNREFUSED 8.8.8.8'));
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.success).toBe(false);
-      expect(result.responseCode).toBe(5); // REFUSED
-    });
-
-    it('handles timeout errors as SERVFAIL', async () => {
-      mockResolve4.mockRejectedValue(new Error('DNS query timeout'));
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.success).toBe(false);
-      expect(result.responseCode).toBe(2); // SERVFAIL
-    });
-
-    it('handles unknown errors as SERVFAIL', async () => {
-      mockResolve4.mockRejectedValue(new Error('Unknown error'));
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.success).toBe(false);
-      expect(result.responseCode).toBe(2);
-      expect(result.error).toBe('Unknown error');
-    });
-
-    it('returns SERVFAIL for unsupported record types', async () => {
-      const result = await resolver.query(
-        { name: 'example.com', type: 'UNSUPPORTED' },
-        recursiveVantage
-      );
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('Unsupported record type: UNSUPPORTED');
-      expect(result.responseCode).toBe(2);
-    });
+    expect(result.success).toBe(false);
+    expect(result.responseCode).toBe(3);
+    expect(result.error).toBe('DNS query failed with rcode 3');
   });
 
-  describe('Response Structure', () => {
-    it('includes query and vantage info in response', async () => {
-      mockResolve4.mockResolvedValue([{ address: '192.0.2.1', ttl: 300 }]);
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.query).toEqual({ name: 'example.com', type: 'A' });
-      expect(result.vantage).toEqual(recursiveVantage);
-    });
+  it('maps transport timeout to SERVFAIL and preserves authoritative recursion policy', async () => {
+    mocks.queryWithDnsPacket.mockRejectedValue(new Error('DNS query timeout'));
 
-    it('includes DNS flags in successful response', async () => {
-      mockResolve4.mockResolvedValue([{ address: '192.0.2.1', ttl: 300 }]);
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.flags).toMatchObject({
-        aa: false,
-        tc: false,
-        rd: true,
-        ra: true,
-        ad: false,
-        cd: false,
-      });
-    });
+    const result = await resolver.query({ name: 'example.com', type: 'A' }, authoritativeVantage);
 
-    it('includes empty authority and additional sections for A', async () => {
-      mockResolve4.mockResolvedValue([{ address: '192.0.2.1', ttl: 300 }]);
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.authority).toEqual([]);
-      expect(result.additional).toEqual([]);
-    });
+    expect(result.success).toBe(false);
+    expect(result.responseCode).toBe(2);
+    expect(result.flags?.rd).toBe(false);
+    expect(result.error).toBe('DNS query timeout');
+  });
 
-    it('includes response time', async () => {
-      mockResolve4.mockResolvedValue([{ address: '192.0.2.1', ttl: 300 }]);
-      const result = await resolver.query({ name: 'example.com', type: 'A' }, recursiveVantage);
-      expect(result.responseTime).toBeGreaterThanOrEqual(0);
-    });
+  it('rejects unsupported record types without network I/O', async () => {
+    const result = await resolver.query(
+      { name: 'example.com', type: 'UNSUPPORTED' },
+      recursiveVantage
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.responseCode).toBe(2);
+    expect(result.error).toBe('Unsupported record type: UNSUPPORTED');
+    expect(mocks.queryWithDnsPacket).not.toHaveBeenCalled();
   });
 });

--- a/apps/collector/src/dns/resolver.ts
+++ b/apps/collector/src/dns/resolver.ts
@@ -1,139 +1,53 @@
 /**
  * DNS Resolver
  *
- * Performs actual DNS queries, capturing REAL answer TTLs (never fabricated).
- *
- * - A/AAAA use Node.js dns with {ttl:true}; this is the only record family for
- *   which Node exposes the real answer TTL.
- * - MX/TXT/NS/CNAME/SOA/CAA use the dns-packet raw path (queryWithDnsPacket),
- *   because Node's high-level dns API hides TTLs for those types and would
- *   otherwise force a fabricated default.
- *
- * Flags are returned uniformly (aa/tc/...). The dns-packet path does observe
- * real flags, but surfacing them (e.g. the AA bit for authoritative queries) is
- * intentionally out of scope here; see docs/architecture/runtime-topology.md.
- *
- * Error mapping uses standardized DNS_RCODE constants from @dns-ops/contracts
- * for consistent status classification across the codebase.
+ * Performs wire-format DNS queries for every supported record type so answer
+ * TTLs, response codes, and flags are preserved exactly. Authoritative targets
+ * are queried with recursion disabled; recursive vantages request recursion.
  */
 
-import { Resolver } from 'node:dns/promises';
 import { DNS_RCODE } from '@dns-ops/contracts';
 import { queryWithDnsPacket } from './dnssec-resolver.js';
-import type { DNSAnswer, DNSQuery, DNSQueryResult, VantageInfo } from './types.js';
+import type { DNSQuery, DNSQueryResult, VantageInfo } from './types.js';
 
-/**
- * Record types resolved via the dns-packet raw path. Node's high-level dns API
- * hides answer TTLs for these, so the wire response must be decoded directly to
- * obtain a real (non-fabricated) TTL.
- */
-const DNS_PACKET_TYPES = new Set(['MX', 'TXT', 'NS', 'CNAME', 'SOA', 'CAA']);
-
-/** Uniform DNS flags returned for both resolution paths. */
-const UNIFORM_FLAGS = {
-  aa: false,
-  tc: false,
-  rd: true,
-  ra: true,
-  ad: false,
-  cd: false,
-} as const;
+const SUPPORTED_TYPES = new Set(['A', 'AAAA', 'MX', 'TXT', 'NS', 'CNAME', 'SOA', 'CAA']);
 
 export class DNSResolver {
-  /**
-   * Perform a DNS query, returning the real answer TTL for every record type.
-   */
+  /** Perform a DNS query and preserve real wire evidence. */
   async query(query: DNSQuery, vantage: VantageInfo): Promise<DNSQueryResult> {
     const startTime = Date.now();
 
     try {
-      if (DNS_PACKET_TYPES.has(query.type)) {
-        return await this.queryViaDnsPacket(query, vantage, startTime);
+      if (!SUPPORTED_TYPES.has(query.type)) {
+        throw new Error(`Unsupported record type: ${query.type}`);
       }
 
-      // A/AAAA (and any future type Node resolves directly) — real TTL via
-      // {ttl:true}.
-      const nodeResolver = new Resolver();
-      nodeResolver.setServers([vantage.identifier]);
-      const performed = await this.performNodeQuery(nodeResolver, query);
-      return {
+      const result = await queryWithDnsPacket(query, vantage.identifier, {
+        recursionDesired: vantage.type !== 'authoritative',
+      });
+      const success = result.responseCode === DNS_RCODE.NOERROR;
+      const response: DNSQueryResult = {
         query,
         vantage,
-        success: true,
-        responseCode: DNS_RCODE.NOERROR,
-        flags: { ...UNIFORM_FLAGS },
-        answers: performed.answers,
-        authority: performed.authority ?? [],
-        additional: performed.additional ?? [],
+        success,
+        responseCode: result.responseCode,
+        flags: result.flags,
+        answers: result.answers,
+        authority: result.authority,
+        additional: result.additional,
         responseTime: Date.now() - startTime,
       };
+
+      if (!success) {
+        response.error = `DNS query failed with rcode ${result.responseCode}`;
+      }
+      return response;
     } catch (error) {
       return this.errorResult(query, vantage, error, Date.now() - startTime);
     }
   }
 
-  /**
-   * Resolve MX/TXT/NS/CNAME/SOA/CAA via dns-packet, capturing the real answer
-   * TTL and mapping the wire rcode to success/responseCode.
-   */
-  private async queryViaDnsPacket(
-    query: DNSQuery,
-    vantage: VantageInfo,
-    startTime: number
-  ): Promise<DNSQueryResult> {
-    const result = await queryWithDnsPacket(query, vantage.identifier);
-    const success = result.responseCode === DNS_RCODE.NOERROR;
-    const base: DNSQueryResult = {
-      query,
-      vantage,
-      success,
-      responseCode: result.responseCode,
-      flags: { ...UNIFORM_FLAGS },
-      answers: result.answers,
-      authority: result.authority,
-      additional: result.additional,
-      responseTime: Date.now() - startTime,
-    };
-    if (!success) {
-      base.error = `DNS query failed with rcode ${result.responseCode}`;
-    }
-    return base;
-  }
-
-  /**
-   * Resolve via Node.js dns (A/AAAA). Throws for unsupported types.
-   */
-  private async performNodeQuery(
-    resolver: Resolver,
-    query: DNSQuery
-  ): Promise<{ answers: DNSAnswer[]; authority?: DNSAnswer[]; additional?: DNSAnswer[] }> {
-    switch (query.type) {
-      case 'A':
-        return this.queryA(resolver, query.name);
-      case 'AAAA':
-        return this.queryAAAA(resolver, query.name);
-      default:
-        throw new Error(`Unsupported record type: ${query.type}`);
-    }
-  }
-
-  private async queryA(resolver: Resolver, name: string): Promise<{ answers: DNSAnswer[] }> {
-    const records = await resolver.resolve4(name, { ttl: true });
-    return {
-      answers: records.map((rec) => ({ name, type: 'A', ttl: rec.ttl, data: rec.address })),
-    };
-  }
-
-  private async queryAAAA(resolver: Resolver, name: string): Promise<{ answers: DNSAnswer[] }> {
-    const records = await resolver.resolve6(name, { ttl: true });
-    return {
-      answers: records.map((rec) => ({ name, type: 'AAAA', ttl: rec.ttl, data: rec.address })),
-    };
-  }
-
-  /**
-   * Build a failure result, mapping the Node error message to an RCODE.
-   */
+  /** Build a failure result while preserving the query's recursion policy. */
   private errorResult(
     query: DNSQuery,
     vantage: VantageInfo,
@@ -147,12 +61,6 @@ export class DNSResolver {
       responseCode = DNS_RCODE.NXDOMAIN;
     } else if (errorMessage.includes('ECONNREFUSED') || errorMessage.includes('REFUSED')) {
       responseCode = DNS_RCODE.REFUSED;
-    } else if (
-      errorMessage.includes('timeout') ||
-      errorMessage.includes('ETIMEDOUT') ||
-      errorMessage.includes('timed out')
-    ) {
-      responseCode = DNS_RCODE.SERVFAIL; // No specific timeout RCODE; use SERVFAIL
     }
 
     return {
@@ -160,7 +68,14 @@ export class DNSResolver {
       vantage,
       success: false,
       responseCode,
-      flags: { aa: false, tc: false, rd: true, ra: false, ad: false, cd: false },
+      flags: {
+        aa: false,
+        tc: false,
+        rd: vantage.type !== 'authoritative',
+        ra: false,
+        ad: false,
+        cd: false,
+      },
       answers: [],
       authority: [],
       additional: [],

--- a/apps/collector/src/jobs/alert-delivery.integration.test.ts
+++ b/apps/collector/src/jobs/alert-delivery.integration.test.ts
@@ -246,7 +246,7 @@ describe('Alert Delivery Integration', () => {
     const finding: MockFinding = {
       id: overrides.id || `finding-${Math.random().toString(36).slice(2)}`,
       snapshotId: SNAPSHOT_ID,
-      type: 'mail.no-spf-record',
+      type: 'mail.no-dmarc-record',
       severity: overrides.severity || 'high',
       title: overrides.title || 'Missing SPF Record',
       description: 'Domain has no SPF record',

--- a/apps/collector/src/jobs/alert-from-findings.test.ts
+++ b/apps/collector/src/jobs/alert-from-findings.test.ts
@@ -192,12 +192,13 @@ describe('generateAlertsFromFindings', () => {
       severity?: 'critical' | 'high' | 'medium' | 'low' | 'info';
       reviewOnly?: boolean;
       title?: string;
+      type?: string;
     } = {}
   ) {
     return {
       id: overrides.id || `finding-${Math.random().toString(36).slice(2)}`,
       snapshotId: SNAPSHOT_ID,
-      type: 'mail.no-spf-record',
+      type: overrides.type || 'monitoring.collection-failed',
       severity: overrides.severity || 'high',
       title: overrides.title || 'Missing SPF Record',
       description: 'Domain has no SPF record',
@@ -211,6 +212,35 @@ describe('generateAlertsFromFindings', () => {
   // =============================================================================
 
   describe('Basic functionality', () => {
+    it('does not create direct alerts for unclassified conditions', async () => {
+      const { generateAlertsFromFindings } = await import('./alert-from-findings.js');
+      mockData.monitoredDomains.push({
+        id: MONITORED_DOMAIN_ID,
+        domainId: DOMAIN_ID,
+        tenantId: TENANT_ID,
+      });
+      mockData.findings.push(createMockFinding({ type: 'unclassified.condition' }));
+
+      const results = await generateAlertsFromFindings(mockDb, SNAPSHOT_ID, TENANT_ID, DOMAIN_ID);
+
+      expect(results).toEqual([]);
+      expect(mockData.alerts).toEqual([]);
+    });
+
+    it('retains explicitly legacy mail alerts until canonical regression evaluation is wired', async () => {
+      const { generateAlertsFromFindings } = await import('./alert-from-findings.js');
+      mockData.monitoredDomains.push({
+        id: MONITORED_DOMAIN_ID,
+        domainId: DOMAIN_ID,
+        tenantId: TENANT_ID,
+      });
+      mockData.findings.push(createMockFinding({ type: 'mail.no-spf-record' }));
+
+      const results = await generateAlertsFromFindings(mockDb, SNAPSHOT_ID, TENANT_ID, DOMAIN_ID);
+
+      expect(results).toHaveLength(1);
+    });
+
     it('should generate alerts for high severity findings', async () => {
       const { generateAlertsFromFindings } = await import('./alert-from-findings.js');
 

--- a/apps/collector/src/jobs/alert-from-findings.test.ts
+++ b/apps/collector/src/jobs/alert-from-findings.test.ts
@@ -227,7 +227,7 @@ describe('generateAlertsFromFindings', () => {
       expect(mockData.alerts).toEqual([]);
     });
 
-    it('retains explicitly legacy mail alerts until canonical regression evaluation is wired', async () => {
+    it('excludes migrated SPF absence from direct legacy alerts', async () => {
       const { generateAlertsFromFindings } = await import('./alert-from-findings.js');
       mockData.monitoredDomains.push({
         id: MONITORED_DOMAIN_ID,
@@ -235,6 +235,21 @@ describe('generateAlertsFromFindings', () => {
         tenantId: TENANT_ID,
       });
       mockData.findings.push(createMockFinding({ type: 'mail.no-spf-record' }));
+
+      const results = await generateAlertsFromFindings(mockDb, SNAPSHOT_ID, TENANT_ID, DOMAIN_ID);
+
+      expect(results).toEqual([]);
+      expect(mockData.alerts).toEqual([]);
+    });
+
+    it('retains direct alerts for unmigrated mail findings', async () => {
+      const { generateAlertsFromFindings } = await import('./alert-from-findings.js');
+      mockData.monitoredDomains.push({
+        id: MONITORED_DOMAIN_ID,
+        domainId: DOMAIN_ID,
+        tenantId: TENANT_ID,
+      });
+      mockData.findings.push(createMockFinding({ type: 'mail.no-dmarc-record' }));
 
       const results = await generateAlertsFromFindings(mockDb, SNAPSHOT_ID, TENANT_ID, DOMAIN_ID);
 

--- a/apps/collector/src/jobs/alert-from-findings.ts
+++ b/apps/collector/src/jobs/alert-from-findings.ts
@@ -9,6 +9,7 @@ import { AlertRepository, FindingRepository, MonitoredDomainRepository } from '@
 import { createLogger } from '@dns-ops/logging';
 import { sendAlertNotification } from '../notifications/webhook.js';
 import type { Env } from '../types.js';
+import { legacyConditionDisposition } from './condition-registry.js';
 
 const logger = createLogger({
   service: 'dns-ops-collector',
@@ -94,6 +95,8 @@ export async function generateAlertsFromFindings(
   const alertableFindings = findings
     .filter((f) => {
       if (skipReviewOnly && f.reviewOnly) return false;
+      // Migrated conditions can notify only through the canonical signal path.
+      if (legacyConditionDisposition(f.type).notificationPath !== 'LEGACY_ALERT') return false;
       return severityPriority[f.severity] <= minPriority;
     })
     .sort((a, b) => severityPriority[a.severity] - severityPriority[b.severity])

--- a/apps/collector/src/jobs/collect-domain.ts
+++ b/apps/collector/src/jobs/collect-domain.ts
@@ -49,6 +49,7 @@ import {
   trackCollectionError,
   trackCollectionResult,
 } from '../middleware/error-tracking.js';
+import { collectAndPersistDomainEvidence } from '../probes/domain-evidence.js';
 import type { Env } from '../types.js';
 
 const logger = getCollectorLogger();
@@ -166,6 +167,23 @@ collectDomainRoutes.post('/domain', async (c) => {
     // Run collection
     const collector = new DNSCollector(config, db);
     const result = await collector.collect();
+
+    const collectedDomain = await domainRepo.findByNameForTenant(normalizedDomain, tenantId);
+    if (collectedDomain) {
+      try {
+        await collectAndPersistDomainEvidence(db, {
+          snapshotId: result.snapshotId,
+          tenantId,
+          domainId: collectedDomain.id,
+          domain: collectedDomain.normalizedName,
+        });
+      } catch (evidenceError) {
+        logger.warn('External evidence collection failed (non-fatal)', {
+          snapshotId: result.snapshotId,
+          error: evidenceError instanceof Error ? evidenceError.message : String(evidenceError),
+        });
+      }
+    }
 
     trackCollectionResult({
       domain: normalizedDomain,

--- a/apps/collector/src/jobs/collect-domain.ts
+++ b/apps/collector/src/jobs/collect-domain.ts
@@ -51,6 +51,7 @@ import {
 } from '../middleware/error-tracking.js';
 import { collectAndPersistDomainEvidence } from '../probes/domain-evidence.js';
 import type { Env } from '../types.js';
+import { finalizePersistedCanonicalConditions } from './operational-condition-finalizer.js';
 
 const logger = getCollectorLogger();
 
@@ -181,6 +182,22 @@ collectDomainRoutes.post('/domain', async (c) => {
         logger.warn('External evidence collection failed (non-fatal)', {
           snapshotId: result.snapshotId,
           error: evidenceError instanceof Error ? evidenceError.message : String(evidenceError),
+        });
+      }
+      try {
+        await finalizePersistedCanonicalConditions(db, {
+          snapshotId: result.snapshotId,
+          tenantId,
+          domainId: collectedDomain.id,
+          domainName: collectedDomain.normalizedName,
+        });
+      } catch (finalizationError) {
+        logger.warn('Canonical condition finalization failed (non-fatal)', {
+          snapshotId: result.snapshotId,
+          error:
+            finalizationError instanceof Error
+              ? finalizationError.message
+              : String(finalizationError),
         });
       }
     }

--- a/apps/collector/src/jobs/collect-mail.ts
+++ b/apps/collector/src/jobs/collect-mail.ts
@@ -615,21 +615,21 @@ async function storeMailEvidence(
     score += 15;
   }
 
-  // SPF: 20 points
-  if (result.spf.present && result.spf.valid) {
-    scoreBreakdown.spf = 20;
-    score += 20;
-  } else if (result.spf.present) {
+  // SPF recursive evaluation is intentionally incomplete in Phase 0–1, so
+  // presence can receive partial credit but never a full-validity score.
+  if (result.spf.present) {
     scoreBreakdown.spf = 10;
     score += 10;
   }
 
-  // DMARC: 25 points (full for reject, less for quarantine/none)
+  // DMARC: score only the RFC 9989 effective policy, never an inherited
+  // record's raw p tag when sp/np applicability is unresolved.
+  const effectiveDmarcPolicy = result.dmarc.dmarcDiscovery?.effectivePolicy;
   if (result.dmarc.present && result.dmarc.valid) {
-    if (dmarcPolicy === 'reject') {
+    if (effectiveDmarcPolicy === 'reject') {
       scoreBreakdown.dmarc = 25;
       score += 25;
-    } else if (dmarcPolicy === 'quarantine') {
+    } else if (effectiveDmarcPolicy === 'quarantine') {
       scoreBreakdown.dmarc = 20;
       score += 20;
     } else {

--- a/apps/collector/src/jobs/condition-registry.test.ts
+++ b/apps/collector/src/jobs/condition-registry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { legacyConditionDisposition } from './condition-registry.js';
+
+describe('legacy condition registry', () => {
+  it('keeps mail findings explicitly legacy until production signal evaluation is wired', () => {
+    expect(legacyConditionDisposition('mail.no-dmarc-record')).toMatchObject({
+      disposition: 'LEGACY_ONLY',
+      notificationPath: 'LEGACY_ALERT',
+    });
+  });
+
+  it('keeps explicitly unmigrated conditions on the legacy path', () => {
+    expect(legacyConditionDisposition('monitoring.collection-failed')).toMatchObject({
+      disposition: 'LEGACY_ONLY',
+      notificationPath: 'LEGACY_ALERT',
+    });
+  });
+
+  it('disables unclassified conditions rather than implicitly notifying', () => {
+    expect(legacyConditionDisposition('unknown.condition')).toMatchObject({
+      disposition: 'DISABLED',
+      notificationPath: 'NONE',
+    });
+  });
+});

--- a/apps/collector/src/jobs/condition-registry.test.ts
+++ b/apps/collector/src/jobs/condition-registry.test.ts
@@ -2,10 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { legacyConditionDisposition } from './condition-registry.js';
 
 describe('legacy condition registry', () => {
-  it('keeps mail findings explicitly legacy until production signal evaluation is wired', () => {
+  it('keeps unmigrated mail findings explicitly legacy', () => {
     expect(legacyConditionDisposition('mail.no-dmarc-record')).toMatchObject({
       disposition: 'LEGACY_ONLY',
       notificationPath: 'LEGACY_ALERT',
+    });
+  });
+
+  it('migrates SPF absence exclusively to the canonical signal path', () => {
+    expect(legacyConditionDisposition('mail.no-spf-record')).toMatchObject({
+      disposition: 'MIGRATED',
+      replacementSignalKind: 'MAIL_DNS_CONFIGURATION_REGRESSION',
+      notificationPath: 'SIGNAL_ALERT',
     });
   });
 

--- a/apps/collector/src/jobs/condition-registry.ts
+++ b/apps/collector/src/jobs/condition-registry.ts
@@ -11,11 +11,19 @@ const MAIL_REGRESSION_FINDINGS = [
 ] as const;
 
 export const LEGACY_CONDITION_REGISTRY: readonly LegacyConditionMapEntry[] = [
-  ...MAIL_REGRESSION_FINDINGS.map((conditionId) => ({
-    conditionId,
-    disposition: 'LEGACY_ONLY' as const,
-    notificationPath: 'LEGACY_ALERT' as const,
-  })),
+  {
+    conditionId: 'mail.no-spf-record',
+    disposition: 'MIGRATED',
+    replacementSignalKind: 'MAIL_DNS_CONFIGURATION_REGRESSION',
+    notificationPath: 'SIGNAL_ALERT',
+  },
+  ...MAIL_REGRESSION_FINDINGS.filter((conditionId) => conditionId !== 'mail.no-spf-record').map(
+    (conditionId) => ({
+      conditionId,
+      disposition: 'LEGACY_ONLY' as const,
+      notificationPath: 'LEGACY_ALERT' as const,
+    })
+  ),
   {
     conditionId: 'monitoring.collection-failed',
     disposition: 'LEGACY_ONLY',

--- a/apps/collector/src/jobs/condition-registry.ts
+++ b/apps/collector/src/jobs/condition-registry.ts
@@ -1,0 +1,34 @@
+import type { LegacyConditionMapEntry } from '@dns-ops/contracts';
+
+const MAIL_REGRESSION_FINDINGS = [
+  'mail.no-mx-record',
+  'mail.no-spf-record',
+  'mail.spf-malformed',
+  'mail.no-dmarc-record',
+  'mail.dmarc-malformed',
+  'mail.no-dkim-queried',
+  'mail.dkim-no-valid-keys',
+] as const;
+
+export const LEGACY_CONDITION_REGISTRY: readonly LegacyConditionMapEntry[] = [
+  ...MAIL_REGRESSION_FINDINGS.map((conditionId) => ({
+    conditionId,
+    disposition: 'LEGACY_ONLY' as const,
+    notificationPath: 'LEGACY_ALERT' as const,
+  })),
+  {
+    conditionId: 'monitoring.collection-failed',
+    disposition: 'LEGACY_ONLY',
+    notificationPath: 'LEGACY_ALERT',
+  },
+];
+
+export function legacyConditionDisposition(conditionId: string): LegacyConditionMapEntry {
+  return (
+    LEGACY_CONDITION_REGISTRY.find((entry) => entry.conditionId === conditionId) ?? {
+      conditionId,
+      disposition: 'DISABLED',
+      notificationPath: 'NONE',
+    }
+  );
+}

--- a/apps/collector/src/jobs/monitoring.integration.test.ts
+++ b/apps/collector/src/jobs/monitoring.integration.test.ts
@@ -230,6 +230,7 @@ function makeDomain(overrides: Partial<MockDomain> = {}): MockDomain {
   return {
     id: 'dom-1',
     name: 'example.com',
+    tenantId: NORMALIZED_TENANT_ID,
     ...overrides,
   };
 }
@@ -583,6 +584,16 @@ describe('Monitoring Routes Tenant Isolation', () => {
       const checkedDomains = json.results.map((r: { domainId: string }) => r.domainId);
       expect(checkedDomains).toContain('dom-us');
       expect(checkedDomains).not.toContain('dom-other');
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/collect/domain'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Internal-Secret': 'test-internal-secret',
+            'X-Tenant-Id': NORMALIZED_TENANT_ID,
+            'X-Actor-Id': 'monitoring-scheduler',
+          }),
+        })
+      );
     });
 
     it('DELETE /domains/:id/monitor should reject deletion of other tenant domain', async () => {

--- a/apps/collector/src/jobs/monitoring.ts
+++ b/apps/collector/src/jobs/monitoring.ts
@@ -75,11 +75,28 @@ monitoringRoutes.post('/check', internalOnlyMiddleware, async (c) => {
         continue;
       }
 
-      // Trigger collection via collector service
+      if (!monitored.tenantId || domain.tenantId !== monitored.tenantId) {
+        monitoringLogger.error(`Monitored domain tenant ownership mismatch: ${monitored.id}`);
+        continue;
+      }
+      const internalSecret = process.env.INTERNAL_SECRET;
+      if (!internalSecret) {
+        monitoringLogger.error(
+          'Monitoring collection is blocked: INTERNAL_SECRET is not configured'
+        );
+        continue;
+      }
+
+      // Trigger collection through the same authenticated service boundary as the web app.
       const collectorUrl = process.env.COLLECTOR_URL || 'http://localhost:3001';
       const response = await fetch(`${collectorUrl}/api/collect/domain`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Internal-Secret': internalSecret,
+          'X-Tenant-Id': monitored.tenantId,
+          'X-Actor-Id': 'monitoring-scheduler',
+        },
         body: JSON.stringify({
           domain: domain.name,
           triggeredBy: 'monitoring-scheduler',

--- a/apps/collector/src/jobs/operational-condition-evaluation.test.ts
+++ b/apps/collector/src/jobs/operational-condition-evaluation.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateOperationalConditions } from './operational-condition-evaluation.js';
+
+const now = new Date('2026-07-28T12:00:00.000Z');
+const tlsBaseline = {
+  tenantId: 'tenant-1',
+  domainId: 'domain-1',
+  kind: 'TLS_CERTIFICATE_REGRESSION' as const,
+  discriminator: 'www.example.com:443',
+  maxEvidenceAgeSeconds: 300,
+  policy: {
+    kind: 'TLS_CERTIFICATE' as const,
+    requireHostnameAuthorized: true,
+    requireChainAuthorized: true,
+    minimumRemainingValiditySeconds: 86_400,
+  },
+};
+const tlsProbe = (probedAt = now, overrides = {}) => ({
+  success: true,
+  probedAt,
+  probeData: {
+    check: 'TLS_CERTIFICATE' as const,
+    status: 'OBSERVED' as const,
+    evidence: {
+      kind: 'TLS_CERTIFICATE' as const,
+      hostname: 'www.example.com',
+      port: 443,
+      hostnameAuthorized: true,
+      chainAuthorized: true,
+      validTo: '2026-08-01T12:00:00.000Z',
+      ...overrides,
+    },
+  },
+});
+
+describe('evaluateOperationalConditions', () => {
+  it('classifies stale TLS evidence as setup/evidence and emits no signal', () => {
+    const result = evaluateOperationalConditions({
+      tenantId: 'tenant-1',
+      domainId: 'domain-1',
+      snapshotComplete: true,
+      baselines: [tlsBaseline],
+      probes: [tlsProbe(new Date(now.getTime() - 301_000))],
+      findings: [],
+      now,
+    });
+    expect(result).toEqual({
+      observations: [],
+      setupEvidence: [
+        {
+          kind: 'TLS_CERTIFICATE_REGRESSION',
+          discriminator: 'www.example.com:443',
+          status: 'EVIDENCE_STALE',
+          action: 'RUN_FRESH_SCAN',
+        },
+      ],
+    });
+  });
+
+  it('emits one stable signal observation for a fresh TLS policy violation', () => {
+    const result = evaluateOperationalConditions({
+      tenantId: 'tenant-1',
+      domainId: 'domain-1',
+      snapshotComplete: true,
+      baselines: [tlsBaseline],
+      probes: [tlsProbe(now, { hostnameAuthorized: false })],
+      findings: [],
+      now,
+    });
+    expect(result.setupEvidence).toEqual([]);
+    expect(result.observations).toMatchObject([
+      {
+        kind: 'TLS_CERTIFICATE_REGRESSION',
+        discriminator: 'www.example.com:443',
+        conditionKey: 'tenant-1:domain-1:TLS_CERTIFICATE_REGRESSION:www.example.com:443',
+        evidence: { hostnameAuthorized: false },
+      },
+    ]);
+  });
+
+  it('only migrates non-review-only no-SPF findings with an explicit SPF baseline', () => {
+    const baseline = {
+      tenantId: 'tenant-1',
+      domainId: 'domain-1',
+      kind: 'MAIL_DNS_CONFIGURATION_REGRESSION' as const,
+      discriminator: 'spf',
+      maxEvidenceAgeSeconds: 3600,
+      policy: { kind: 'SPF_PRESENT' as const },
+    };
+    const result = evaluateOperationalConditions({
+      tenantId: 'tenant-1',
+      domainId: 'domain-1',
+      snapshotComplete: true,
+      baselines: [baseline],
+      probes: [],
+      findings: [
+        { id: 'finding-1', type: 'mail.no-spf-record', reviewOnly: false },
+        { id: 'finding-2', type: 'mail.no-spf-record', reviewOnly: true },
+      ],
+      now,
+    });
+    expect(result.observations).toMatchObject([
+      {
+        kind: 'MAIL_DNS_CONFIGURATION_REGRESSION',
+        discriminator: 'spf',
+        evidence: { findingId: 'finding-1' },
+      },
+    ]);
+  });
+
+  it('does not infer baselines or make incomplete/unknown evidence operational', () => {
+    const noBaseline = evaluateOperationalConditions({
+      tenantId: 'tenant-1',
+      domainId: 'domain-1',
+      snapshotComplete: true,
+      baselines: [],
+      probes: [tlsProbe(now, { hostnameAuthorized: false })],
+      findings: [],
+      now,
+    });
+    const incomplete = evaluateOperationalConditions({
+      tenantId: 'tenant-1',
+      domainId: 'domain-1',
+      snapshotComplete: false,
+      baselines: [tlsBaseline],
+      probes: [tlsProbe(now, { hostnameAuthorized: false })],
+      findings: [],
+      now,
+    });
+    const unknown = evaluateOperationalConditions({
+      tenantId: 'tenant-1',
+      domainId: 'domain-1',
+      snapshotComplete: true,
+      baselines: [tlsBaseline],
+      probes: [
+        {
+          success: false,
+          probedAt: now,
+          probeData: { check: 'TLS_CERTIFICATE', status: 'UNKNOWN' },
+        },
+      ],
+      findings: [],
+      now,
+    });
+    expect(noBaseline.observations).toEqual([]);
+    expect(incomplete).toEqual({ observations: [], setupEvidence: [] });
+    expect(unknown.observations).toEqual([]);
+    expect(unknown.setupEvidence[0]?.status).toBe('EVIDENCE_UNAVAILABLE');
+  });
+});

--- a/apps/collector/src/jobs/operational-condition-evaluation.ts
+++ b/apps/collector/src/jobs/operational-condition-evaluation.ts
@@ -1,0 +1,179 @@
+import {
+  type InternalSignalKind,
+  internalConditionKey,
+  normalizeOperationalDiscriminator,
+  type OperationalConditionBaselinePolicy,
+} from '@dns-ops/contracts';
+
+export interface PersistedConditionBaseline {
+  tenantId: string;
+  domainId: string;
+  kind: InternalSignalKind;
+  discriminator: string;
+  policy: OperationalConditionBaselinePolicy;
+  maxEvidenceAgeSeconds: number;
+}
+
+export interface PersistedConditionProbe {
+  success: boolean;
+  probedAt: Date;
+  probeData: unknown;
+}
+
+export interface PersistedConditionFinding {
+  id: string;
+  type: string;
+  reviewOnly: boolean;
+}
+
+export interface CanonicalConditionObservation {
+  kind: InternalSignalKind;
+  discriminator: string;
+  conditionKey: string;
+  evidence: Record<string, unknown>;
+}
+
+export interface SetupEvidenceResult {
+  kind: InternalSignalKind;
+  discriminator: string;
+  status: 'MISSING_BASELINE' | 'EVIDENCE_STALE' | 'EVIDENCE_UNAVAILABLE';
+  action: 'ACCEPT_BASELINE' | 'RUN_FRESH_SCAN';
+}
+
+export interface ConditionEvaluation {
+  observations: CanonicalConditionObservation[];
+  setupEvidence: SetupEvidenceResult[];
+}
+
+interface TlsProbeData {
+  check: 'TLS_CERTIFICATE';
+  status: 'OBSERVED' | 'UNKNOWN';
+  evidence: {
+    kind: 'TLS_CERTIFICATE';
+    hostname: string;
+    port: number;
+    hostnameAuthorized: boolean;
+    chainAuthorized: boolean;
+    validTo: string;
+  };
+}
+
+function isTlsProbeData(value: unknown): value is TlsProbeData {
+  if (!value || typeof value !== 'object') return false;
+  const data = value as Partial<TlsProbeData>;
+  return (
+    data.check === 'TLS_CERTIFICATE' &&
+    data.status === 'OBSERVED' &&
+    !!data.evidence &&
+    data.evidence.kind === 'TLS_CERTIFICATE'
+  );
+}
+
+function setup(
+  kind: InternalSignalKind,
+  discriminator: string,
+  status: SetupEvidenceResult['status']
+): SetupEvidenceResult {
+  return {
+    kind,
+    discriminator,
+    status,
+    action: status === 'MISSING_BASELINE' ? 'ACCEPT_BASELINE' : 'RUN_FRESH_SCAN',
+  };
+}
+
+/**
+ * Converts already-persisted, complete collection results into canonical observations.
+ * It intentionally has no network, persistence, or notification dependency.
+ */
+export function evaluateOperationalConditions(input: {
+  tenantId: string;
+  domainId: string;
+  snapshotComplete: boolean;
+  baselines: PersistedConditionBaseline[];
+  probes: PersistedConditionProbe[];
+  findings: PersistedConditionFinding[];
+  now: Date;
+}): ConditionEvaluation {
+  const result: ConditionEvaluation = { observations: [], setupEvidence: [] };
+  if (!input.snapshotComplete) return result;
+
+  for (const baseline of input.baselines) {
+    const discriminator = normalizeOperationalDiscriminator(baseline.discriminator);
+    if (baseline.kind === 'TLS_CERTIFICATE_REGRESSION') {
+      const probe = input.probes.find((candidate) => {
+        if (!candidate.success || !isTlsProbeData(candidate.probeData)) return false;
+        return (
+          normalizeOperationalDiscriminator(
+            `${candidate.probeData.evidence.hostname}:${candidate.probeData.evidence.port}`
+          ) === discriminator
+        );
+      });
+      if (!probe) {
+        result.setupEvidence.push(setup(baseline.kind, discriminator, 'EVIDENCE_UNAVAILABLE'));
+        continue;
+      }
+      if (input.now.getTime() - probe.probedAt.getTime() > baseline.maxEvidenceAgeSeconds * 1000) {
+        result.setupEvidence.push(setup(baseline.kind, discriminator, 'EVIDENCE_STALE'));
+        continue;
+      }
+      const evidence = (probe.probeData as TlsProbeData).evidence;
+      const policy = baseline.policy;
+      if (policy.kind !== 'TLS_CERTIFICATE') {
+        result.setupEvidence.push(setup(baseline.kind, discriminator, 'EVIDENCE_UNAVAILABLE'));
+        continue;
+      }
+      const insufficientValidity =
+        Date.parse(evidence.validTo) - input.now.getTime() <
+        policy.minimumRemainingValiditySeconds * 1000;
+      if (
+        (policy.requireHostnameAuthorized && !evidence.hostnameAuthorized) ||
+        (policy.requireChainAuthorized && !evidence.chainAuthorized) ||
+        insufficientValidity
+      ) {
+        result.observations.push({
+          kind: baseline.kind,
+          discriminator,
+          conditionKey: internalConditionKey(
+            input.tenantId,
+            input.domainId,
+            baseline.kind,
+            discriminator
+          ),
+          evidence: {
+            probeKind: 'TLS_CERTIFICATE',
+            probedAt: probe.probedAt.toISOString(),
+            hostnameAuthorized: evidence.hostnameAuthorized,
+            chainAuthorized: evidence.chainAuthorized,
+            validTo: evidence.validTo,
+          },
+        });
+      }
+      continue;
+    }
+
+    if (baseline.kind === 'MAIL_DNS_CONFIGURATION_REGRESSION') {
+      if (baseline.policy.kind !== 'SPF_PRESENT' || discriminator !== 'spf') {
+        result.setupEvidence.push(setup(baseline.kind, discriminator, 'EVIDENCE_UNAVAILABLE'));
+        continue;
+      }
+      const finding = input.findings.find(
+        (candidate) => candidate.type === 'mail.no-spf-record' && !candidate.reviewOnly
+      );
+      if (finding) {
+        result.observations.push({
+          kind: baseline.kind,
+          discriminator,
+          conditionKey: internalConditionKey(
+            input.tenantId,
+            input.domainId,
+            baseline.kind,
+            discriminator
+          ),
+          evidence: { findingId: finding.id, findingType: finding.type },
+        });
+      }
+    }
+  }
+  return result;
+}

--- a/apps/collector/src/jobs/operational-condition-finalizer.test.ts
+++ b/apps/collector/src/jobs/operational-condition-finalizer.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import { finalizeCanonicalConditions } from './operational-condition-finalizer.js';
+
+const now = new Date('2026-07-28T12:00:00.000Z');
+const baseline = {
+  tenantId: 'tenant-1',
+  domainId: 'domain-1',
+  kind: 'MAIL_DNS_CONFIGURATION_REGRESSION' as const,
+  discriminator: 'spf',
+  maxEvidenceAgeSeconds: 3600,
+  policy: { kind: 'SPF_PRESENT' as const },
+};
+
+function input() {
+  return {
+    tenantId: 'tenant-1',
+    domainId: 'domain-1',
+    domainName: 'example.com',
+    snapshotId: 'snapshot-1',
+    snapshotComplete: true,
+    monitoredDomainId: 'monitor-1',
+    webhookUrl: 'https://hooks.example.test/alerts',
+    baselines: [baseline],
+    probes: [],
+    findings: [{ id: 'finding-1', type: 'mail.no-spf-record', reviewOnly: false }],
+    now,
+  };
+}
+
+describe('finalizeCanonicalConditions', () => {
+  it('sends only newly-created or reopened canonical alerts', async () => {
+    const send = vi.fn().mockResolvedValue({ success: true });
+    const alert = {
+      id: 'alert-1',
+      title: 'Mail DNS configuration regression',
+      description: 'x',
+      severity: 'high' as const,
+    };
+    const observer = {
+      observe: vi
+        .fn()
+        .mockResolvedValueOnce({ created: { alert: true }, reopened: { alert: false }, alert })
+        .mockResolvedValueOnce({ created: { alert: false }, reopened: { alert: false }, alert })
+        .mockResolvedValueOnce({
+          created: { alert: false },
+          reopened: { alert: true },
+          alert: { ...alert, id: 'alert-2' },
+        }),
+    };
+    await finalizeCanonicalConditions(input(), { observer, send });
+    await finalizeCanonicalConditions(input(), { observer, send });
+    await finalizeCanonicalConditions(input(), { observer, send });
+    expect(observer.observe).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenNthCalledWith(1, 'alert-1', 'https://hooks.example.test/alerts', alert);
+    expect(send).toHaveBeenNthCalledWith(2, 'alert-2', 'https://hooks.example.test/alerts', {
+      ...alert,
+      id: 'alert-2',
+    });
+  });
+
+  it('does not send stale TLS evidence', async () => {
+    const send = vi.fn();
+    const observer = { observe: vi.fn() };
+    const stale = {
+      ...input(),
+      baselines: [
+        {
+          tenantId: 'tenant-1',
+          domainId: 'domain-1',
+          kind: 'TLS_CERTIFICATE_REGRESSION' as const,
+          discriminator: 'www.example.com:443',
+          maxEvidenceAgeSeconds: 1,
+          policy: {
+            kind: 'TLS_CERTIFICATE' as const,
+            requireHostnameAuthorized: true,
+            requireChainAuthorized: true,
+            minimumRemainingValiditySeconds: 0,
+          },
+        },
+      ],
+      findings: [],
+      probes: [
+        {
+          success: true,
+          probedAt: new Date(now.getTime() - 2000),
+          probeData: {
+            check: 'TLS_CERTIFICATE' as const,
+            status: 'OBSERVED' as const,
+            evidence: {
+              kind: 'TLS_CERTIFICATE' as const,
+              hostname: 'www.example.com',
+              port: 443,
+              hostnameAuthorized: false,
+              chainAuthorized: true,
+              validTo: '2027-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      ],
+    };
+    const result = await finalizeCanonicalConditions(stale, { observer, send });
+    expect(result.evaluation.setupEvidence).toMatchObject([{ status: 'EVIDENCE_STALE' }]);
+    expect(observer.observe).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/collector/src/jobs/operational-condition-finalizer.ts
+++ b/apps/collector/src/jobs/operational-condition-finalizer.ts
@@ -1,0 +1,106 @@
+import type { InternalSignalKind } from '@dns-ops/contracts';
+import {
+  evaluateOperationalConditions,
+  type PersistedConditionBaseline,
+  type PersistedConditionFinding,
+  type PersistedConditionProbe,
+} from './operational-condition-evaluation.js';
+
+export interface CanonicalConditionOutcome {
+  created: { alert: boolean };
+  reopened: { alert: boolean };
+  alert: {
+    id: string;
+    title: string;
+    description: string;
+    severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
+  };
+}
+
+export interface CanonicalConditionObserver {
+  observe(input: {
+    tenantId: string;
+    domainId: string;
+    snapshotId: string;
+    kind: InternalSignalKind;
+    discriminator: string;
+    monitoredDomainId: string;
+    title: string;
+    description: string;
+    severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
+    triggeredByFindingId?: string;
+  }): Promise<CanonicalConditionOutcome>;
+}
+
+function presentation(
+  kind: InternalSignalKind
+): Pick<CanonicalConditionOutcome['alert'], 'title' | 'description' | 'severity'> {
+  switch (kind) {
+    case 'TLS_CERTIFICATE_REGRESSION':
+      return {
+        title: 'TLS certificate regression',
+        description: 'Fresh TLS evidence violates the accepted operational baseline.',
+        severity: 'high',
+      };
+    case 'MAIL_DNS_CONFIGURATION_REGRESSION':
+      return {
+        title: 'Mail DNS configuration regression',
+        description: 'A baseline-required SPF record is missing from the completed scan.',
+        severity: 'high',
+      };
+    default:
+      throw new Error(`Unsupported canonical finalizer signal: ${kind}`);
+  }
+}
+
+/**
+ * The sole canonical notification boundary. Evaluator output never sends directly;
+ * only a newly-created or reopened canonical alert is delivered.
+ */
+export async function finalizeCanonicalConditions(
+  input: {
+    tenantId: string;
+    domainId: string;
+    domainName: string;
+    snapshotId: string;
+    snapshotComplete: boolean;
+    monitoredDomainId: string;
+    webhookUrl?: string;
+    baselines: PersistedConditionBaseline[];
+    probes: PersistedConditionProbe[];
+    findings: PersistedConditionFinding[];
+    now: Date;
+  },
+  dependencies: {
+    observer: CanonicalConditionObserver;
+    send: (
+      alertId: string,
+      webhookUrl: string,
+      alert: CanonicalConditionOutcome['alert']
+    ) => Promise<unknown>;
+  }
+) {
+  const evaluation = evaluateOperationalConditions(input);
+  const outcomes: CanonicalConditionOutcome[] = [];
+  for (const observation of evaluation.observations) {
+    const view = presentation(observation.kind);
+    const outcome = await dependencies.observer.observe({
+      tenantId: input.tenantId,
+      domainId: input.domainId,
+      snapshotId: input.snapshotId,
+      kind: observation.kind,
+      discriminator: observation.discriminator,
+      monitoredDomainId: input.monitoredDomainId,
+      ...view,
+      triggeredByFindingId:
+        typeof observation.evidence.findingId === 'string'
+          ? observation.evidence.findingId
+          : undefined,
+    });
+    outcomes.push(outcome);
+    if (input.webhookUrl && (outcome.created.alert || outcome.reopened.alert)) {
+      await dependencies.send(outcome.alert.id, input.webhookUrl, outcome.alert);
+    }
+  }
+  return { evaluation, outcomes };
+}

--- a/apps/collector/src/jobs/operational-condition-finalizer.ts
+++ b/apps/collector/src/jobs/operational-condition-finalizer.ts
@@ -1,5 +1,15 @@
 import type { InternalSignalKind } from '@dns-ops/contracts';
 import {
+  FindingRepository,
+  type IDatabaseAdapter,
+  MonitoredDomainRepository,
+  OperationalBaselineRepository,
+  OperationalConditionService,
+  ProbeObservationRepository,
+  SnapshotRepository,
+} from '@dns-ops/db';
+import { sendAlertNotification } from '../notifications/webhook.js';
+import {
   evaluateOperationalConditions,
   type PersistedConditionBaseline,
   type PersistedConditionFinding,
@@ -57,6 +67,55 @@ function presentation(
  * The sole canonical notification boundary. Evaluator output never sends directly;
  * only a newly-created or reopened canonical alert is delivered.
  */
+export async function finalizePersistedCanonicalConditions(
+  db: IDatabaseAdapter,
+  input: { tenantId: string; domainId: string; domainName: string; snapshotId: string; now?: Date }
+) {
+  const snapshot = await new SnapshotRepository(db).findById(input.snapshotId);
+  if (!snapshot || snapshot.domainId !== input.domainId) {
+    throw new Error('Canonical finalization snapshot is outside the domain');
+  }
+  const monitored = await new MonitoredDomainRepository(db).findByDomainId(
+    input.domainId,
+    input.tenantId
+  );
+  if (!monitored || !monitored.isActive) {
+    return { evaluation: { observations: [], setupEvidence: [] }, outcomes: [] };
+  }
+  const [baselines, probes, snapshotFindings] = await Promise.all([
+    new OperationalBaselineRepository(db).listActive(input.tenantId, input.domainId),
+    new ProbeObservationRepository(db).findBySnapshotId(input.snapshotId),
+    new FindingRepository(db).findBySnapshotId(input.snapshotId),
+  ]);
+  const observer = new OperationalConditionService(db);
+  return finalizeCanonicalConditions(
+    {
+      tenantId: input.tenantId,
+      domainId: input.domainId,
+      domainName: input.domainName,
+      snapshotId: input.snapshotId,
+      snapshotComplete: snapshot.resultState === 'complete',
+      monitoredDomainId: monitored.id,
+      webhookUrl: monitored.alertChannels.webhook,
+      baselines,
+      probes,
+      findings: snapshotFindings,
+      now: input.now ?? new Date(),
+    },
+    {
+      observer,
+      send: (alertId, webhookUrl, alert) =>
+        sendAlertNotification(
+          alertId,
+          webhookUrl,
+          { ...alert, domain: input.domainName, tenantId: input.tenantId },
+          db,
+          process.env.WEB_APP_URL
+        ),
+    }
+  );
+}
+
 export async function finalizeCanonicalConditions(
   input: {
     tenantId: string;

--- a/apps/collector/src/jobs/worker.processors.test.ts
+++ b/apps/collector/src/jobs/worker.processors.test.ts
@@ -46,6 +46,10 @@ vi.mock('./alert-from-findings.js', () => ({
   generateAndSendFindingAlerts: vi.fn().mockResolvedValue({ alerts: [], webhookSent: false }),
 }));
 
+vi.mock('./operational-condition-finalizer.js', () => ({
+  finalizePersistedCanonicalConditions: vi.fn().mockResolvedValue({ outcomes: [] }),
+}));
+
 vi.mock('./queue.js', () => ({
   getRedisConnection: vi.fn().mockReturnValue({}),
   scheduleMonitoringJob: vi.fn().mockResolvedValue('job-123'),

--- a/apps/collector/src/jobs/worker.ts
+++ b/apps/collector/src/jobs/worker.ts
@@ -27,6 +27,7 @@ import {
   trackJobStart,
 } from '../middleware/error-tracking.js';
 import { getJobMetrics } from '../middleware/job-metrics.js';
+import { collectAndPersistDomainEvidence } from '../probes/domain-evidence.js';
 import { generateAndSendFindingAlerts } from './alert-from-findings.js';
 import {
   type CollectDomainJobData,
@@ -89,6 +90,23 @@ export async function processCollectDomain(job: Job<CollectDomainJobData>): Prom
 
     const collector = new DNSCollector(config, db);
     const result = await collector.collect();
+
+    const evidenceDomain = await new DomainRepository(db).findByNameForTenant(domain, tenantId);
+    if (evidenceDomain) {
+      try {
+        await collectAndPersistDomainEvidence(db, {
+          snapshotId: result.snapshotId,
+          tenantId,
+          domainId: evidenceDomain.id,
+          domain: evidenceDomain.normalizedName,
+        });
+      } catch (evidenceError) {
+        logger.warn('External evidence collection failed (non-fatal)', {
+          snapshotId: result.snapshotId,
+          error: evidenceError instanceof Error ? evidenceError.message : String(evidenceError),
+        });
+      }
+    }
 
     // JOB-002: Generate alerts from high-severity findings and deliver via webhook
     // Alerts only apply to monitored domains — the function handles the lookup
@@ -288,8 +306,11 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
 
     // Get domain to check zone management
     const domain = await domainRepo.findById(domainId);
-    if (!domain) {
-      throw new Error(`Domain ${domainId} not found`);
+    if (!domain || domain.tenantId !== tenantId) {
+      throw new Error(`Domain ${domainId} is outside the monitoring tenant`);
+    }
+    if (domain.normalizedName !== domainName.toLowerCase()) {
+      throw new Error('Monitoring job domain name does not match the registered domain');
     }
 
     const config: CollectionConfig = {
@@ -303,6 +324,20 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
 
     const collector = new DNSCollector(config, db);
     const result = await collector.collect();
+
+    try {
+      await collectAndPersistDomainEvidence(db, {
+        snapshotId: result.snapshotId,
+        tenantId,
+        domainId: domain.id,
+        domain: domain.normalizedName,
+      });
+    } catch (evidenceError) {
+      logger.warn('External evidence collection failed (non-fatal)', {
+        snapshotId: result.snapshotId,
+        error: evidenceError instanceof Error ? evidenceError.message : String(evidenceError),
+      });
+    }
 
     await job.updateProgress(100);
 

--- a/apps/collector/src/jobs/worker.ts
+++ b/apps/collector/src/jobs/worker.ts
@@ -358,6 +358,22 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
         error: evidenceError instanceof Error ? evidenceError.message : String(evidenceError),
       });
     }
+    try {
+      await finalizePersistedCanonicalConditions(db, {
+        snapshotId: result.snapshotId,
+        tenantId,
+        domainId: domain.id,
+        domainName: domain.normalizedName,
+      });
+    } catch (finalizationError) {
+      logger.warn('Canonical condition finalization failed (non-fatal)', {
+        snapshotId: result.snapshotId,
+        error:
+          finalizationError instanceof Error
+            ? finalizationError.message
+            : String(finalizationError),
+      });
+    }
 
     await job.updateProgress(100);
 

--- a/apps/collector/src/jobs/worker.ts
+++ b/apps/collector/src/jobs/worker.ts
@@ -366,13 +366,14 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
         domainName: domain.normalizedName,
       });
     } catch (finalizationError) {
-      logger.warn('Canonical condition finalization failed (non-fatal)', {
+      logger.error('Canonical condition finalization failed; monitoring refresh will retry', {
         snapshotId: result.snapshotId,
         error:
           finalizationError instanceof Error
             ? finalizationError.message
             : String(finalizationError),
       });
+      throw finalizationError;
     }
 
     await job.updateProgress(100);

--- a/apps/collector/src/jobs/worker.ts
+++ b/apps/collector/src/jobs/worker.ts
@@ -29,6 +29,7 @@ import {
 import { getJobMetrics } from '../middleware/job-metrics.js';
 import { collectAndPersistDomainEvidence } from '../probes/domain-evidence.js';
 import { generateAndSendFindingAlerts } from './alert-from-findings.js';
+import { finalizePersistedCanonicalConditions } from './operational-condition-finalizer.js';
 import {
   type CollectDomainJobData,
   type FleetReportJobData,
@@ -104,6 +105,25 @@ export async function processCollectDomain(job: Job<CollectDomainJobData>): Prom
         logger.warn('External evidence collection failed (non-fatal)', {
           snapshotId: result.snapshotId,
           error: evidenceError instanceof Error ? evidenceError.message : String(evidenceError),
+        });
+      }
+    }
+
+    if (evidenceDomain) {
+      try {
+        await finalizePersistedCanonicalConditions(db, {
+          snapshotId: result.snapshotId,
+          tenantId,
+          domainId: evidenceDomain.id,
+          domainName: evidenceDomain.normalizedName,
+        });
+      } catch (finalizationError) {
+        logger.warn('Canonical condition finalization failed (non-fatal)', {
+          snapshotId: result.snapshotId,
+          error:
+            finalizationError instanceof Error
+              ? finalizationError.message
+              : String(finalizationError),
         });
       }
     }

--- a/apps/collector/src/mail/checker.test.ts
+++ b/apps/collector/src/mail/checker.test.ts
@@ -190,6 +190,11 @@ describe('Mail Checker', () => {
       expect(result.present).toBe(true);
       expect(result.valid).toBe(true);
       expect(result.record).toContain('v=spf1');
+      expect(result.spfAssessment).toMatchObject({
+        scope: 'FIRST_LEVEL_ONLY',
+        includeDomains: ['_spf.google.com'],
+        completeEvaluation: false,
+      });
     });
 
     it('should handle missing SPF record', async () => {

--- a/apps/collector/src/mail/checker.test.ts
+++ b/apps/collector/src/mail/checker.test.ts
@@ -15,14 +15,16 @@ import {
 
 // Mock DNS resolution
 vi.mock('./dns.js', () => ({
+  resolveDomainExists: vi.fn(),
   resolveTXT: vi.fn(),
 }));
 
-import { resolveTXT } from './dns.js';
+import { resolveDomainExists, resolveTXT } from './dns.js';
 
 describe('Mail Checker', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (resolveDomainExists as ReturnType<typeof vi.fn>).mockResolvedValue(true);
   });
 
   describe('performMailCheck', () => {
@@ -49,7 +51,7 @@ describe('Mail Checker', () => {
       expect(result.dmarc.present).toBe(false);
       expect(result.dkim.present).toBe(false);
       expect(result.spf.present).toBe(false);
-      expect(result.dmarc.errors).toContain('DNS error: NXDOMAIN');
+      expect(result.dmarc.dmarcDiscovery?.status).toBe('UNKNOWN');
     });
   });
 
@@ -73,7 +75,7 @@ describe('Mail Checker', () => {
 
       expect(result.present).toBe(false);
       expect(result.valid).toBe(false);
-      expect(result.errors).toContain('DNS error: NXDOMAIN');
+      expect(result.dmarcDiscovery?.status).toBe('UNKNOWN');
     });
 
     it('should handle TXT records without DMARC', async () => {
@@ -86,7 +88,8 @@ describe('Mail Checker', () => {
 
       expect(result.present).toBe(false);
       expect(result.valid).toBe(false);
-      expect(result.errors).toContain('No DMARC record found');
+      expect(result.errors).toContain('No applicable DMARC policy record found');
+      expect(result.dmarcDiscovery?.queries.length).toBeLessThanOrEqual(8);
     });
 
     it('should store raw record content', async () => {

--- a/apps/collector/src/mail/checker.ts
+++ b/apps/collector/src/mail/checker.ts
@@ -42,7 +42,9 @@ import {
   parseSPF,
   type SPFRecord,
 } from '@dns-ops/parsing';
-import { type MxRecord, resolveMX, resolveTXT } from './dns.js';
+import type { DmarcPolicyDiscoveryResult } from './dmarc-discovery.js';
+import { applyDmarcAuthorDomainExistence, discoverDmarcPolicy } from './dmarc-discovery.js';
+import { type MxRecord, resolveDomainExists, resolveMX, resolveTXT } from './dns.js';
 
 export interface MailCheckResult {
   domain: string;
@@ -61,6 +63,7 @@ export interface RecordCheckResult {
   record?: string;
   parsed?: DMARCRecord | SPFRecord;
   spfAssessment?: FirstLevelSpfAssessment;
+  dmarcDiscovery?: DmarcPolicyDiscoveryResult;
   errors?: string[];
 }
 
@@ -151,35 +154,63 @@ export async function performMailCheck(
 /**
  * Check DMARC record
  */
-export async function checkDMARC(domain: string): Promise<RecordCheckResult> {
+async function resolveDmarcTxt(name: string): Promise<string[]> {
   try {
-    const records = await resolveTXT(`_dmarc.${domain}`);
-    const dmarcRecord = records.find((r) => r.includes('v=DMARC1'));
-
-    if (!dmarcRecord) {
-      return {
-        present: false,
-        valid: false,
-        errors: ['No DMARC record found'],
-      };
-    }
-
-    const parsed = parseDMARC(dmarcRecord);
-    return {
-      present: true,
-      valid: parsed !== null,
-      record: dmarcRecord,
-      parsed: parsed || undefined,
-      errors: parsed ? undefined : ['Failed to parse DMARC record'],
-    };
+    return await resolveTXT(name);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String(error.code)
+        : undefined;
+    if (code === 'ENODATA' || code === 'ENOTFOUND') return [];
+    throw error;
+  }
+}
+
+export async function checkDMARC(domain: string): Promise<RecordCheckResult> {
+  // Start discovery first so the existing parallel mail-check query ordering is
+  // preserved; domain existence is separate evidence and is not part of the
+  // RFC 9989 eight-query DMARC Tree Walk budget.
+  const discoveryPromise = discoverDmarcPolicy(domain, resolveDmarcTxt);
+  const existencePromise = resolveDomainExists(domain).catch(() => undefined);
+  const [discovery, authorDomainExists] = await Promise.all([discoveryPromise, existencePromise]);
+  const dmarcDiscovery = applyDmarcAuthorDomainExistence(discovery, authorDomainExists);
+
+  if (dmarcDiscovery.status === 'UNKNOWN') {
     return {
       present: false,
       valid: false,
-      errors: [`DNS error: ${message}`],
+      dmarcDiscovery,
+      errors: [dmarcDiscovery.error ?? 'DMARC policy discovery is incomplete'],
     };
   }
+
+  if (dmarcDiscovery.status === 'NOT_FOUND' || !dmarcDiscovery.record) {
+    return {
+      present: false,
+      valid: false,
+      dmarcDiscovery,
+      errors: ['No applicable DMARC policy record found'],
+    };
+  }
+
+  const parsed = parseDMARC(dmarcDiscovery.record);
+  const policyDetermined = dmarcDiscovery.policyApplication === 'DETERMINED';
+  return {
+    present: true,
+    valid: parsed !== null && policyDetermined,
+    record: dmarcDiscovery.record,
+    parsed: parsed || undefined,
+    dmarcDiscovery,
+    errors:
+      parsed && policyDetermined
+        ? undefined
+        : [
+            parsed
+              ? 'Applicable DMARC policy requires domain-existence evidence'
+              : 'Failed to parse applicable DMARC policy record',
+          ],
+  };
 }
 
 /**

--- a/apps/collector/src/mail/checker.ts
+++ b/apps/collector/src/mail/checker.ts
@@ -34,7 +34,14 @@
  * @see MailEvidenceRepository for persisted evidence storage
  */
 
-import { type DMARCRecord, parseDMARC, parseSPF, type SPFRecord } from '@dns-ops/parsing';
+import type { FirstLevelSpfAssessment } from '@dns-ops/contracts';
+import {
+  assessFirstLevelSpf,
+  type DMARCRecord,
+  parseDMARC,
+  parseSPF,
+  type SPFRecord,
+} from '@dns-ops/parsing';
 import { type MxRecord, resolveMX, resolveTXT } from './dns.js';
 
 export interface MailCheckResult {
@@ -53,6 +60,7 @@ export interface RecordCheckResult {
   valid: boolean;
   record?: string;
   parsed?: DMARCRecord | SPFRecord;
+  spfAssessment?: FirstLevelSpfAssessment;
   errors?: string[];
 }
 
@@ -286,12 +294,14 @@ export async function checkSPF(domain: string): Promise<RecordCheckResult> {
     }
 
     const parsed = parseSPF(spfRecord);
+    const spfAssessment = parsed ? assessFirstLevelSpf(parsed) : undefined;
     return {
       present: true,
-      valid: parsed !== null,
+      valid: spfAssessment?.status === 'DIRECT_SYNTAX_VALID',
       record: spfRecord,
       parsed: parsed || undefined,
-      errors: parsed ? undefined : ['Failed to parse SPF record'],
+      spfAssessment,
+      errors: parsed ? undefined : ['Failed to parse directly published SPF record'],
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/collector/src/mail/dmarc-discovery.test.ts
+++ b/apps/collector/src/mail/dmarc-discovery.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DMARC_TREE_WALK_QUERY_LIMIT, discoverDmarcPolicy } from './dmarc-discovery.js';
+
+function fixture(records: Record<string, string[] | Error>) {
+  return vi.fn(async (name: string): Promise<string[]> => {
+    const answer = records[name] ?? [];
+    if (answer instanceof Error) throw answer;
+    return answer;
+  });
+}
+
+describe('RFC 9989 DMARC policy discovery', () => {
+  it('prefers the Author Domain and stops after one query', async () => {
+    const resolveTxt = fixture({
+      '_dmarc.mail.example.com': ['v=DMARC1; p=reject'],
+    });
+
+    const result = await discoverDmarcPolicy('Mail.Example.COM.', resolveTxt);
+
+    expect(result).toMatchObject({
+      status: 'FOUND',
+      authorDomain: 'mail.example.com',
+      policyDomain: 'mail.example.com',
+      source: 'AUTHOR_DOMAIN',
+      effectivePolicy: 'reject',
+      effectivePolicyTag: 'p',
+      policyApplication: 'DETERMINED',
+    });
+    expect(result.queries.map((query) => query.name)).toEqual(['_dmarc.mail.example.com']);
+  });
+
+  it('accepts RFC whitespace around the version equals sign but rejects version prefixes', async () => {
+    const valid = await discoverDmarcPolicy(
+      'example.com',
+      fixture({ '_dmarc.example.com': ['v = DMARC1 ; p=none'] })
+    );
+    const invalid = await discoverDmarcPolicy(
+      'example.com',
+      fixture({ '_dmarc.example.com': ['v=DMARC10; p=reject'] })
+    );
+
+    expect(valid.status).toBe('FOUND');
+    expect(invalid.status).toBe('NOT_FOUND');
+  });
+
+  it('uses at most eight queries and skips to seven labels for a deep name', async () => {
+    const domain = 'a.b.c.d.e.f.g.h.i.j.mail.example.com';
+
+    const result = await discoverDmarcPolicy(domain, fixture({}));
+
+    expect(result.status).toBe('NOT_FOUND');
+    expect(result.queryLimit).toBe(DMARC_TREE_WALK_QUERY_LIMIT);
+    expect(result.queries.map((query) => query.name)).toEqual([
+      `_dmarc.${domain}`,
+      '_dmarc.g.h.i.j.mail.example.com',
+      '_dmarc.h.i.j.mail.example.com',
+      '_dmarc.i.j.mail.example.com',
+      '_dmarc.j.mail.example.com',
+      '_dmarc.mail.example.com',
+      '_dmarc.example.com',
+      '_dmarc.com',
+    ]);
+  });
+
+  it('selects the organizational-domain record when a higher PSD record stops the walk', async () => {
+    const resolveTxt = fixture({
+      '_dmarc.example.com': ['v=DMARC1; p=quarantine'],
+      '_dmarc.com': ['v=DMARC1; p=reject; psd=y'],
+    });
+
+    const result = await discoverDmarcPolicy('a.mail.example.com', resolveTxt);
+
+    expect(result).toMatchObject({
+      status: 'FOUND',
+      policyDomain: 'example.com',
+      organizationalDomain: 'example.com',
+      source: 'ORGANIZATIONAL_DOMAIN',
+      record: 'v=DMARC1; p=quarantine',
+    });
+  });
+
+  it('uses a PSD record when no organizational-domain record exists', async () => {
+    const resolveTxt = fixture({
+      '_dmarc.com': ['v=DMARC1; p=reject; psd=y'],
+    });
+
+    const result = await discoverDmarcPolicy('a.mail.example.com', resolveTxt);
+
+    expect(result).toMatchObject({
+      status: 'FOUND',
+      policyDomain: 'com',
+      organizationalDomain: 'example.com',
+      source: 'PUBLIC_SUFFIX_DOMAIN',
+    });
+  });
+
+  it('discards multiple current-version records at one target', async () => {
+    const resolveTxt = fixture({
+      '_dmarc.mail.example.com': ['v=DMARC1; p=reject', 'v=DMARC1; p=none'],
+      '_dmarc.example.com': ['v=DMARC1; p=quarantine; psd=n'],
+    });
+
+    const result = await discoverDmarcPolicy('mail.example.com', resolveTxt);
+
+    expect(result).toMatchObject({
+      status: 'FOUND',
+      policyDomain: 'example.com',
+      source: 'ORGANIZATIONAL_DOMAIN',
+    });
+    expect(result.queries[0]?.outcome).toBe('MULTIPLE_RECORDS');
+  });
+
+  it('ignores a malformed psd value and continues the walk', async () => {
+    const result = await discoverDmarcPolicy(
+      'a.mail.example.com',
+      fixture({
+        '_dmarc.mail.example.com': ['v=DMARC1; p=none; psd=y=bad'],
+        '_dmarc.example.com': ['v=DMARC1; p=reject; psd=n'],
+      }),
+      { authorDomainExists: true }
+    );
+
+    expect(result).toMatchObject({
+      policyDomain: 'example.com',
+      effectivePolicy: 'reject',
+      effectivePolicyTag: 'p',
+    });
+  });
+
+  it('uses sp and np for existing and non-existent inherited Author Domains', async () => {
+    const records = {
+      '_dmarc.example.com': ['v=DMARC1; p=reject; sp=none; np=quarantine; psd=n'],
+    };
+    const existing = await discoverDmarcPolicy('mail.example.com', fixture(records), {
+      authorDomainExists: true,
+    });
+    const nonExistent = await discoverDmarcPolicy('absent.example.com', fixture(records), {
+      authorDomainExists: false,
+    });
+
+    expect(existing).toMatchObject({ effectivePolicy: 'none', effectivePolicyTag: 'sp' });
+    expect(nonExistent).toMatchObject({
+      effectivePolicy: 'quarantine',
+      effectivePolicyTag: 'np',
+    });
+  });
+
+  it('falls back from missing np to sp before p', async () => {
+    const result = await discoverDmarcPolicy(
+      'absent.example.com',
+      fixture({ '_dmarc.example.com': ['v=DMARC1; p=reject; sp=quarantine; psd=n'] }),
+      { authorDomainExists: false }
+    );
+
+    expect(result).toMatchObject({
+      effectivePolicy: 'quarantine',
+      effectivePolicyTag: 'sp',
+    });
+  });
+
+  it('uses RFC 9989 p=none fallback for invalid policy tags only with valid rua', async () => {
+    const withRua = await discoverDmarcPolicy(
+      'example.com',
+      fixture({
+        '_dmarc.example.com': ['v=DMARC1; p=reject; sp=bogus; rua=mailto:dmarc@example.com'],
+      })
+    );
+    const withoutRua = await discoverDmarcPolicy(
+      'example.com',
+      fixture({ '_dmarc.example.com': ['v=DMARC1; p=reject; sp=bogus'] })
+    );
+
+    expect(withRua).toMatchObject({
+      effectivePolicy: 'none',
+      effectivePolicyTag: 'p',
+      policyApplication: 'DETERMINED',
+    });
+    expect(withoutRua.policyApplication).toBe('INVALID_POLICY');
+  });
+
+  it('does not score a duplicate malformed policy tag as reject', async () => {
+    const result = await discoverDmarcPolicy(
+      'example.com',
+      fixture({
+        '_dmarc.example.com': ['v=DMARC1; p=reject; p=bogus; rua=mailto:dmarc@example.com'],
+      })
+    );
+
+    expect(result).toMatchObject({
+      effectivePolicy: 'none',
+      policyApplication: 'DETERMINED',
+    });
+  });
+
+  it('applies t=y one policy level below the published effective policy', async () => {
+    const reject = await discoverDmarcPolicy(
+      'example.com',
+      fixture({ '_dmarc.example.com': ['v=DMARC1; p=reject; t=y'] })
+    );
+    const quarantine = await discoverDmarcPolicy(
+      'example.com',
+      fixture({ '_dmarc.example.com': ['v=DMARC1; p=quarantine; t=y'] })
+    );
+
+    expect(reject.effectivePolicy).toBe('quarantine');
+    expect(quarantine.effectivePolicy).toBe('none');
+  });
+
+  it('rejects malformed percent escapes in reporting URIs', async () => {
+    const result = await discoverDmarcPolicy(
+      'example.com',
+      fixture({ '_dmarc.example.com': ['v=DMARC1; p=bogus; rua=mailto:%ZZ'] })
+    );
+
+    expect(result.policyApplication).toBe('INVALID_POLICY');
+    expect(result.effectivePolicy).toBeUndefined();
+  });
+
+  it('treats psd=y at the walk starting domain as the organizational record', async () => {
+    const result = await discoverDmarcPolicy(
+      'mail.example.com',
+      fixture({ '_dmarc.example.com': ['v=DMARC1; p=none; psd=y'] }),
+      { authorDomainExists: true }
+    );
+
+    expect(result).toMatchObject({
+      organizationalDomain: 'example.com',
+      policyDomain: 'example.com',
+      source: 'ORGANIZATIONAL_DOMAIN',
+    });
+  });
+
+  it('returns actionable UNKNOWN rather than absence after a DNS error', async () => {
+    const resolveTxt = fixture({
+      '_dmarc.example.com': new Error('SERVFAIL'),
+    });
+
+    const result = await discoverDmarcPolicy('mail.example.com', resolveTxt);
+
+    expect(result).toMatchObject({
+      status: 'UNKNOWN',
+      error: 'DMARC policy discovery stopped because a DNS query failed',
+    });
+    expect(result.queries).toHaveLength(2);
+    expect(result.queries[1]).toMatchObject({ outcome: 'DNS_ERROR', error: 'SERVFAIL' });
+  });
+});

--- a/apps/collector/src/mail/dmarc-discovery.ts
+++ b/apps/collector/src/mail/dmarc-discovery.ts
@@ -1,0 +1,298 @@
+export const DMARC_TREE_WALK_QUERY_LIMIT = 8;
+
+export interface DmarcDiscoveryQuery {
+  name: string;
+  domain: string;
+  outcome: 'NO_RECORD' | 'SINGLE_RECORD' | 'MULTIPLE_RECORDS' | 'DNS_ERROR';
+  record?: string;
+  error?: string;
+}
+
+export interface DmarcPolicyDiscoveryResult {
+  status: 'FOUND' | 'NOT_FOUND' | 'UNKNOWN';
+  authorDomain: string;
+  policyDomain?: string;
+  organizationalDomain?: string;
+  source?: 'AUTHOR_DOMAIN' | 'ORGANIZATIONAL_DOMAIN' | 'PUBLIC_SUFFIX_DOMAIN';
+  record?: string;
+  authorDomainExists?: boolean;
+  effectivePolicy?: 'none' | 'quarantine' | 'reject';
+  effectivePolicyTag?: 'p' | 'sp' | 'np';
+  policyApplication: 'DETERMINED' | 'REQUIRES_DOMAIN_EXISTENCE' | 'INVALID_POLICY' | 'NO_POLICY';
+  queries: DmarcDiscoveryQuery[];
+  queryLimit: typeof DMARC_TREE_WALK_QUERY_LIMIT;
+  error?: string;
+}
+
+interface DiscoveredRecord {
+  domain: string;
+  record: string;
+  psd?: 'y' | 'n';
+}
+
+function normalizeDomain(domain: string): string {
+  return domain.trim().replace(/\.$/, '').toLowerCase();
+}
+
+function currentDmarcRecords(records: string[]): string[] {
+  return records.filter((record) => /^v[\t ]*=[\t ]*DMARC1(?:[\t ]*;|[\t ]*$)/.test(record));
+}
+
+function tagValues(record: string, tag: string): string[] {
+  const values: string[] = [];
+  for (const term of record.split(';')) {
+    const equalIndex = term.indexOf('=');
+    if (equalIndex < 0) continue;
+    const name = term.slice(0, equalIndex).trim().toLowerCase();
+    if (name === tag) values.push(term.slice(equalIndex + 1).trim());
+  }
+  return values;
+}
+
+function tagValue(record: string, tag: string): string | undefined {
+  return tagValues(record, tag)[0];
+}
+
+function psdTag(record: string): 'y' | 'n' | undefined {
+  const value = tagValue(record, 'psd');
+  return value === 'y' || value === 'n' ? value : undefined;
+}
+
+function policyTag(
+  record: string,
+  tag: 'p' | 'sp' | 'np'
+): 'none' | 'quarantine' | 'reject' | undefined {
+  const value = tagValue(record, tag);
+  return value === 'none' || value === 'quarantine' || value === 'reject' ? value : undefined;
+}
+
+function isValidDmarcUri(candidate: string): boolean {
+  const uri = candidate.trim();
+  if (!/^[A-Za-z][A-Za-z0-9+.-]*:[A-Za-z0-9\-._~:/?#[\]@$&'()*+;=%]*$/.test(uri)) {
+    return false;
+  }
+  return !/%(?![0-9A-Fa-f]{2})/.test(uri);
+}
+
+function hasValidReportingUri(record: string): boolean {
+  const rua = tagValue(record, 'rua');
+  return rua?.split(',').some(isValidDmarcUri) ?? false;
+}
+
+function determinedPolicy(
+  record: string,
+  policy: 'none' | 'quarantine' | 'reject',
+  tag: 'p' | 'sp' | 'np'
+): Pick<
+  DmarcPolicyDiscoveryResult,
+  'effectivePolicy' | 'effectivePolicyTag' | 'policyApplication'
+> {
+  const effectivePolicy =
+    tagValue(record, 't') === 'y' ? (policy === 'reject' ? 'quarantine' : 'none') : policy;
+  return { effectivePolicy, effectivePolicyTag: tag, policyApplication: 'DETERMINED' };
+}
+
+function invalidPolicyFallback(
+  record: string
+):
+  | Pick<DmarcPolicyDiscoveryResult, 'effectivePolicy' | 'effectivePolicyTag' | 'policyApplication'>
+  | undefined {
+  const hasInvalidPolicyTag = (['p', 'sp', 'np'] as const).some((tag) => {
+    const values = tagValues(record, tag);
+    return values.length > 1 || (values.length === 1 && policyTag(record, tag) === undefined);
+  });
+  if (!hasInvalidPolicyTag && tagValue(record, 'p') !== undefined) return undefined;
+  return hasValidReportingUri(record)
+    ? determinedPolicy(record, 'none', 'p')
+    : { policyApplication: 'INVALID_POLICY' };
+}
+
+function effectivePolicy(
+  record: string,
+  source: DmarcPolicyDiscoveryResult['source'],
+  authorDomainExists?: boolean
+): Pick<
+  DmarcPolicyDiscoveryResult,
+  'effectivePolicy' | 'effectivePolicyTag' | 'policyApplication'
+> {
+  const fallback = invalidPolicyFallback(record);
+  if (fallback) return fallback;
+
+  if (source === 'AUTHOR_DOMAIN') {
+    const policy = policyTag(record, 'p');
+    return policy ? determinedPolicy(record, policy, 'p') : { policyApplication: 'INVALID_POLICY' };
+  }
+  if (authorDomainExists === undefined) {
+    return { policyApplication: 'REQUIRES_DOMAIN_EXISTENCE' };
+  }
+
+  const candidateTags: Array<'p' | 'sp' | 'np'> = authorDomainExists
+    ? ['sp', 'p']
+    : ['np', 'sp', 'p'];
+  for (const tag of candidateTags) {
+    const policy = policyTag(record, tag);
+    if (policy) {
+      return determinedPolicy(record, policy, tag);
+    }
+  }
+
+  return { policyApplication: 'INVALID_POLICY' };
+}
+
+export function applyDmarcAuthorDomainExistence(
+  discovery: DmarcPolicyDiscoveryResult,
+  authorDomainExists: boolean | undefined
+): DmarcPolicyDiscoveryResult {
+  if (discovery.status !== 'FOUND' || !discovery.record || !discovery.source) return discovery;
+  return {
+    ...discovery,
+    authorDomainExists,
+    ...effectivePolicy(discovery.record, discovery.source, authorDomainExists),
+  };
+}
+
+function childBelow(authorLabels: string[], ancestorDomain: string): string | undefined {
+  const ancestorLabels = ancestorDomain.split('.');
+  if (authorLabels.length <= ancestorLabels.length) return undefined;
+  return authorLabels.slice(-(ancestorLabels.length + 1)).join('.');
+}
+
+/**
+ * Discover the DMARC policy applicable to an Author Domain using the RFC 9989
+ * DNS Tree Walk. The resolver is injected so deterministic fixtures can prove
+ * the query sequence without making live DNS requests.
+ */
+export async function discoverDmarcPolicy(
+  authorDomainInput: string,
+  resolveTxt: (name: string) => Promise<string[]>,
+  options: { authorDomainExists?: boolean } = {}
+): Promise<DmarcPolicyDiscoveryResult> {
+  const authorDomain = normalizeDomain(authorDomainInput);
+  const authorLabels = authorDomain.split('.').filter(Boolean);
+  const queries: DmarcDiscoveryQuery[] = [];
+  const discovered: DiscoveredRecord[] = [];
+
+  const query = async (domain: string): Promise<DiscoveredRecord | 'ERROR' | undefined> => {
+    const name = `_dmarc.${domain}`;
+    try {
+      const records = currentDmarcRecords(await resolveTxt(name));
+      if (records.length === 0) {
+        queries.push({ name, domain, outcome: 'NO_RECORD' });
+        return undefined;
+      }
+      if (records.length > 1) {
+        queries.push({ name, domain, outcome: 'MULTIPLE_RECORDS' });
+        return undefined;
+      }
+
+      const record = records[0];
+      const found = { domain, record, psd: psdTag(record) };
+      queries.push({ name, domain, outcome: 'SINGLE_RECORD', record });
+      return found;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      queries.push({ name, domain, outcome: 'DNS_ERROR', error: message });
+      return 'ERROR';
+    }
+  };
+
+  const unknown = (): DmarcPolicyDiscoveryResult => ({
+    status: 'UNKNOWN',
+    authorDomain,
+    policyApplication: 'NO_POLICY',
+    queries,
+    queryLimit: DMARC_TREE_WALK_QUERY_LIMIT,
+    error: 'DMARC policy discovery stopped because a DNS query failed',
+  });
+
+  const direct = await query(authorDomain);
+  if (direct === 'ERROR') return unknown();
+  if (direct) {
+    const source = 'AUTHOR_DOMAIN' as const;
+    return {
+      status: 'FOUND',
+      authorDomain,
+      policyDomain: authorDomain,
+      organizationalDomain: direct.psd === 'n' ? authorDomain : undefined,
+      source,
+      record: direct.record,
+      authorDomainExists: options.authorDomainExists,
+      ...effectivePolicy(direct.record, source, options.authorDomainExists),
+      queries,
+      queryLimit: DMARC_TREE_WALK_QUERY_LIMIT,
+    };
+  }
+
+  let targetLabels =
+    authorLabels.length <= DMARC_TREE_WALK_QUERY_LIMIT
+      ? authorLabels.slice(1)
+      : authorLabels.slice(-7);
+  const walkStartingDomain = targetLabels.join('.');
+
+  while (targetLabels.length > 0 && queries.length < DMARC_TREE_WALK_QUERY_LIMIT) {
+    const domain = targetLabels.join('.');
+    const found = await query(domain);
+    if (found === 'ERROR') return unknown();
+    if (found) {
+      discovered.push(found);
+      if (found.psd) break;
+    }
+    targetLabels = targetLabels.slice(1);
+  }
+
+  if (discovered.length === 0) {
+    return {
+      status: 'NOT_FOUND',
+      authorDomain,
+      policyApplication: 'NO_POLICY',
+      queries,
+      queryLimit: DMARC_TREE_WALK_QUERY_LIMIT,
+    };
+  }
+
+  let organizationalDomain: string | undefined;
+  for (const found of discovered) {
+    if (found.psd === 'n') {
+      organizationalDomain = found.domain;
+      break;
+    }
+    if (found.psd === 'y' && found.domain !== walkStartingDomain) {
+      organizationalDomain = childBelow(authorLabels, found.domain);
+      break;
+    }
+  }
+  organizationalDomain ??= discovered.at(-1)?.domain;
+
+  const organizationalRecord = discovered.find((found) => found.domain === organizationalDomain);
+  const publicSuffixRecord = discovered.find((found) => found.psd === 'y');
+  const applicable = organizationalRecord ?? publicSuffixRecord;
+
+  if (!applicable) {
+    return {
+      status: 'NOT_FOUND',
+      authorDomain,
+      organizationalDomain,
+      policyApplication: 'NO_POLICY',
+      queries,
+      queryLimit: DMARC_TREE_WALK_QUERY_LIMIT,
+    };
+  }
+
+  const source =
+    applicable.domain === organizationalDomain
+      ? ('ORGANIZATIONAL_DOMAIN' as const)
+      : ('PUBLIC_SUFFIX_DOMAIN' as const);
+
+  return {
+    status: 'FOUND',
+    authorDomain,
+    policyDomain: applicable.domain,
+    organizationalDomain,
+    source,
+    record: applicable.record,
+    authorDomainExists: options.authorDomainExists,
+    ...effectivePolicy(applicable.record, source, options.authorDomainExists),
+    queries,
+    queryLimit: DMARC_TREE_WALK_QUERY_LIMIT,
+  };
+}

--- a/apps/collector/src/mail/dns.ts
+++ b/apps/collector/src/mail/dns.ts
@@ -2,7 +2,7 @@
  * DNS Resolution utilities for mail checking
  */
 
-import { resolveMx, resolveTxt } from 'node:dns/promises';
+import { resolveAny, resolveMx, resolveTxt } from 'node:dns/promises';
 
 /**
  * Resolve TXT records for a hostname
@@ -11,6 +11,25 @@ export async function resolveTXT(hostname: string): Promise<string[]> {
   const records = await resolveTxt(hostname);
   // Join multi-part TXT records
   return records.map((parts) => parts.join(''));
+}
+
+/**
+ * Determine whether a domain exists without treating a NOERROR/NODATA answer as
+ * non-existence. Only NXDOMAIN (ENOTFOUND) proves absence.
+ */
+export async function resolveDomainExists(domain: string): Promise<boolean> {
+  try {
+    await resolveAny(domain);
+    return true;
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String(error.code)
+        : undefined;
+    if (code === 'ENOTFOUND') return false;
+    if (code === 'ENODATA') return true;
+    throw error;
+  }
 }
 
 /**

--- a/apps/collector/src/mail/index.ts
+++ b/apps/collector/src/mail/index.ts
@@ -16,4 +16,11 @@ export {
   type SelectorProvenance,
 } from './checker.js';
 
-export { resolveTXT } from './dns.js';
+export {
+  applyDmarcAuthorDomainExistence,
+  DMARC_TREE_WALK_QUERY_LIMIT,
+  type DmarcDiscoveryQuery,
+  type DmarcPolicyDiscoveryResult,
+  discoverDmarcPolicy,
+} from './dmarc-discovery.js';
+export { resolveDomainExists, resolveTXT } from './dns.js';

--- a/apps/collector/src/mail/mail-chain.integration.test.ts
+++ b/apps/collector/src/mail/mail-chain.integration.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock DNS for mail checks
 vi.mock('./dns.js', () => ({
+  resolveDomainExists: vi.fn().mockResolvedValue(true),
   resolveTXT: vi.fn(),
 }));
 
@@ -85,7 +86,7 @@ describe('MAIL-001: Mail Chain Integration', () => {
       expect(result.dkim.present).toBe(false);
 
       // Error states should be captured
-      expect(result.dmarc.errors).toContain('DNS error: NXDOMAIN');
+      expect(result.dmarc.dmarcDiscovery?.status).toBe('UNKNOWN');
       expect(result.spf.errors).toContain('DNS error: NXDOMAIN');
     });
 

--- a/apps/collector/src/probes/domain-evidence.test.ts
+++ b/apps/collector/src/probes/domain-evidence.test.ts
@@ -1,0 +1,166 @@
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import { domainProfiles, domains, probeObservations, snapshots } from '@dns-ops/db/schema';
+import { describe, expect, it } from 'vitest';
+import { collectAndPersistDomainEvidence } from './domain-evidence.js';
+
+function createDb(purpose: 'WEB' | 'MAIL' | 'REDIRECT' | 'UNKNOWN') {
+  const persisted: unknown[] = [];
+  const db = {
+    async selectOne(table: unknown) {
+      if (table === snapshots) return { id: 'snapshot-1', domainId: 'domain-1' };
+      if (table === domains)
+        return { id: 'domain-1', tenantId: 'tenant-1', normalizedName: 'example.com' };
+      if (table === domainProfiles) {
+        return { domainId: 'domain-1', tenantId: 'tenant-1', purpose, criticality: 'NORMAL' };
+      }
+      return undefined;
+    },
+    async insertMany(table: unknown, values: unknown[]) {
+      if (table !== probeObservations) throw new Error('Unexpected table');
+      persisted.push(...values);
+      return values;
+    },
+  };
+  return { db: db as unknown as IDatabaseAdapter, persisted };
+}
+
+describe('collectAndPersistDomainEvidence', () => {
+  it('rejects a snapshot/domain pair outside the supplied tenant before persistence', async () => {
+    const { db, persisted } = createDb('WEB');
+    await expect(
+      collectAndPersistDomainEvidence(
+        db,
+        {
+          snapshotId: 'snapshot-1',
+          tenantId: 'other-tenant',
+          domainId: 'domain-1',
+          domain: 'example.com',
+        },
+        { activeProbesEnabled: false }
+      )
+    ).rejects.toThrow('outside the tenant');
+    expect(persisted).toEqual([]);
+  });
+
+  it('persists disabled web checks as actionable UNKNOWN evidence, not operational objects', async () => {
+    const { db, persisted } = createDb('WEB');
+    const count = await collectAndPersistDomainEvidence(
+      db,
+      {
+        snapshotId: 'snapshot-1',
+        tenantId: 'tenant-1',
+        domainId: 'domain-1',
+        domain: 'example.com',
+      },
+      { activeProbesEnabled: false }
+    );
+    expect(count).toBe(5);
+    expect(persisted).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ probeType: 'rdap', status: 'error', success: false }),
+        expect.objectContaining({ probeType: 'tls_cert', status: 'error', success: false }),
+        expect.objectContaining({ probeType: 'http', status: 'error', success: false }),
+      ])
+    );
+    expect(JSON.stringify(persisted)).toContain('NOT_CURRENTLY_OBSERVABLE');
+  });
+
+  it('collects enabled profile-applicable evidence through injected bounded probes', async () => {
+    const { db, persisted } = createDb('WEB');
+    const count = await collectAndPersistDomainEvidence(
+      db,
+      {
+        snapshotId: 'snapshot-1',
+        tenantId: 'tenant-1',
+        domainId: 'domain-1',
+        domain: 'example.com',
+      },
+      {
+        activeProbesEnabled: true,
+        rdap: {
+          resolveHostname: async () => ['1.1.1.1'],
+          fetcher: async (url) =>
+            new Response(
+              url.includes('dns.json')
+                ? JSON.stringify({ services: [[['com'], ['https://rdap.example/']]] })
+                : JSON.stringify({
+                    objectClassName: 'domain',
+                    ldhName: 'example.com',
+                    events: [{ eventAction: 'expiration', eventDate: '2030-01-01T00:00:00Z' }],
+                  }),
+              { headers: { 'content-type': 'application/json' } }
+            ),
+        },
+        tls: {
+          resolveHostname: async () => ['1.1.1.1'],
+          connector: async () => ({
+            kind: 'TLS_CERTIFICATE',
+            hostname: 'example.com',
+            resolvedAddress: '1.1.1.1',
+            port: 443,
+            protocol: 'TLSv1.3',
+            cipher: 'TLS_AES_256_GCM_SHA384',
+            hostnameAuthorized: true,
+            chainAuthorized: true,
+            subject: 'CN=example.com',
+            issuer: 'CN=CA',
+            subjectAlternativeNames: ['example.com'],
+            validFrom: '2026-01-01T00:00:00.000Z',
+            validTo: '2030-01-01T00:00:00.000Z',
+            fingerprintSha256: 'AA:BB',
+          }),
+        },
+        http: {
+          resolveHostname: async () => ['1.1.1.1'],
+          fetcher: async () =>
+            new Response('<html></html>', { headers: { 'content-type': 'text/html' } }),
+        },
+      }
+    );
+    expect(count).toBe(11);
+    expect(
+      persisted.filter((row) => (row as { status?: string }).status === 'success')
+    ).toHaveLength(11);
+  });
+
+  it('does not create homepage indexability evidence for redirect-only domains', async () => {
+    const { db, persisted } = createDb('REDIRECT');
+    const count = await collectAndPersistDomainEvidence(
+      db,
+      {
+        snapshotId: 'snapshot-1',
+        tenantId: 'tenant-1',
+        domainId: 'domain-1',
+        domain: 'example.com',
+      },
+      { activeProbesEnabled: false }
+    );
+    expect(count).toBe(4);
+    expect(JSON.stringify(persisted)).not.toContain('HOMEPAGE_INDEXABILITY');
+  });
+
+  it('persists purpose-undeclared web setup evidence without probing', async () => {
+    const { db, persisted } = createDb('UNKNOWN');
+    const count = await collectAndPersistDomainEvidence(
+      db,
+      {
+        snapshotId: 'snapshot-1',
+        tenantId: 'tenant-1',
+        domainId: 'domain-1',
+        domain: 'example.com',
+      },
+      { activeProbesEnabled: false }
+    );
+    expect(count).toBe(4);
+    expect(persisted).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ probeType: 'rdap' }),
+        expect.objectContaining({
+          probeData: expect.objectContaining({
+            unknown: expect.objectContaining({ reason: 'PURPOSE_UNDECLARED' }),
+          }),
+        }),
+      ])
+    );
+  });
+});

--- a/apps/collector/src/probes/domain-evidence.ts
+++ b/apps/collector/src/probes/domain-evidence.ts
@@ -1,0 +1,183 @@
+import {
+  type DomainEvidenceCheck,
+  type EvidenceCheckResult,
+  type ExternalEvidenceData,
+  evidenceApplicability,
+  purposeUndeclaredUnknown,
+  type UnknownResolution,
+} from '@dns-ops/contracts';
+import {
+  DomainProfileRepository,
+  DomainRepository,
+  type IDatabaseAdapter,
+  ProbeObservationRepository,
+  SnapshotRepository,
+} from '@dns-ops/db';
+import { getEnvConfig } from '../config/env.js';
+import { externalEvidenceToObservation } from './external-evidence-persistence.js';
+import { collectHttpWebEvidence, type HttpWebCollectionOptions } from './http-web.js';
+import { collectRdapExpirationEvidence, type RdapCollectionOptions } from './rdap.js';
+import { getProbeSemaphore, initProbeSemaphore } from './semaphore.js';
+import {
+  collectTlsCertificateEvidence,
+  type TLSCertificateCollectionOptions,
+} from './tls-certificate.js';
+
+export interface DomainEvidenceCollectionOptions {
+  activeProbesEnabled?: boolean;
+  rdap?: RdapCollectionOptions;
+  tls?: TLSCertificateCollectionOptions;
+  http?: HttpWebCollectionOptions;
+}
+
+const configuredProbes = getEnvConfig().probes;
+initProbeSemaphore(configuredProbes.concurrency);
+
+function unavailable(check: string): EvidenceCheckResult<ExternalEvidenceData> {
+  const unknown: UnknownResolution = {
+    reason: 'UNSUPPORTED_CHECK',
+    explanation: `${check} collection is disabled until active probes are explicitly enabled.`,
+    action: 'NOT_CURRENTLY_OBSERVABLE',
+    actionLabel: `${check} is not currently observable`,
+    blocking: true,
+  };
+  return { status: 'UNKNOWN', unknown };
+}
+
+type PendingResult = {
+  result: EvidenceCheckResult<ExternalEvidenceData>;
+  check: DomainEvidenceCheck;
+  hostname: string;
+  port?: number;
+};
+
+export async function collectAndPersistDomainEvidence(
+  db: IDatabaseAdapter,
+  input: { snapshotId: string; tenantId: string; domainId: string; domain: string },
+  options: DomainEvidenceCollectionOptions = {}
+): Promise<number> {
+  const snapshot = await new SnapshotRepository(db).findById(input.snapshotId);
+  const domain = await new DomainRepository(db).findById(input.domainId);
+  if (
+    !snapshot ||
+    snapshot.domainId !== input.domainId ||
+    !domain ||
+    domain.tenantId !== input.tenantId ||
+    domain.normalizedName !== input.domain.toLowerCase()
+  ) {
+    throw new Error('Snapshot or domain is outside the tenant');
+  }
+
+  const profile = await new DomainProfileRepository(db).findByDomainId(
+    input.domainId,
+    input.tenantId
+  );
+  const purpose = profile?.purpose ?? 'UNKNOWN';
+  const enabled = options.activeProbesEnabled ?? configuredProbes.enabled;
+  const timeoutMs = configuredProbes.timeoutMs;
+  const semaphore = getProbeSemaphore();
+  const runProbe = <T>(collect: () => Promise<T>) => semaphore.run(collect);
+  const results: PendingResult[] = [];
+
+  if (evidenceApplicability(purpose, 'RDAP_EXPIRATION') === 'APPLICABLE') {
+    results.push({
+      result: enabled
+        ? await runProbe(() =>
+            collectRdapExpirationEvidence(input.domain, {
+              ...options.rdap,
+              timeoutMs: options.rdap?.timeoutMs ?? timeoutMs,
+            })
+          )
+        : unavailable('RDAP expiration'),
+      check: 'RDAP_EXPIRATION',
+      hostname: input.domain,
+      port: 443,
+    });
+  }
+
+  if (evidenceApplicability(purpose, 'TLS_CERTIFICATE') === 'APPLICABLE') {
+    results.push({
+      result: enabled
+        ? await runProbe(() =>
+            collectTlsCertificateEvidence(input.domain, {
+              ...options.tls,
+              timeoutMs: options.tls?.timeoutMs ?? timeoutMs,
+            })
+          )
+        : unavailable('TLS certificate'),
+      check: 'TLS_CERTIFICATE',
+      hostname: input.domain,
+      port: 443,
+    });
+  }
+
+  const webApplicability = evidenceApplicability(purpose, 'HTTP_REACHABILITY');
+  if (webApplicability === 'UNKNOWN') {
+    const result: EvidenceCheckResult<ExternalEvidenceData> = {
+      status: 'UNKNOWN',
+      unknown: purposeUndeclaredUnknown('Web evidence'),
+    };
+    results.push({ result, check: 'HTTP_REACHABILITY', hostname: input.domain });
+    results.push({ result, check: 'REDIRECT_TOPOLOGY', hostname: input.domain });
+    results.push({ result, check: 'HOMEPAGE_INDEXABILITY', hostname: input.domain });
+  } else if (webApplicability === 'APPLICABLE') {
+    const web = enabled
+      ? await runProbe(() =>
+          collectHttpWebEvidence(input.domain, {
+            ...options.http,
+            timeoutMs: options.http?.timeoutMs ?? timeoutMs,
+          })
+        )
+      : null;
+    if (web) {
+      for (const start of web.starts) {
+        results.push({
+          result: start.reachability,
+          check: 'HTTP_REACHABILITY',
+          hostname: input.domain,
+        });
+        results.push({
+          result: start.redirect,
+          check: 'REDIRECT_TOPOLOGY',
+          hostname: input.domain,
+        });
+      }
+      if (evidenceApplicability(purpose, 'HOMEPAGE_INDEXABILITY') === 'APPLICABLE') {
+        results.push({
+          result: web.indexability,
+          check: 'HOMEPAGE_INDEXABILITY',
+          hostname: input.domain,
+        });
+      }
+    } else {
+      results.push({
+        result: unavailable('HTTP reachability'),
+        check: 'HTTP_REACHABILITY',
+        hostname: input.domain,
+      });
+      results.push({
+        result: unavailable('Redirect topology'),
+        check: 'REDIRECT_TOPOLOGY',
+        hostname: input.domain,
+      });
+      if (evidenceApplicability(purpose, 'HOMEPAGE_INDEXABILITY') === 'APPLICABLE') {
+        results.push({
+          result: unavailable('Homepage indexability'),
+          check: 'HOMEPAGE_INDEXABILITY',
+          hostname: input.domain,
+        });
+      }
+    }
+  }
+
+  const observations = results.flatMap(({ result, check, hostname, port }) => {
+    const observation = externalEvidenceToObservation(input.snapshotId, result, {
+      check,
+      hostname,
+      port,
+    });
+    return observation ? [observation] : [];
+  });
+  if (observations.length === 0) return 0;
+  return (await new ProbeObservationRepository(db).createMany(observations)).length;
+}

--- a/apps/collector/src/probes/external-evidence-persistence.test.ts
+++ b/apps/collector/src/probes/external-evidence-persistence.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { externalEvidenceToObservation } from './external-evidence-persistence.js';
+
+describe('externalEvidenceToObservation', () => {
+  it('persists determined TLS evidence with its typed check and target', () => {
+    const observation = externalEvidenceToObservation(
+      'snapshot-1',
+      {
+        status: 'OBSERVED',
+        observedAt: '2026-01-01T00:00:00.000Z',
+        evidence: {
+          kind: 'TLS_CERTIFICATE',
+          hostname: 'example.com',
+          resolvedAddress: '1.1.1.1',
+          port: 443,
+          protocol: 'TLSv1.3',
+          cipher: 'TLS_AES_256_GCM_SHA384',
+          hostnameAuthorized: true,
+          chainAuthorized: true,
+          subject: 'CN=example.com',
+          issuer: 'CN=CA',
+          subjectAlternativeNames: ['example.com'],
+          validFrom: '2026-01-01T00:00:00.000Z',
+          validTo: '2027-01-01T00:00:00.000Z',
+          fingerprintSha256: 'AA:BB',
+        },
+      },
+      { check: 'TLS_CERTIFICATE', hostname: 'unused' }
+    );
+
+    expect(observation).toMatchObject({
+      probeType: 'tls_cert',
+      status: 'success',
+      success: true,
+      hostname: 'example.com',
+      probeData: { check: 'TLS_CERTIFICATE', status: 'OBSERVED' },
+    });
+  });
+
+  it('persists UNKNOWN as an evidence row without promoting it to a signal', () => {
+    const observation = externalEvidenceToObservation(
+      'snapshot-1',
+      {
+        status: 'UNKNOWN',
+        unknown: {
+          reason: 'PROBE_FAILED',
+          explanation: 'TLS timed out',
+          action: 'RETRY_PROBE',
+          actionLabel: 'Retry TLS probe',
+          blocking: true,
+        },
+      },
+      { check: 'TLS_CERTIFICATE', hostname: 'example.com', port: 443 }
+    );
+
+    expect(observation).toMatchObject({
+      probeType: 'tls_cert',
+      status: 'error',
+      success: false,
+      errorMessage: 'TLS timed out',
+      probeData: {
+        check: 'TLS_CERTIFICATE',
+        status: 'UNKNOWN',
+        unknown: { action: 'RETRY_PROBE' },
+      },
+    });
+  });
+
+  it('does not persist an explicitly not-applicable check', () => {
+    expect(
+      externalEvidenceToObservation(
+        'snapshot-1',
+        { status: 'NOT_APPLICABLE', explanation: 'Mail-only domain' },
+        { check: 'HTTP_REACHABILITY', hostname: 'example.com' }
+      )
+    ).toBeNull();
+  });
+});

--- a/apps/collector/src/probes/external-evidence-persistence.ts
+++ b/apps/collector/src/probes/external-evidence-persistence.ts
@@ -1,0 +1,106 @@
+import type {
+  EvidenceCheckResult,
+  HomepageIndexabilityEvidence,
+  HttpReachabilityEvidence,
+  HttpRedirectEvidence,
+  RdapExpirationEvidence,
+  TLSCertificateEvidence,
+} from '@dns-ops/contracts';
+import type { NewProbeObservation } from '@dns-ops/db';
+
+type ExternalEvidence =
+  | RdapExpirationEvidence
+  | TLSCertificateEvidence
+  | HttpReachabilityEvidence
+  | HttpRedirectEvidence
+  | HomepageIndexabilityEvidence;
+
+type Check =
+  | 'RDAP_EXPIRATION'
+  | 'TLS_CERTIFICATE'
+  | 'HTTP_REACHABILITY'
+  | 'REDIRECT_TOPOLOGY'
+  | 'HOMEPAGE_INDEXABILITY';
+
+function checkForEvidence(evidence: ExternalEvidence): Check {
+  switch (evidence.kind) {
+    case 'RDAP_EXPIRATION':
+      return 'RDAP_EXPIRATION';
+    case 'TLS_CERTIFICATE':
+      return 'TLS_CERTIFICATE';
+    case 'HTTP_REACHABILITY':
+      return 'HTTP_REACHABILITY';
+    case 'HTTP_REDIRECT':
+      return 'REDIRECT_TOPOLOGY';
+    case 'HOMEPAGE_INDEXABILITY':
+      return 'HOMEPAGE_INDEXABILITY';
+  }
+}
+
+function probeType(check: Check): 'rdap' | 'tls_cert' | 'http' {
+  if (check === 'RDAP_EXPIRATION') return 'rdap';
+  if (check === 'TLS_CERTIFICATE') return 'tls_cert';
+  return 'http';
+}
+
+function hostnameForEvidence(evidence: ExternalEvidence): string {
+  switch (evidence.kind) {
+    case 'RDAP_EXPIRATION':
+      return evidence.domain;
+    case 'TLS_CERTIFICATE':
+      return evidence.hostname;
+    case 'HTTP_REACHABILITY':
+      return new URL(evidence.url).hostname;
+    case 'HTTP_REDIRECT':
+      return new URL(evidence.startUrl).hostname;
+    case 'HOMEPAGE_INDEXABILITY':
+      return new URL(evidence.requestedUrl).hostname;
+  }
+}
+
+function portForEvidence(evidence: ExternalEvidence): number | null {
+  if (evidence.kind === 'TLS_CERTIFICATE') return evidence.port;
+  if (evidence.kind === 'RDAP_EXPIRATION') return 443;
+  const url =
+    evidence.kind === 'HTTP_REDIRECT'
+      ? evidence.startUrl
+      : evidence.kind === 'HOMEPAGE_INDEXABILITY'
+        ? evidence.requestedUrl
+        : evidence.url;
+  return new URL(url).port
+    ? Number(new URL(url).port)
+    : new URL(url).protocol === 'https:'
+      ? 443
+      : 80;
+}
+
+export function externalEvidenceToObservation(
+  snapshotId: string,
+  result: EvidenceCheckResult<ExternalEvidence>,
+  fallback: { check: Check; hostname: string; port?: number }
+): NewProbeObservation | null {
+  if (result.status === 'NOT_APPLICABLE') return null;
+  const evidence = result.evidence;
+  const check = evidence ? checkForEvidence(evidence) : fallback.check;
+  const hostname = evidence ? hostnameForEvidence(evidence) : fallback.hostname;
+  const port = evidence ? portForEvidence(evidence) : (fallback.port ?? null);
+  const observedAt = result.status === 'OBSERVED' ? new Date(result.observedAt) : new Date();
+
+  return {
+    snapshotId,
+    probeType: probeType(check),
+    status: result.status === 'OBSERVED' ? 'success' : 'error',
+    hostname,
+    port,
+    success: result.status === 'OBSERVED',
+    errorMessage: result.status === 'UNKNOWN' ? result.unknown.explanation : null,
+    probedAt: observedAt,
+    responseTimeMs: evidence?.kind === 'HTTP_REACHABILITY' ? evidence.responseTimeMs : null,
+    probeData: {
+      check,
+      status: result.status,
+      evidence,
+      unknown: result.status === 'UNKNOWN' ? result.unknown : undefined,
+    },
+  };
+}

--- a/apps/collector/src/probes/http-web.test.ts
+++ b/apps/collector/src/probes/http-web.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest';
+import { collectHttpWebEvidence } from './http-web.js';
+
+const publicResolver = async () => ['93.184.216.34'];
+
+function response(body = '', init: ResponseInit = {}): Response {
+  const headers = new Headers({ 'content-type': 'text/html; charset=utf-8' });
+  new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+  return new Response(body, { ...init, status: init.status ?? 200, headers });
+}
+
+function fixtureFetcher(overrides: Record<string, Response> = {}) {
+  return vi.fn((url: string) => {
+    const fixed = overrides[url];
+    if (fixed) return Promise.resolve(fixed.clone());
+    if (url === 'http://example.com/') {
+      return Promise.resolve(
+        response('', { status: 301, headers: { location: 'https://example.com/' } })
+      );
+    }
+    if (url === 'http://www.example.com/') {
+      return Promise.resolve(
+        response('', { status: 308, headers: { location: 'https://example.com/' } })
+      );
+    }
+    if (url === 'https://www.example.com/') {
+      return Promise.resolve(
+        response('', { status: 301, headers: { location: 'https://example.com/' } })
+      );
+    }
+    return Promise.resolve(
+      response(
+        '<html><head><meta name="robots" content="noindex, nofollow"><link rel="canonical" href="/canonical"></head></html>',
+        { headers: { 'x-robots-tag': 'noindex' } }
+      )
+    );
+  });
+}
+
+describe('collectHttpWebEvidence', () => {
+  it('collects exactly the HTTP/HTTPS apex/www matrix with bounded manual redirects', async () => {
+    const fetcher = fixtureFetcher();
+    const result = await collectHttpWebEvidence('Example.COM.', {
+      fetcher,
+      resolveHostname: publicResolver,
+      now: () => new Date('2026-01-01T00:00:00Z'),
+    });
+
+    expect(result.starts.map((entry) => entry.startUrl)).toEqual([
+      'http://example.com/',
+      'https://example.com/',
+      'http://www.example.com/',
+      'https://www.example.com/',
+    ]);
+    expect(result.starts.every((entry) => entry.redirect.status === 'OBSERVED')).toBe(true);
+    const httpApex = result.starts[0].redirect;
+    expect(httpApex.status).toBe('OBSERVED');
+    if (httpApex.status !== 'OBSERVED') throw new Error('Expected redirect fixture');
+    expect(httpApex.evidence).toMatchObject({
+      finalUrl: 'https://example.com/',
+      hops: [
+        expect.objectContaining({ status: 301, location: 'https://example.com/' }),
+        expect.objectContaining({ status: 200, resolvedAddresses: ['93.184.216.34'] }),
+      ],
+    });
+    expect(result.starts[1].reachability).toMatchObject({
+      status: 'OBSERVED',
+      evidence: { url: 'https://example.com/', responseStatus: 200 },
+    });
+    expect(result.indexability).toEqual({
+      status: 'OBSERVED',
+      observedAt: '2026-01-01T00:00:00.000Z',
+      evidence: expect.objectContaining({
+        requestedUrl: 'https://example.com/',
+        finalUrl: 'https://example.com/',
+        xRobotsTags: ['noindex'],
+        metaRobots: ['noindex', 'nofollow'],
+        canonicalUrl: 'https://example.com/canonical',
+      }),
+    });
+    expect(fetcher.mock.calls.every(([, init]) => init.redirect === 'manual')).toBe(true);
+  });
+
+  it('permits a bounded redirect path but still validates each redirect hostname', async () => {
+    const fetcher = fixtureFetcher({
+      'https://example.com/': response('', {
+        status: 302,
+        headers: { location: '/welcome?lang=en' },
+      }),
+      'https://example.com/welcome?lang=en': response('<meta name="robots" content="index">'),
+    });
+    const result = await collectHttpWebEvidence('example.com', {
+      fetcher,
+      resolveHostname: publicResolver,
+    });
+
+    const redirect = result.starts[1].redirect;
+    expect(redirect.status).toBe('OBSERVED');
+    if (redirect.status !== 'OBSERVED') throw new Error('Expected redirect fixture');
+    expect(redirect.evidence.finalUrl).toBe('https://example.com/welcome?lang=en');
+    expect(result.indexability).toMatchObject({
+      status: 'OBSERVED',
+      evidence: { finalUrl: 'https://example.com/welcome?lang=en' },
+    });
+  });
+
+  it('keeps a redirect to a private address as actionable UNKNOWN', async () => {
+    const fetcher = fixtureFetcher({
+      'https://example.com/': response('', {
+        status: 302,
+        headers: { location: 'http://private.example/' },
+      }),
+    });
+    const resolver = async (hostname: string) =>
+      hostname === 'private.example' ? ['127.0.0.1'] : ['93.184.216.34'];
+    const result = await collectHttpWebEvidence('example.com', {
+      fetcher,
+      resolveHostname: resolver,
+    });
+
+    expect(result.starts[1].redirect).toMatchObject({
+      status: 'UNKNOWN',
+      unknown: { reason: 'EXTERNAL_DECISION_REQUIRED', action: 'REVIEW_MANUALLY' },
+    });
+    expect(result.starts[1].reachability).toMatchObject({ status: 'UNKNOWN' });
+    expect(result.indexability).toMatchObject({ status: 'UNKNOWN' });
+  });
+
+  it('stops and escalates sensitive redirect locations without persisting the target', async () => {
+    const fetcher = fixtureFetcher({
+      'https://example.com/': response('', {
+        status: 302,
+        headers: { location: 'https://outside.example/?access_token=redacted' },
+      }),
+    });
+    const result = await collectHttpWebEvidence('example.com', {
+      fetcher,
+      resolveHostname: publicResolver,
+    });
+
+    expect(result.starts[1].redirect).toMatchObject({
+      status: 'UNKNOWN',
+      unknown: {
+        reason: 'EXTERNAL_DECISION_REQUIRED',
+        action: 'REVIEW_MANUALLY',
+        actionLabel: 'Stop probing and review redirect target',
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('access_token=redacted');
+  });
+
+  it('caps redirect hops and homepage body inspection deterministically', async () => {
+    const loopFetcher = vi.fn((url: string) =>
+      Promise.resolve(response('', { status: 302, headers: { location: `${url}?next=1` } }))
+    );
+    const loopResult = await collectHttpWebEvidence('example.com', {
+      fetcher: loopFetcher,
+      resolveHostname: publicResolver,
+      maxRedirects: 1,
+    });
+    expect(loopResult.starts.every((entry) => entry.redirect.status === 'UNKNOWN')).toBe(true);
+
+    const largeFetcher = fixtureFetcher({
+      'https://example.com/': response(`<meta name="robots" content="noindex">${'x'.repeat(100)}`),
+    });
+    const largeResult = await collectHttpWebEvidence('example.com', {
+      fetcher: largeFetcher,
+      resolveHostname: publicResolver,
+      maxBodyBytes: 32,
+    });
+    expect(largeResult.indexability).toMatchObject({
+      status: 'OBSERVED',
+      evidence: { bodyBytesInspected: 32, bodyTruncated: true },
+    });
+  });
+
+  it('does not parse non-HTML bodies and preserves observed matrix evidence', async () => {
+    const fetcher = fixtureFetcher({
+      'https://example.com/': response('<meta name="robots" content="noindex">', {
+        headers: { 'content-type': 'application/json', 'x-robots-tag': ' NoIndex, NOFOLLOW ' },
+      }),
+    });
+    const result = await collectHttpWebEvidence('example.com', {
+      fetcher,
+      resolveHostname: publicResolver,
+    });
+
+    expect(result.starts[1].redirect.status).toBe('OBSERVED');
+    expect(result.indexability).toMatchObject({
+      status: 'UNKNOWN',
+      unknown: { reason: 'UNSUPPORTED_CHECK', action: 'REVIEW_MANUALLY' },
+    });
+  });
+
+  it('cancels response bodies on failed redirect paths', async () => {
+    const cancellations: string[] = [];
+    const fetcher = vi.fn((url: string) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('unused'));
+        },
+        cancel() {
+          cancellations.push(url);
+        },
+      });
+      return Promise.resolve(new Response(body, { status: 302 }));
+    });
+
+    const result = await collectHttpWebEvidence('example.com', {
+      fetcher,
+      resolveHostname: publicResolver,
+    });
+    await Promise.resolve();
+
+    expect(result.starts.every((entry) => entry.redirect.status === 'UNKNOWN')).toBe(true);
+    expect(cancellations).toHaveLength(4);
+  });
+
+  it('returns actionable UNKNOWN when DNS resolution misses the cumulative deadline', async () => {
+    const result = await collectHttpWebEvidence('example.com', {
+      fetcher: vi.fn(),
+      resolveHostname: () => new Promise<string[]>(() => undefined),
+      timeoutMs: 5,
+    });
+
+    expect(result.starts).toHaveLength(4);
+    expect(result.starts.every((entry) => entry.reachability.status === 'UNKNOWN')).toBe(true);
+    expect(result.indexability).toMatchObject({
+      status: 'UNKNOWN',
+      unknown: { reason: 'PROBE_FAILED', action: 'RETRY_PROBE' },
+    });
+  });
+
+  it('rejects arbitrary paths and resolver aliases without probing them', async () => {
+    await expect(
+      collectHttpWebEvidence('https://example.com/path', { fetcher: vi.fn() })
+    ).rejects.toThrow('registered hostname');
+
+    const fetcher = vi.fn();
+    const result = await collectHttpWebEvidence('example.com', {
+      fetcher,
+      resolveHostname: async () => ['alias.internal.example'],
+    });
+    expect(result.starts.every((entry) => entry.reachability.status === 'UNKNOWN')).toBe(true);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/apps/collector/src/probes/http-web.ts
+++ b/apps/collector/src/probes/http-web.ts
@@ -1,0 +1,435 @@
+import { isIP } from 'node:net';
+import type {
+  EvidenceCheckResult,
+  HomepageIndexabilityEvidence,
+  HttpReachabilityEvidence,
+  HttpRedirectEvidence,
+  HttpRedirectHopEvidence,
+} from '@dns-ops/contracts';
+import { checkResolvedIP, validateUrl } from './ssrf-guard.js';
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_MAX_REDIRECTS = 5;
+const DEFAULT_MAX_BODY_BYTES = 128 * 1024;
+
+type Fetcher = (input: string, init: RequestInit) => Promise<Response>;
+type Resolver = (hostname: string) => Promise<string[]>;
+
+export interface HttpWebCollectionOptions {
+  fetcher?: Fetcher;
+  resolveHostname?: Resolver;
+  timeoutMs?: number;
+  maxRedirects?: number;
+  maxBodyBytes?: number;
+  now?: () => Date;
+}
+
+export interface HttpWebStartEvidence {
+  startUrl: string;
+  reachability: EvidenceCheckResult<HttpReachabilityEvidence>;
+  redirect: EvidenceCheckResult<HttpRedirectEvidence>;
+}
+
+export interface HttpWebCollectionResult {
+  starts: HttpWebStartEvidence[];
+  indexability: EvidenceCheckResult<HomepageIndexabilityEvidence>;
+}
+
+interface FetchedHop {
+  hop: HttpRedirectHopEvidence;
+  response: Response;
+  responseTimeMs: number;
+}
+
+function deadlineError(): Error {
+  return new Error('HTTP evidence collection deadline exceeded');
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(deadlineError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(deadlineError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function validateRegisteredHostname(value: string): string {
+  const hostname = value.trim().toLowerCase().replace(/\.$/, '');
+  if (
+    !hostname ||
+    hostname.length > 253 ||
+    hostname.includes('/') ||
+    hostname.includes(':') ||
+    hostname.includes('[') ||
+    hostname.includes(']') ||
+    isIP(hostname) !== 0
+  ) {
+    throw new Error('HTTP evidence requires a registered hostname, not an IP literal');
+  }
+  const parsed = new URL(`https://${hostname}/`);
+  if (parsed.hostname !== hostname || !hostname.includes('.')) {
+    throw new Error('Invalid registered hostname');
+  }
+  return hostname;
+}
+
+async function defaultResolver(hostname: string): Promise<string[]> {
+  const { promises: dns } = await import('node:dns');
+  return [
+    ...new Set((await dns.lookup(hostname, { all: true })).map(({ address }) => address)),
+  ].sort();
+}
+
+async function safeAddresses(
+  hostname: string,
+  resolver: Resolver,
+  signal: AbortSignal
+): Promise<string[]> {
+  const resolved = await abortable(resolver(hostname), signal);
+  if (resolved.length === 0) throw new Error(`HTTP hostname ${hostname} did not resolve`);
+  const addresses = [...new Set(resolved)].sort();
+  for (const address of addresses) {
+    if (isIP(address) === 0 || address.includes('%')) {
+      throw new Error(`HTTP resolver returned a non-IP address: ${address}`);
+    }
+    const result = checkResolvedIP(address);
+    if (!result.allowed) throw new Error(`Unsafe HTTP address ${address}: ${result.reason}`);
+  }
+  return addresses;
+}
+
+function redirectContainsSensitiveQuery(url: URL): boolean {
+  return [...url.searchParams.keys()].some((key) =>
+    /(?:access[_-]?token|auth(?:entication)?|code|key|password|secret|session|signature|sig|token)/i.test(
+      key
+    )
+  );
+}
+
+function safeUrl(value: string, allowRedirectPath = false): URL {
+  const checked = validateUrl(value);
+  if (!checked.allowed || !checked.url) {
+    throw new Error(`Unsafe HTTP URL: ${checked.reason ?? 'invalid URL'}`);
+  }
+  const url = checked.url;
+  if (url.username || url.password || url.hash) {
+    throw new Error('Unsafe HTTP URL credentials or fragment');
+  }
+  if (allowRedirectPath && redirectContainsSensitiveQuery(url)) {
+    throw new Error('Redirect target contains sensitive query parameters');
+  }
+  if (!allowRedirectPath && (url.pathname !== '/' || url.search)) {
+    throw new Error('HTTP evidence only permits the registered homepage URL');
+  }
+  if (url.toString().length > 2_048) throw new Error('HTTP evidence URL exceeds 2048 characters');
+  return url;
+}
+
+async function fetchHop(
+  url: URL,
+  fetcher: Fetcher,
+  resolver: Resolver,
+  signal: AbortSignal,
+  now: () => Date
+): Promise<FetchedHop> {
+  const addresses = await safeAddresses(url.hostname, resolver, signal);
+  const startedAt = Date.now();
+  const response = await abortable(
+    fetcher(url.toString(), {
+      signal,
+      redirect: 'manual',
+      headers: {
+        Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.1',
+        'User-Agent': 'DNS-Ops-HTTP-Evidence/1.0',
+      },
+    }),
+    signal
+  );
+  const location = response.headers.get('location') ?? undefined;
+  return {
+    hop: {
+      url: url.toString(),
+      status: response.status,
+      location,
+      resolvedAddresses: addresses,
+      observedAt: now().toISOString(),
+    },
+    response,
+    responseTimeMs: Date.now() - startedAt,
+  };
+}
+
+function isRedirect(status: number): boolean {
+  return status >= 300 && status <= 399;
+}
+
+async function boundedText(
+  response: Response,
+  maxBodyBytes: number,
+  signal: AbortSignal
+): Promise<{ text: string; bytes: number; truncated: boolean }> {
+  if (!response.body) return { text: '', bytes: 0, truncated: false };
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  let truncated = false;
+  try {
+    while (true) {
+      const { done, value } = await abortable(reader.read(), signal);
+      if (done) break;
+      const remaining = maxBodyBytes - bytes;
+      if (value.byteLength > remaining) {
+        if (remaining > 0) chunks.push(value.slice(0, remaining));
+        bytes += Math.max(0, remaining);
+        truncated = true;
+        void reader.cancel('HTTP body size limit reached').catch(() => undefined);
+        break;
+      }
+      bytes += value.byteLength;
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return { text: Buffer.concat(chunks, bytes).toString('utf8'), bytes, truncated };
+}
+
+function normalizedRobotsDirectives(value: string): string[] {
+  return value
+    .split(',')
+    .map((directive) => directive.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function parseRobotsMeta(html: string): string[] {
+  const result: string[] = [];
+  const tags = html.match(/<meta\b[^>]*>/gi) ?? [];
+  for (const tag of tags) {
+    const name = /\bname\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(tag);
+    const content = /\bcontent\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(tag);
+    const metaName = (name?.[1] ?? name?.[2] ?? name?.[3] ?? '').toLowerCase();
+    const metaContent = content?.[1] ?? content?.[2] ?? content?.[3] ?? '';
+    if (metaName === 'robots' || metaName.endsWith('bot')) {
+      result.push(...normalizedRobotsDirectives(metaContent));
+    }
+  }
+  return result;
+}
+
+function parseCanonical(html: string, finalUrl: string): string | undefined {
+  const tags = html.match(/<link\b[^>]*>/gi) ?? [];
+  for (const tag of tags) {
+    const rel = /\brel\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(tag);
+    const href = /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(tag);
+    const relValue = (rel?.[1] ?? rel?.[2] ?? rel?.[3] ?? '').toLowerCase().split(/\s+/);
+    const hrefValue = href?.[1] ?? href?.[2] ?? href?.[3];
+    if (!relValue.includes('canonical') || !hrefValue) continue;
+    try {
+      return new URL(hrefValue, finalUrl).toString();
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function unknown(label: string, detail: string) {
+  const unsafeRedirect =
+    detail.startsWith('Unsafe HTTP') || detail.startsWith('Redirect target contains sensitive');
+  return unsafeRedirect
+    ? {
+        reason: 'EXTERNAL_DECISION_REQUIRED' as const,
+        explanation: `${label} probing stopped: ${detail}`,
+        action: 'REVIEW_MANUALLY' as const,
+        actionLabel: 'Stop probing and review redirect target',
+        blocking: true,
+      }
+    : {
+        reason: 'PROBE_FAILED' as const,
+        explanation: `${label} evidence could not be collected: ${detail}`,
+        action: 'RETRY_PROBE' as const,
+        actionLabel: `Retry ${label.toLowerCase()} probe`,
+        blocking: true,
+      };
+}
+
+function releaseResponse(response: Response | undefined): void {
+  void response?.body?.cancel().catch(() => undefined);
+}
+
+async function collectOne(
+  startUrl: string,
+  fetcher: Fetcher,
+  resolver: Resolver,
+  signal: AbortSignal,
+  maxRedirects: number,
+  now: () => Date
+): Promise<HttpWebStartEvidence & { final?: FetchedHop; hops?: HttpRedirectHopEvidence[] }> {
+  try {
+    let current = safeUrl(startUrl);
+    const hops: HttpRedirectHopEvidence[] = [];
+    let final: FetchedHop | undefined;
+
+    for (let redirects = 0; redirects <= maxRedirects; redirects++) {
+      const fetched = await fetchHop(current, fetcher, resolver, signal, now);
+      hops.push(fetched.hop);
+      if (!isRedirect(fetched.response.status)) {
+        final = fetched;
+        break;
+      }
+      if (!fetched.hop.location) {
+        releaseResponse(fetched.response);
+        throw new Error(`Redirect ${fetched.response.status} lacks Location`);
+      }
+      if (redirects === maxRedirects) {
+        releaseResponse(fetched.response);
+        throw new Error(`Redirect limit of ${maxRedirects} exceeded`);
+      }
+      try {
+        current = safeUrl(new URL(fetched.hop.location, current).toString(), true);
+      } catch (error) {
+        releaseResponse(fetched.response);
+        throw error;
+      }
+      releaseResponse(fetched.response);
+    }
+    if (!final) throw new Error('HTTP response did not reach a final endpoint');
+
+    const redirectEvidence: HttpRedirectEvidence = {
+      kind: 'HTTP_REDIRECT',
+      startUrl,
+      hops,
+      finalUrl: final.hop.url,
+      truncated: false,
+    };
+    const reachability: HttpReachabilityEvidence = {
+      kind: 'HTTP_REACHABILITY',
+      url: final.hop.url,
+      responseStatus: final.hop.status,
+      resolvedAddresses: final.hop.resolvedAddresses,
+      responseTimeMs: final.responseTimeMs,
+    };
+    const observedAt = now().toISOString();
+    return {
+      startUrl,
+      reachability: { status: 'OBSERVED', observedAt, evidence: reachability },
+      redirect: { status: 'OBSERVED', observedAt, evidence: redirectEvidence },
+      final,
+      hops,
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      startUrl,
+      reachability: { status: 'UNKNOWN', unknown: unknown('HTTP reachability', detail) },
+      redirect: { status: 'UNKNOWN', unknown: unknown('HTTP redirect topology', detail) },
+    };
+  }
+}
+
+export async function collectHttpWebEvidence(
+  registeredHostname: string,
+  options: HttpWebCollectionOptions = {}
+): Promise<HttpWebCollectionResult> {
+  const hostname = validateRegisteredHostname(registeredHostname);
+  const fetcher = options.fetcher ?? fetch;
+  const resolver = options.resolveHostname ?? defaultResolver;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  if (!Number.isInteger(maxRedirects) || maxRedirects < 0 || maxRedirects > 8) {
+    throw new Error('HTTP redirect limit must be an integer from 0 through 8');
+  }
+  if (!Number.isInteger(maxBodyBytes) || maxBodyBytes < 1 || maxBodyBytes > 1024 * 1024) {
+    throw new Error('HTTP body limit must be 1 through 1048576 bytes');
+  }
+  const now = options.now ?? (() => new Date());
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), timeoutMs);
+  const starts = [
+    `http://${hostname}/`,
+    `https://${hostname}/`,
+    `http://www.${hostname}/`,
+    `https://www.${hostname}/`,
+  ];
+
+  const collected: Array<HttpWebStartEvidence & { final?: FetchedHop }> = [];
+  try {
+    for (const startUrl of starts) {
+      collected.push(
+        await collectOne(startUrl, fetcher, resolver, controller.signal, maxRedirects, now)
+      );
+    }
+    const startEvidence = collected.map(({ final: _final, ...entry }) => entry);
+    const selected = collected[1];
+    if (!selected.final || selected.redirect.status !== 'OBSERVED') {
+      return {
+        starts: startEvidence,
+        indexability: {
+          status: 'UNKNOWN',
+          unknown: unknown('Homepage indexability', 'HTTPS apex redirect evidence was unavailable'),
+        },
+      };
+    }
+
+    const contentType = selected.final.response.headers
+      .get('content-type')
+      ?.split(';')[0]
+      .trim()
+      .toLowerCase();
+    if (contentType !== 'text/html' && contentType !== 'application/xhtml+xml') {
+      return {
+        starts: startEvidence,
+        indexability: {
+          status: 'UNKNOWN',
+          unknown: {
+            reason: 'UNSUPPORTED_CHECK',
+            explanation: `Homepage indexability cannot be parsed from ${contentType ?? 'an unspecified'} content type.`,
+            action: 'REVIEW_MANUALLY',
+            actionLabel: 'Review homepage response manually',
+            blocking: true,
+          },
+        },
+      };
+    }
+
+    try {
+      const body = await boundedText(selected.final.response, maxBodyBytes, controller.signal);
+      const robotsHeader = selected.final.response.headers.get('x-robots-tag');
+      const evidence: HomepageIndexabilityEvidence = {
+        kind: 'HOMEPAGE_INDEXABILITY',
+        requestedUrl: selected.startUrl,
+        finalUrl: selected.final.hop.url,
+        responseStatus: selected.final.hop.status,
+        xRobotsTags: robotsHeader ? normalizedRobotsDirectives(robotsHeader) : [],
+        metaRobots: parseRobotsMeta(body.text),
+        canonicalUrl: parseCanonical(body.text, selected.final.hop.url),
+        bodyBytesInspected: body.bytes,
+        bodyTruncated: body.truncated,
+      };
+      return {
+        starts: startEvidence,
+        indexability: { status: 'OBSERVED', observedAt: now().toISOString(), evidence },
+      };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      return {
+        starts: startEvidence,
+        indexability: { status: 'UNKNOWN', unknown: unknown('Homepage indexability', detail) },
+      };
+    }
+  } finally {
+    for (const entry of collected) releaseResponse(entry.final?.response);
+    clearTimeout(deadline);
+  }
+}

--- a/apps/collector/src/probes/index.ts
+++ b/apps/collector/src/probes/index.ts
@@ -14,6 +14,7 @@ export {
   probeAllowlist,
   probeAllowlistManager,
 } from './allowlist.js';
+export { externalEvidenceToObservation } from './external-evidence-persistence.js';
 export type {
   HttpWebCollectionOptions,
   HttpWebCollectionResult,

--- a/apps/collector/src/probes/index.ts
+++ b/apps/collector/src/probes/index.ts
@@ -14,6 +14,12 @@ export {
   probeAllowlist,
   probeAllowlistManager,
 } from './allowlist.js';
+export type {
+  HttpWebCollectionOptions,
+  HttpWebCollectionResult,
+  HttpWebStartEvidence,
+} from './http-web.js';
+export { collectHttpWebEvidence } from './http-web.js';
 export type { MTASTSPolicy, MTASTSProbeResult } from './mta-sts.js';
 // MTA-STS Probe
 export { fetchMTASTSPolicy, validateMTASTSTxtRecord } from './mta-sts.js';

--- a/apps/collector/src/probes/index.ts
+++ b/apps/collector/src/probes/index.ts
@@ -17,6 +17,8 @@ export {
 export type { MTASTSPolicy, MTASTSProbeResult } from './mta-sts.js';
 // MTA-STS Probe
 export { fetchMTASTSPolicy, validateMTASTSTxtRecord } from './mta-sts.js';
+export type { RdapCollectionOptions } from './rdap.js';
+export { collectRdapExpirationEvidence } from './rdap.js';
 export type {} from './semaphore.js';
 // Probe Semaphore (concurrency control)
 export { getProbeSemaphore, resetProbeSemaphore, Semaphore } from './semaphore.js';
@@ -25,4 +27,4 @@ export type { SMTPProbeResult } from './smtp-starttls.js';
 export { probeMXHosts, probeSMTPStarttls } from './smtp-starttls.js';
 export type { SSRFCheckResult } from './ssrf-guard.js';
 // SSRF Guard
-export { checkResolvedIP, checkSSRF, validateUrl } from './ssrf-guard.js';
+export { checkResolvedIP, checkSSRF, resolveAndCheck, validateUrl } from './ssrf-guard.js';

--- a/apps/collector/src/probes/index.ts
+++ b/apps/collector/src/probes/index.ts
@@ -28,3 +28,10 @@ export { probeMXHosts, probeSMTPStarttls } from './smtp-starttls.js';
 export type { SSRFCheckResult } from './ssrf-guard.js';
 // SSRF Guard
 export { checkResolvedIP, checkSSRF, resolveAndCheck, validateUrl } from './ssrf-guard.js';
+export type {
+  TLSCertificateCollectionOptions,
+  TLSConnector,
+  TLSProbeSocket,
+  TLSSocketFactory,
+} from './tls-certificate.js';
+export { collectTlsCertificateEvidence } from './tls-certificate.js';

--- a/apps/collector/src/probes/persist-observations.ts
+++ b/apps/collector/src/probes/persist-observations.ts
@@ -5,7 +5,7 @@
  * Used by probe routes after collecting probe results.
  */
 
-import { ProbeObservationRepository } from '@dns-ops/db';
+import { type ProbeData, ProbeObservationRepository } from '@dns-ops/db';
 import { getCollectorLogger } from '../middleware/error-tracking.js';
 import type { Env } from '../types.js';
 import type { MTASTSProbeResult } from './mta-sts.js';
@@ -22,6 +22,7 @@ export type ProbeStatus =
   | 'refused'
   | 'ssrf_blocked'
   | 'allowlist_denied'
+  | 'parse_error'
   | 'error';
 
 /**
@@ -173,14 +174,14 @@ export async function persistProbeObservations(
   _tenantId: string,
   observations: Array<{
     snapshotId: string;
-    probeType: 'smtp_starttls' | 'mta_sts';
+    probeType: 'smtp_starttls' | 'mta_sts' | 'tls_cert' | 'http' | 'rdap';
     status: string;
     hostname: string;
     port: number;
     success: boolean;
     errorMessage: string | null;
     responseTimeMs: number;
-    probeData: Record<string, unknown> | null;
+    probeData: ProbeData | null;
   }>
 ): Promise<number> {
   if (!db) {

--- a/apps/collector/src/probes/rdap.test.ts
+++ b/apps/collector/src/probes/rdap.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi } from 'vitest';
+import { collectRdapExpirationEvidence } from './rdap.js';
+
+const bootstrap = {
+  services: [[['com'], ['https://rdap.example/']]],
+};
+
+function jsonResponse(value: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+const publicResolver = async () => ['93.184.216.34'];
+
+describe('collectRdapExpirationEvidence', () => {
+  it('uses IANA bootstrap and returns traceable expiration evidence', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(bootstrap))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          objectClassName: 'domain',
+          ldhName: 'example.com',
+          events: [
+            { eventAction: 'registration', eventDate: '2020-01-01T00:00:00Z' },
+            { eventAction: 'expiration', eventDate: '2030-01-01T00:00:00Z' },
+          ],
+          notices: [{ title: 'Terms of Use' }],
+        })
+      );
+
+    const result = await collectRdapExpirationEvidence('Example.COM.', {
+      fetcher,
+      resolveHostname: publicResolver,
+      now: () => new Date('2026-01-01T00:00:00Z'),
+    });
+
+    expect(result).toEqual({
+      status: 'OBSERVED',
+      observedAt: '2026-01-01T00:00:00.000Z',
+      evidence: expect.objectContaining({
+        domain: 'example.com',
+        sourceUrl: 'https://rdap.example/domain/example.com',
+        expirationDate: '2030-01-01T00:00:00Z',
+        notices: ['Terms of Use'],
+      }),
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls.every((call) => call[1].redirect === 'error')).toBe(true);
+  });
+
+  it('keeps a successful response without an expiration event actionable UNKNOWN', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(bootstrap))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          objectClassName: 'domain',
+          ldhName: 'example.com',
+          events: [{ eventAction: 'registration', eventDate: '2020-01-01T00:00:00Z' }],
+        })
+      );
+
+    const result = await collectRdapExpirationEvidence('example.com', {
+      fetcher,
+      resolveHostname: publicResolver,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown).toMatchObject({
+      reason: 'EXTERNAL_DECISION_REQUIRED',
+      action: 'REVIEW_MANUALLY',
+    });
+    expect(result.evidence?.events).toEqual([
+      { action: 'registration', date: '2020-01-01T00:00:00Z' },
+    ]);
+  });
+
+  it('rejects an RDAP service that resolves to a private address', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        services: [[['com'], ['https://private-rdap.example/']]],
+      })
+    );
+    const resolver = async (hostname: string) =>
+      hostname === 'private-rdap.example' ? ['127.0.0.1'] : ['93.184.216.34'];
+
+    const result = await collectRdapExpirationEvidence('example.com', {
+      fetcher,
+      resolveHostname: resolver,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown.explanation).toContain('Unsafe RDAP address');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces response-size and JSON bounds', async () => {
+    const oversized = vi.fn().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-length': '9999' },
+      })
+    );
+    const streamedOversized = vi.fn().mockResolvedValueOnce(new Response('x'.repeat(11)));
+    const malformed = vi.fn().mockResolvedValueOnce(new Response('{broken', { status: 200 }));
+
+    const tooLarge = await collectRdapExpirationEvidence('example.com', {
+      fetcher: oversized,
+      resolveHostname: publicResolver,
+      maxResponseBytes: 10,
+    });
+    const streamedTooLarge = await collectRdapExpirationEvidence('example.com', {
+      fetcher: streamedOversized,
+      resolveHostname: publicResolver,
+      maxResponseBytes: 10,
+    });
+    const invalidJson = await collectRdapExpirationEvidence('example.com', {
+      fetcher: malformed,
+      resolveHostname: publicResolver,
+    });
+
+    expect(tooLarge.status).toBe('UNKNOWN');
+    expect(streamedTooLarge.status).toBe('UNKNOWN');
+    expect(invalidJson.status).toBe('UNKNOWN');
+    if (
+      tooLarge.status !== 'UNKNOWN' ||
+      streamedTooLarge.status !== 'UNKNOWN' ||
+      invalidJson.status !== 'UNKNOWN'
+    ) {
+      throw new Error('Expected bounded UNKNOWN fixtures');
+    }
+    expect(tooLarge.unknown.explanation).toContain('exceeds 10 bytes');
+    expect(streamedTooLarge.unknown.explanation).toContain('exceeds 10 bytes');
+    expect(invalidJson.unknown.explanation).toContain('not valid JSON');
+  });
+
+  it('returns unsupported UNKNOWN when IANA has no HTTPS service', async () => {
+    const result = await collectRdapExpirationEvidence('example.invalid', {
+      fetcher: vi.fn().mockResolvedValue(jsonResponse({ services: [] })),
+      resolveHostname: publicResolver,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown).toMatchObject({
+      reason: 'UNSUPPORTED_CHECK',
+      action: 'NOT_CURRENTLY_OBSERVABLE',
+    });
+  });
+
+  it('keeps mismatched and conflicting domain evidence UNKNOWN', async () => {
+    const mismatchFetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(bootstrap))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          objectClassName: 'domain',
+          ldhName: 'other.example',
+          events: [{ eventAction: 'expiration', eventDate: '2030-01-01T00:00:00Z' }],
+        })
+      );
+    const conflictFetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(bootstrap))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          objectClassName: 'domain',
+          ldhName: 'example.com',
+          events: [
+            { eventAction: 'expiration', eventDate: '2030-01-01T00:00:00Z' },
+            { eventAction: 'expiration', eventDate: '2031-01-01T00:00:00Z' },
+          ],
+        })
+      );
+
+    const mismatch = await collectRdapExpirationEvidence('example.com', {
+      fetcher: mismatchFetcher,
+      resolveHostname: publicResolver,
+    });
+    const conflict = await collectRdapExpirationEvidence('example.com', {
+      fetcher: conflictFetcher,
+      resolveHostname: publicResolver,
+    });
+
+    expect(mismatch.status).toBe('UNKNOWN');
+    expect(conflict.status).toBe('UNKNOWN');
+    if (mismatch.status !== 'UNKNOWN' || conflict.status !== 'UNKNOWN') {
+      throw new Error('Expected inconsistent UNKNOWN fixtures');
+    }
+    expect(mismatch.unknown.explanation).toContain('identity does not match');
+    expect(conflict.unknown).toMatchObject({
+      reason: 'EXTERNAL_DECISION_REQUIRED',
+      action: 'REVIEW_MANUALLY',
+    });
+  });
+
+  it.each([
+    '2021-02-29T00:00:00Z',
+    '2023-02-30T00:00:00Z',
+    '2020-01-01T24:00:00Z',
+  ])('rejects impossible RFC3339 event date %s', async (eventDate) => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(bootstrap))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          objectClassName: 'domain',
+          ldhName: 'example.com',
+          events: [{ eventAction: 'expiration', eventDate }],
+        })
+      );
+
+    const result = await collectRdapExpirationEvidence('example.com', {
+      fetcher,
+      resolveHostname: publicResolver,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown).toMatchObject({
+      reason: 'EXTERNAL_DECISION_REQUIRED',
+      action: 'REVIEW_MANUALLY',
+    });
+  });
+
+  it('does not await a stalled stream cancellation after enforcing the byte cap', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('x'.repeat(11)));
+      },
+      cancel() {
+        return new Promise<void>(() => undefined);
+      },
+    });
+    const fetcher = vi.fn().mockResolvedValue(new Response(body));
+
+    const result = await Promise.race([
+      collectRdapExpirationEvidence('example.com', {
+        fetcher,
+        resolveHostname: publicResolver,
+        maxResponseBytes: 10,
+        timeoutMs: 20,
+      }),
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(() => reject(new Error('collector remained pending')), 100)
+      ),
+    ]);
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown.explanation).toContain('exceeds 10 bytes');
+  });
+
+  it('aborts a stalled resolver within the collection deadline', async () => {
+    const stalledResolver = () => new Promise<string[]>(() => undefined);
+    const result = await collectRdapExpirationEvidence('example.com', {
+      fetcher: vi.fn(),
+      resolveHostname: stalledResolver,
+      timeoutMs: 5,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown.explanation).toContain('deadline exceeded');
+  });
+
+  it('aborts a stalled bootstrap request', async () => {
+    const fetcher = vi.fn(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        })
+    );
+
+    const result = await collectRdapExpirationEvidence('example.com', {
+      fetcher,
+      resolveHostname: publicResolver,
+      timeoutMs: 5,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown).toMatchObject({ reason: 'PROBE_FAILED', action: 'RETRY_PROBE' });
+  });
+});

--- a/apps/collector/src/probes/rdap.ts
+++ b/apps/collector/src/probes/rdap.ts
@@ -1,0 +1,355 @@
+import type { EvidenceCheckResult, RdapExpirationEvidence } from '@dns-ops/contracts';
+import { checkResolvedIP, validateUrl } from './ssrf-guard.js';
+
+const IANA_DNS_BOOTSTRAP_URL = 'https://data.iana.org/rdap/dns.json';
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 512 * 1024;
+
+type Fetcher = (input: string, init: RequestInit) => Promise<Response>;
+type Resolver = (hostname: string) => Promise<string[]>;
+
+function abortError(): Error {
+  return new Error('RDAP collection deadline exceeded');
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(abortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+interface RdapBootstrap {
+  services?: unknown;
+}
+
+interface RdapDomainResponse {
+  objectClassName?: unknown;
+  ldhName?: unknown;
+  events?: unknown;
+  notices?: unknown;
+}
+
+export interface RdapCollectionOptions {
+  fetcher?: Fetcher;
+  resolveHostname?: Resolver;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+  now?: () => Date;
+}
+
+function probeUnknown(detail: string) {
+  return {
+    reason: 'PROBE_FAILED' as const,
+    explanation: `RDAP expiration evidence could not be collected: ${detail}`,
+    action: 'RETRY_PROBE' as const,
+    actionLabel: 'Retry RDAP probe',
+    blocking: true,
+  };
+}
+
+function validateDomain(domain: string): string {
+  const normalized = domain.trim().toLowerCase().replace(/\.$/, '');
+  if (!normalized || normalized.length > 253 || normalized.includes('/')) {
+    throw new Error('Invalid registered domain name');
+  }
+  const parsed = new URL(`https://${normalized}/`);
+  if (parsed.hostname !== normalized || !normalized.includes('.')) {
+    throw new Error('Invalid registered domain name');
+  }
+  return normalized;
+}
+
+async function defaultResolver(hostname: string): Promise<string[]> {
+  const { promises: dns } = await import('node:dns');
+  return (await dns.lookup(hostname, { all: true })).map(({ address }) => address);
+}
+
+async function assertSafeHttps(
+  url: string,
+  resolveHostname: Resolver,
+  signal: AbortSignal
+): Promise<URL> {
+  const checked = validateUrl(url);
+  if (!checked.allowed || !checked.url || checked.url.protocol !== 'https:') {
+    throw new Error(`Unsafe RDAP URL: ${checked.reason ?? 'HTTPS is required'}`);
+  }
+  if (checked.url.username || checked.url.password || checked.url.hash) {
+    throw new Error('Unsafe RDAP URL credentials or fragment');
+  }
+
+  const addresses = await abortable(resolveHostname(checked.url.hostname), signal);
+  if (addresses.length === 0) throw new Error('RDAP hostname did not resolve');
+  for (const address of addresses) {
+    const addressCheck = checkResolvedIP(address);
+    if (!addressCheck.allowed) {
+      throw new Error(`Unsafe RDAP address ${address}: ${addressCheck.reason}`);
+    }
+  }
+  return checked.url;
+}
+
+async function readBoundedBody(
+  response: Response,
+  maxResponseBytes: number,
+  signal: AbortSignal
+): Promise<string> {
+  const declaredLengthHeader = response.headers.get('content-length');
+  if (declaredLengthHeader !== null) {
+    const declaredLength = Number(declaredLengthHeader);
+    if (Number.isFinite(declaredLength) && declaredLength > maxResponseBytes) {
+      throw new Error(`RDAP response exceeds ${maxResponseBytes} bytes`);
+    }
+  }
+
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytesRead = 0;
+  try {
+    while (true) {
+      const { done, value } = await abortable(reader.read(), signal);
+      if (done) break;
+      bytesRead += value.byteLength;
+      if (bytesRead > maxResponseBytes) {
+        void reader.cancel('RDAP response size limit exceeded').catch(() => undefined);
+        throw new Error(`RDAP response exceeds ${maxResponseBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, bytesRead).toString('utf8');
+}
+
+async function fetchBoundedJson(
+  url: string,
+  fetcher: Fetcher,
+  resolveHostname: Resolver,
+  signal: AbortSignal,
+  maxResponseBytes: number
+): Promise<{ status: number; value: unknown }> {
+  await assertSafeHttps(url, resolveHostname, signal);
+  const response = await abortable(
+    fetcher(url, {
+      signal,
+      redirect: 'error',
+      headers: {
+        Accept: 'application/rdap+json, application/json',
+        'User-Agent': 'DNS-Ops-RDAP/1.0',
+      },
+    }),
+    signal
+  );
+  const body = await readBoundedBody(response, maxResponseBytes, signal);
+  if (!response.ok) throw new Error(`RDAP HTTP ${response.status}`);
+  try {
+    return { status: response.status, value: JSON.parse(body) };
+  } catch {
+    throw new Error('RDAP response is not valid JSON');
+  }
+}
+
+function serviceUrlFromBootstrap(bootstrap: RdapBootstrap, domain: string): string | null {
+  if (!Array.isArray(bootstrap.services)) return null;
+  const labels = domain.split('.');
+  let best: { suffixLength: number; url: string } | null = null;
+
+  for (const service of bootstrap.services) {
+    if (!Array.isArray(service) || !Array.isArray(service[0]) || !Array.isArray(service[1]))
+      continue;
+    const suffixes = service[0].filter((value): value is string => typeof value === 'string');
+    const urls = service[1].filter((value): value is string => typeof value === 'string');
+    const httpsUrl = urls.find((url) => url.startsWith('https://'));
+    if (!httpsUrl) continue;
+
+    for (const suffix of suffixes) {
+      const normalizedSuffix = suffix.toLowerCase().replace(/^\./, '');
+      const suffixLabels = normalizedSuffix.split('.');
+      if (labels.slice(-suffixLabels.length).join('.') !== normalizedSuffix) continue;
+      if (!best || suffixLabels.length > best.suffixLength) {
+        best = { suffixLength: suffixLabels.length, url: httpsUrl };
+      }
+    }
+  }
+
+  return best?.url ?? null;
+}
+
+const RFC3339_DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|([+-])(\d{2}):(\d{2}))$/;
+
+function isValidRfc3339DateTime(value: string): boolean {
+  const match = RFC3339_DATE_TIME.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = match[8] === undefined ? 0 : Number(match[8]);
+  const offsetMinute = match[9] === undefined ? 0 : Number(match[9]);
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) return false;
+  if (offsetHour > 23 || offsetMinute > 59) return false;
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return day >= 1 && day <= daysInMonth && !Number.isNaN(Date.parse(value));
+}
+
+function parseEvents(value: unknown): {
+  events: Array<{ action: string; date: string }>;
+  invalid: boolean;
+} {
+  if (value === undefined) return { events: [], invalid: false };
+  if (!Array.isArray(value)) return { events: [], invalid: true };
+
+  const events: Array<{ action: string; date: string }> = [];
+  let invalid = false;
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') {
+      invalid = true;
+      continue;
+    }
+    const candidate = entry as { eventAction?: unknown; eventDate?: unknown };
+    if (
+      typeof candidate.eventAction !== 'string' ||
+      typeof candidate.eventDate !== 'string' ||
+      !isValidRfc3339DateTime(candidate.eventDate)
+    ) {
+      invalid = true;
+      continue;
+    }
+    events.push({ action: candidate.eventAction, date: candidate.eventDate });
+  }
+  return { events, invalid };
+}
+
+function parseNotices(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object') return [];
+    const title = (entry as { title?: unknown }).title;
+    return typeof title === 'string' ? [title] : [];
+  });
+}
+
+export async function collectRdapExpirationEvidence(
+  registeredDomain: string,
+  options: RdapCollectionOptions = {}
+): Promise<EvidenceCheckResult<RdapExpirationEvidence>> {
+  const fetcher = options.fetcher ?? fetch;
+  const resolveHostname = options.resolveHostname ?? defaultResolver;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxResponseBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+  const now = options.now ?? (() => new Date());
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), timeoutMs);
+  let domain: string;
+
+  try {
+    domain = validateDomain(registeredDomain);
+    const bootstrapResult = await fetchBoundedJson(
+      IANA_DNS_BOOTSTRAP_URL,
+      fetcher,
+      resolveHostname,
+      controller.signal,
+      maxResponseBytes
+    );
+    const serviceUrl = serviceUrlFromBootstrap(bootstrapResult.value as RdapBootstrap, domain);
+    if (!serviceUrl) {
+      return {
+        status: 'UNKNOWN',
+        unknown: {
+          reason: 'UNSUPPORTED_CHECK',
+          explanation: `IANA RDAP bootstrap has no HTTPS service for ${domain}.`,
+          action: 'NOT_CURRENTLY_OBSERVABLE',
+          actionLabel: 'RDAP expiration is not currently observable',
+          blocking: true,
+        },
+      };
+    }
+
+    const serviceBase = serviceUrl.endsWith('/') ? serviceUrl : `${serviceUrl}/`;
+    const sourceUrl = new URL(`domain/${encodeURIComponent(domain)}`, serviceBase).toString();
+    const domainResult = await fetchBoundedJson(
+      sourceUrl,
+      fetcher,
+      resolveHostname,
+      controller.signal,
+      maxResponseBytes
+    );
+    const response = domainResult.value as RdapDomainResponse;
+    if (
+      response.objectClassName !== 'domain' ||
+      typeof response.ldhName !== 'string' ||
+      response.ldhName.toLowerCase().replace(/\.$/, '') !== domain
+    ) {
+      throw new Error(`RDAP response identity does not match ${domain}`);
+    }
+    const parsedEvents = parseEvents(response.events);
+    const events = parsedEvents.events;
+    const expirations = events.filter((event) =>
+      ['expiration', 'expiry'].includes(event.action.toLowerCase())
+    );
+    const expirationInstants = new Set(expirations.map((event) => Date.parse(event.date)));
+    const expiration = expirations[0];
+    const evidence: RdapExpirationEvidence = {
+      kind: 'RDAP_EXPIRATION',
+      domain,
+      sourceUrl,
+      responseStatus: domainResult.status,
+      events,
+      expirationDate: expiration?.date,
+      notices: parseNotices(response.notices),
+    };
+
+    if (parsedEvents.invalid || expirationInstants.size > 1) {
+      return {
+        status: 'UNKNOWN',
+        observedAt: now().toISOString(),
+        evidence,
+        unknown: {
+          reason: 'EXTERNAL_DECISION_REQUIRED',
+          explanation: `RDAP returned malformed or conflicting event evidence for ${domain}.`,
+          action: 'REVIEW_MANUALLY',
+          actionLabel: 'Review RDAP events manually',
+          blocking: true,
+        },
+      };
+    }
+
+    if (!expiration) {
+      return {
+        status: 'UNKNOWN',
+        observedAt: now().toISOString(),
+        evidence,
+        unknown: {
+          reason: 'EXTERNAL_DECISION_REQUIRED',
+          explanation: `RDAP returned no expiration event for ${domain}.`,
+          action: 'REVIEW_MANUALLY',
+          actionLabel: 'Review registrar expiration manually',
+          blocking: true,
+        },
+      };
+    }
+
+    return { status: 'OBSERVED', observedAt: now().toISOString(), evidence };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { status: 'UNKNOWN', unknown: probeUnknown(detail) };
+  } finally {
+    clearTimeout(deadline);
+  }
+}

--- a/apps/collector/src/probes/ssrf-guard.test.ts
+++ b/apps/collector/src/probes/ssrf-guard.test.ts
@@ -317,6 +317,30 @@ describe('PR-06.1: IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)', () => {
     expect(result.blockedCategory).toBe('loopback');
   });
 
+  it.each([
+    '0:0:0:0:0:ffff:127.0.0.1',
+    '0:0:0:0:0:ffff:7f00:1',
+    '0000:0000:0000:0000:0000:ffff:7f00:0001',
+  ])('blocks expanded IPv4-mapped loopback %s', (address) => {
+    const result = checkSSRF(address);
+    expect(result.allowed).toBe(false);
+    expect(result.blockedCategory).toBe('loopback');
+  });
+
+  it('allows expanded mapped public IPv4', () => {
+    expect(checkSSRF('0:0:0:0:0:ffff:8.8.8.8').allowed).toBe(true);
+  });
+
+  it.each([
+    '0:0:0:0:0:ffff:127.0.0.1%lo',
+    '0:0:0:0:0:ffff:7f00:1%lo',
+    'fe80::1%eth0',
+  ])('rejects zone-scoped IPv6 target %s', (address) => {
+    const result = checkSSRF(address);
+    expect(result.allowed).toBe(false);
+    expect(result.blockedCategory).toBe('invalid');
+  });
+
   // Well-known IPv6 addresses unrelated to IPv4-mapped
   it('should allow 64:ff9b:: (IPv4/IPv6 translation prefix, RFC 6052)', () => {
     const result = checkSSRF('64:ff9b::');
@@ -360,11 +384,24 @@ describe('PR-06.1: Link-Local Full Range Coverage (169.254.x)', () => {
     expect(result.blockedCategory).toBe('link-local');
   });
 
-  it('should block any address in fe80::/10 range', () => {
-    // fe80:: to febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
-    const result = checkSSRF('fe80:0000:0000:0000:0000:0000:0000:0001');
+  it.each([
+    'fe80::1',
+    'fe90::1',
+    'febf::1',
+  ])('should block %s across the complete fe80::/10 range', (address) => {
+    const result = checkSSRF(address);
     expect(result.allowed).toBe(false);
     expect(result.blockedCategory).toBe('link-local');
+  });
+
+  it.each([
+    'ff00::1',
+    'ff02::1',
+    'ffff::1',
+  ])('should block %s across the complete ff00::/8 range', (address) => {
+    const result = checkSSRF(address);
+    expect(result.allowed).toBe(false);
+    expect(result.blockedCategory).toBe('multicast');
   });
 
   it('should allow fec0:: (old site-local, now reserved)', () => {
@@ -495,10 +532,10 @@ describe('PR-06.1: IPv4 Cidr Notation Edge Cases', () => {
     expect(result.allowed).toBe(true); // Treated as hostname
   });
 
-  it('should handle IPv4 with port number', () => {
-    // Note: This isn't IP notation, treated as hostname
+  it('blocks an IPv4 address with a port when passed as a bare target', () => {
     const result = checkSSRF('192.0.2.1:8080');
-    expect(result.allowed).toBe(true); // Treated as hostname (not ideal but current behavior)
+    expect(result.allowed).toBe(false);
+    expect(result.blockedCategory).toBe('invalid');
   });
 });
 

--- a/apps/collector/src/probes/ssrf-guard.ts
+++ b/apps/collector/src/probes/ssrf-guard.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net';
+
 /**
  * SSRF Guard - Bead 10
  *
@@ -31,21 +33,6 @@ const BLOCKED_IPV4_RANGES = [
   { start: 0xc0000200, end: 0xc00002ff, name: '192.0.2.0/24 (TEST-NET-1)' },
   { start: 0xc6336400, end: 0xc63364ff, name: '198.51.100.0/24 (TEST-NET-2)' },
   { start: 0xcb007100, end: 0xcb0071ff, name: '203.0.113.0/24 (TEST-NET-3)' },
-];
-
-// IPv6 blocked ranges (prefix-based).
-//
-// fc00::/7 (unique local, RFC 4193) spans fc00:: through fdff::.
-// In hex, the first byte is 0xfc or 0xfd — so we need BOTH 'fc' and 'fd'
-// as prefixes. The original 'fc00:' prefix only covered the first /12 and
-// missed fc01::, fc10::, fd00::, etc. Fixed in PR-06.
-const BLOCKED_IPV6_PREFIXES = [
-  { prefix: '::1', name: '::1/128 (loopback)' },
-  { prefix: 'fe80:', name: 'fe80::/10 (link-local)' },
-  { prefix: 'fc', name: 'fc00::/7 part fc (unique local)' },
-  { prefix: 'fd', name: 'fc00::/7 part fd (unique local)' },
-  { prefix: 'ff00:', name: 'ff00::/8 (multicast)' },
-  { prefix: '::', name: '::/128 (unspecified)' },
 ];
 
 /**
@@ -105,25 +92,35 @@ function checkIPv4(ip: string): SSRFCheckResult {
  * @returns The dotted-decimal IPv4 string, or null if not IPv4-mapped.
  */
 function extractIPv4FromMapped(normalized: string): string | null {
-  // ::ffff:a.b.c.d  (most common notation)
-  const dotDecimalMatch = normalized.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (dotDecimalMatch) {
-    return dotDecimalMatch[1];
+  let address = normalized;
+  const dottedTail = address.match(/(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (dottedTail) {
+    const octets = dottedTail.slice(1).map(Number);
+    if (octets.some((octet) => octet < 0 || octet > 255)) return null;
+    const high = ((octets[0] << 8) | octets[1]).toString(16);
+    const low = ((octets[2] << 8) | octets[3]).toString(16);
+    address = `${address.slice(0, dottedTail.index)}${high}:${low}`;
   }
 
-  // ::ffff:hhhh:hhhh  (hex notation, e.g. ::ffff:7f00:0001 = ::ffff:127.0.0.1)
-  const hexMatch = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (hexMatch) {
-    const high = parseInt(hexMatch[1], 16);
-    const low = parseInt(hexMatch[2], 16);
-    const a = (high >> 8) & 0xff;
-    const b = high & 0xff;
-    const c = (low >> 8) & 0xff;
-    const d = low & 0xff;
-    return `${a}.${b}.${c}.${d}`;
-  }
+  const compressedParts = address.split('::');
+  if (compressedParts.length > 2) return null;
+  const left = compressedParts[0] ? compressedParts[0].split(':') : [];
+  const right =
+    compressedParts.length === 2 && compressedParts[1] ? compressedParts[1].split(':') : [];
+  const missing = compressedParts.length === 2 ? 8 - left.length - right.length : 0;
+  const parts =
+    compressedParts.length === 2
+      ? [...left, ...Array(Math.max(0, missing)).fill('0'), ...right]
+      : left;
+  if (parts.length !== 8 || parts.some((part) => !/^[0-9a-f]{1,4}$/.test(part))) return null;
+  const hextets = parts.map((part) => Number.parseInt(part, 16));
+  const mappedPrefix = hextets.slice(0, 5).every((part) => part === 0) && hextets[5] === 0xffff;
+  const compatiblePrefix = hextets.slice(0, 6).every((part) => part === 0);
+  if (!mappedPrefix && !compatiblePrefix) return null;
 
-  return null;
+  const high = hextets[6];
+  const low = hextets[7];
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
 }
 
 /**
@@ -140,6 +137,23 @@ function checkIPv6(ip: string): SSRFCheckResult {
     .toLowerCase()
     .trim()
     .replace(/^\[|\]$/g, '');
+
+  // Zone identifiers are meaningful only in a local interface context and are
+  // never valid outbound probe targets. Reject rather than normalize them.
+  if (normalized.includes('%')) {
+    return {
+      allowed: false,
+      reason: 'IPv6 zone identifier is not allowed',
+      blockedCategory: 'invalid',
+    };
+  }
+
+  if (normalized === '::1') {
+    return { allowed: false, reason: 'Blocked: ::1/128 (loopback)', blockedCategory: 'loopback' };
+  }
+  if (normalized === '::') {
+    return { allowed: false, reason: 'Blocked: ::/128 (unspecified)', blockedCategory: 'reserved' };
+  }
 
   // --- IPv4-mapped IPv6 (::ffff:a.b.c.d or ::ffff:hhhh:hhhh) ---
   // Must be checked BEFORE the generic prefix list because ::ffff: starts
@@ -159,23 +173,37 @@ function checkIPv6(ip: string): SSRFCheckResult {
     return { allowed: true };
   }
 
-  // --- Standard IPv6 prefix checks ---
-  for (const blocked of BLOCKED_IPV6_PREFIXES) {
-    if (normalized.startsWith(blocked.prefix)) {
-      return {
-        allowed: false,
-        reason: `Blocked: ${blocked.name}`,
-        blockedCategory: blocked.name.includes('loopback')
-          ? 'loopback'
-          : blocked.name.includes('link-local')
-            ? 'link-local'
-            : blocked.name.includes('multicast')
-              ? 'multicast'
-              : blocked.name.includes('local')
-                ? 'private'
-                : 'reserved',
-      };
-    }
+  if (isIP(normalized) !== 6) {
+    return { allowed: false, reason: 'Invalid IPv6 address', blockedCategory: 'invalid' };
+  }
+
+  // Classify the complete CIDR range from the first 16-bit hextet rather than
+  // matching one textual spelling. This covers compressed and expanded forms.
+  const firstHextetText = normalized.split(':').find((part) => part.length > 0);
+  const firstHextet = firstHextetText ? Number.parseInt(firstHextetText, 16) : Number.NaN;
+  if (!Number.isFinite(firstHextet) || firstHextet < 0 || firstHextet > 0xffff) {
+    return { allowed: false, reason: 'Invalid IPv6 address', blockedCategory: 'invalid' };
+  }
+  if ((firstHextet & 0xffc0) === 0xfe80) {
+    return {
+      allowed: false,
+      reason: 'Blocked: fe80::/10 (link-local)',
+      blockedCategory: 'link-local',
+    };
+  }
+  if ((firstHextet & 0xfe00) === 0xfc00) {
+    return {
+      allowed: false,
+      reason: 'Blocked: fc00::/7 (unique local)',
+      blockedCategory: 'private',
+    };
+  }
+  if ((firstHextet & 0xff00) === 0xff00) {
+    return {
+      allowed: false,
+      reason: 'Blocked: ff00::/8 (multicast)',
+      blockedCategory: 'multicast',
+    };
   }
 
   return { allowed: true };

--- a/apps/collector/src/probes/tls-certificate.test.ts
+++ b/apps/collector/src/probes/tls-certificate.test.ts
@@ -1,0 +1,218 @@
+import { EventEmitter } from 'node:events';
+import type { TLSCertificateEvidence } from '@dns-ops/contracts';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  collectTlsCertificateEvidence,
+  type TLSProbeSocket,
+  type TLSSocketFactory,
+} from './tls-certificate.js';
+
+function evidence(overrides: Partial<TLSCertificateEvidence> = {}): TLSCertificateEvidence {
+  return {
+    kind: 'TLS_CERTIFICATE',
+    hostname: 'example.com',
+    resolvedAddress: '1.1.1.1',
+    port: 443,
+    protocol: 'TLSv1.3',
+    cipher: 'TLS_AES_256_GCM_SHA384',
+    hostnameAuthorized: true,
+    chainAuthorized: true,
+    subject: 'CN=example.com',
+    issuer: 'CN=Example CA',
+    subjectAlternativeNames: ['example.com', 'www.example.com'],
+    validFrom: '2026-01-01T00:00:00.000Z',
+    validTo: '2027-01-01T00:00:00.000Z',
+    fingerprintSha256: 'AA:BB:CC',
+    ...overrides,
+  };
+}
+
+function fakeSocket(options: {
+  authorized: boolean;
+  authorizationError?: Error;
+  subjectaltname?: string;
+}) {
+  const emitter = new EventEmitter();
+  let socket: TLSProbeSocket;
+  const destroy = vi.fn(() => socket);
+  socket = Object.assign(emitter, {
+    authorized: options.authorized,
+    authorizationError: options.authorizationError,
+    destroy,
+    getPeerCertificate: () => ({
+      raw: Buffer.from('certificate'),
+      fingerprint256: 'AA:BB:CC',
+      subject: { CN: 'example.com' },
+      issuer: { CN: 'Example CA' },
+      subjectaltname: options.subjectaltname ?? 'DNS:example.com, DNS:www.example.com',
+      valid_from: 'Jan  1 00:00:00 2026 GMT',
+      valid_to: 'Jan  1 00:00:00 2027 GMT',
+    }),
+    getCipher: () => ({ name: 'TLS_AES_256_GCM_SHA384', version: 'TLSv1.3' }),
+    getProtocol: () => 'TLSv1.3',
+  }) as unknown as TLSProbeSocket;
+  return { socket, destroy, emitter };
+}
+
+describe('collectTlsCertificateEvidence', () => {
+  it('pins the deterministic public address while preserving hostname validation', async () => {
+    const connector = vi.fn().mockResolvedValue(evidence());
+    const result = await collectTlsCertificateEvidence('Example.COM.', {
+      resolveHostname: async () => ['8.8.8.8', '1.1.1.1'],
+      connector,
+      now: () => new Date('2026-02-01T00:00:00Z'),
+    });
+
+    expect(result).toEqual({
+      status: 'OBSERVED',
+      observedAt: '2026-02-01T00:00:00.000Z',
+      evidence: evidence(),
+    });
+    expect(connector).toHaveBeenCalledWith('example.com', '1.1.1.1', 443, expect.any(AbortSignal));
+  });
+
+  it('uses one pinned permissive connection and separates chain trust from hostname identity', async () => {
+    const { socket, destroy, emitter } = fakeSocket({
+      authorized: true,
+      subjectaltname: 'DNS:"evil,DNS:forged.example", DNS:real.example',
+    });
+    const socketFactory = vi.fn(() => {
+      queueMicrotask(() => emitter.emit('secureConnect'));
+      return socket;
+    }) as TLSSocketFactory;
+
+    const result = await collectTlsCertificateEvidence('example.com', {
+      resolveHostname: async () => ['1.1.1.1'],
+      socketFactory,
+    });
+
+    expect(result.status).toBe('OBSERVED');
+    if (result.status !== 'OBSERVED') throw new Error('Expected observed fixture');
+    expect(result.evidence.chainAuthorized).toBe(true);
+    expect(result.evidence.hostnameAuthorized).toBe(false);
+    expect(result.evidence.subjectAlternativeNames).toEqual(['real.example']);
+    expect(socketFactory).toHaveBeenCalledTimes(1);
+    expect(socketFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: '1.1.1.1',
+        port: 443,
+        servername: 'example.com',
+        rejectUnauthorized: false,
+      })
+    );
+    const connectionOptions = vi.mocked(socketFactory).mock.calls[0][0];
+    expect(connectionOptions.checkServerIdentity?.('example.com', {} as never)).toBeUndefined();
+    expect(destroy).toHaveBeenCalledWith();
+  });
+
+  it('preserves observed invalid-certificate authorization evidence', async () => {
+    const invalidEvidence = evidence({
+      hostnameAuthorized: false,
+      chainAuthorized: false,
+      authorizationError: 'certificate has expired',
+    });
+    const result = await collectTlsCertificateEvidence('example.com', {
+      resolveHostname: async () => ['1.1.1.1'],
+      connector: async () => invalidEvidence,
+    });
+
+    expect(result.status).toBe('OBSERVED');
+    if (result.status !== 'OBSERVED') throw new Error('Expected observed fixture');
+    expect(result.evidence).toMatchObject({
+      hostnameAuthorized: false,
+      chainAuthorized: false,
+      authorizationError: 'certificate has expired',
+    });
+  });
+
+  it('rejects the target when any resolved address is private', async () => {
+    const connector = vi.fn();
+    const result = await collectTlsCertificateEvidence('example.com', {
+      resolveHostname: async () => ['1.1.1.1', '127.0.0.1'],
+      connector,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown).toMatchObject({ reason: 'PROBE_FAILED', action: 'RETRY_PROBE' });
+    expect(result.unknown.explanation).toContain('Unsafe TLS address');
+    expect(connector).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-IP resolver output and bracketed IPv6 target input', async () => {
+    const connector = vi.fn();
+    const nonIp = await collectTlsCertificateEvidence('example.com', {
+      resolveHostname: async () => ['resolver-alias.example'],
+      connector,
+    });
+    const bracketed = await collectTlsCertificateEvidence('[2001:db8::1]', {
+      resolveHostname: vi.fn(),
+      connector,
+    });
+
+    expect(nonIp.status).toBe('UNKNOWN');
+    expect(bracketed.status).toBe('UNKNOWN');
+    if (nonIp.status !== 'UNKNOWN' || bracketed.status !== 'UNKNOWN') {
+      throw new Error('Expected invalid target fixtures');
+    }
+    expect(nonIp.unknown.explanation).toContain('non-IP address');
+    expect(bracketed.unknown.explanation).toContain('Invalid TLS hostname');
+    expect(connector).not.toHaveBeenCalled();
+  });
+
+  it('rejects connector evidence for a different target', async () => {
+    const result = await collectTlsCertificateEvidence('example.com', {
+      resolveHostname: async () => ['1.1.1.1'],
+      connector: async () => evidence({ hostname: 'other.example' }),
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown.explanation).toContain('mismatched target evidence');
+  });
+
+  it('bounds stalled DNS resolution with the cumulative deadline', async () => {
+    const result = await collectTlsCertificateEvidence('example.com', {
+      resolveHostname: () => new Promise<string[]>(() => undefined),
+      connector: vi.fn(),
+      timeoutMs: 5,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown.explanation).toContain('deadline exceeded');
+  });
+
+  it('aborts and destroys a stalled production socket without emitting an unhandled error', async () => {
+    const { socket, destroy } = fakeSocket({ authorized: false });
+    const result = await collectTlsCertificateEvidence('example.com', {
+      resolveHostname: async () => ['1.1.1.1'],
+      socketFactory: () => socket,
+      timeoutMs: 5,
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown.explanation).toContain('deadline exceeded');
+    expect(destroy).toHaveBeenCalledWith();
+  });
+
+  it('turns connector failure into actionable UNKNOWN', async () => {
+    const result = await collectTlsCertificateEvidence('example.com', {
+      resolveHostname: async () => ['1.1.1.1'],
+      connector: async () => {
+        throw new Error('handshake failed');
+      },
+    });
+
+    expect(result.status).toBe('UNKNOWN');
+    if (result.status !== 'UNKNOWN') throw new Error('Expected UNKNOWN fixture');
+    expect(result.unknown).toEqual({
+      reason: 'PROBE_FAILED',
+      explanation: 'TLS certificate evidence could not be collected: handshake failed',
+      action: 'RETRY_PROBE',
+      actionLabel: 'Retry TLS certificate probe',
+      blocking: true,
+    });
+  });
+});

--- a/apps/collector/src/probes/tls-certificate.ts
+++ b/apps/collector/src/probes/tls-certificate.ts
@@ -1,0 +1,302 @@
+import { isIP } from 'node:net';
+import * as tls from 'node:tls';
+import type { EvidenceCheckResult, TLSCertificateEvidence } from '@dns-ops/contracts';
+import { checkResolvedIP, checkSSRF } from './ssrf-guard.js';
+
+const HTTPS_PORT = 443;
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+type Resolver = (hostname: string) => Promise<string[]>;
+export type TLSConnector = (
+  hostname: string,
+  address: string,
+  port: number,
+  signal: AbortSignal
+) => Promise<TLSCertificateEvidence>;
+
+export interface TLSProbeSocket {
+  authorized: boolean;
+  authorizationError?: Error;
+  once(event: 'secureConnect', listener: () => void): this;
+  once(event: 'error', listener: (error: Error) => void): this;
+  off(event: 'secureConnect', listener: () => void): this;
+  off(event: 'error', listener: (error: Error) => void): this;
+  destroy(error?: Error): this;
+  getPeerCertificate(detailed: true): tls.DetailedPeerCertificate;
+  getCipher(): tls.CipherNameAndProtocol;
+  getProtocol(): string | null;
+}
+
+export type TLSSocketFactory = (options: tls.ConnectionOptions) => TLSProbeSocket;
+
+export interface TLSCertificateCollectionOptions {
+  resolveHostname?: Resolver;
+  connector?: TLSConnector;
+  socketFactory?: TLSSocketFactory;
+  timeoutMs?: number;
+  now?: () => Date;
+}
+
+function deadlineError(): Error {
+  return new Error('TLS certificate collection deadline exceeded');
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(deadlineError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(deadlineError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function validateHostname(hostname: string): string {
+  const normalized = hostname.trim().toLowerCase().replace(/\.$/, '');
+  if (
+    !normalized ||
+    normalized.length > 253 ||
+    normalized.includes('/') ||
+    normalized.includes(':') ||
+    normalized.includes('[') ||
+    normalized.includes(']')
+  ) {
+    throw new Error('Invalid TLS hostname');
+  }
+  const parsed = new URL(`https://${normalized}/`);
+  if (parsed.hostname !== normalized || isIP(normalized) !== 0) {
+    throw new Error('TLS evidence requires a registered hostname, not an IP literal');
+  }
+  const hostnameCheck = checkSSRF(normalized);
+  if (!hostnameCheck.allowed) throw new Error(`Unsafe TLS hostname: ${hostnameCheck.reason}`);
+  return normalized;
+}
+
+async function defaultResolver(hostname: string): Promise<string[]> {
+  const { promises: dns } = await import('node:dns');
+  const resolved = await dns.lookup(hostname, { all: true });
+  return [...new Set(resolved.map(({ address }) => address))].sort();
+}
+
+function connectTls(
+  hostname: string,
+  address: string,
+  port: number,
+  signal: AbortSignal,
+  socketFactory: TLSSocketFactory
+): Promise<TLSProbeSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = socketFactory({
+      host: address,
+      port,
+      servername: hostname,
+      rejectUnauthorized: false,
+      checkServerIdentity: () => undefined,
+    });
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort);
+      socket.off('secureConnect', onSecure);
+      socket.off('error', onError);
+    };
+    const onAbort = () => {
+      cleanup();
+      socket.destroy();
+      reject(deadlineError());
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      socket.destroy();
+      reject(error);
+    };
+    const onSecure = () => {
+      cleanup();
+      resolve(socket);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    socket.once('secureConnect', onSecure);
+    socket.once('error', onError);
+  });
+}
+
+function distinguishedName(value: tls.PeerCertificate['subject']): string {
+  if (!value) return '';
+  return Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${key}=${String(entry)}`)
+    .join(', ');
+}
+
+function subjectAlternativeNames(value: string | undefined): string[] {
+  if (!value) return [];
+  const entries: string[] = [];
+  let current = '';
+  let quoted = false;
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+    } else if (character === '\\' && quoted) {
+      current += character;
+      escaped = true;
+    } else if (character === '"') {
+      current += character;
+      quoted = !quoted;
+    } else if (character === ',' && !quoted) {
+      entries.push(current.trim());
+      current = '';
+    } else {
+      current += character;
+    }
+  }
+  entries.push(current.trim());
+
+  return entries
+    .flatMap((entry) => {
+      if (!entry.startsWith('DNS:')) return [];
+      const rawName = entry.slice(4);
+      let name: string;
+      try {
+        name = rawName.startsWith('"') ? JSON.parse(rawName) : rawName;
+      } catch {
+        return [];
+      }
+      return /^(?:\*\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(
+        name
+      )
+        ? [name]
+        : [];
+    })
+    .sort();
+}
+
+function certificateDate(value: string, field: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) throw new Error(`TLS certificate has invalid ${field}`);
+  return parsed.toISOString();
+}
+
+function evidenceFromSocket(
+  socket: TLSProbeSocket,
+  hostname: string,
+  address: string,
+  port: number
+): TLSCertificateEvidence {
+  const certificate = socket.getPeerCertificate(true);
+  if (!certificate?.raw || !certificate.fingerprint256) {
+    throw new Error('TLS peer did not provide a complete certificate');
+  }
+  const hostnameError = tls.checkServerIdentity(hostname, certificate);
+  const cipher = socket.getCipher();
+  const protocol = socket.getProtocol();
+  if (!protocol || !cipher.name) throw new Error('TLS session metadata is incomplete');
+
+  return {
+    kind: 'TLS_CERTIFICATE',
+    hostname,
+    resolvedAddress: address,
+    port,
+    protocol,
+    cipher: cipher.name,
+    hostnameAuthorized: hostnameError === undefined,
+    chainAuthorized: socket.authorized,
+    authorizationError:
+      [
+        socket.authorized
+          ? undefined
+          : (socket.authorizationError?.message ?? 'certificate chain is not authorized'),
+        hostnameError?.message,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .join('; ') || undefined,
+    subject: distinguishedName(certificate.subject),
+    issuer: distinguishedName(certificate.issuer),
+    subjectAlternativeNames: subjectAlternativeNames(certificate.subjectaltname),
+    validFrom: certificateDate(certificate.valid_from, 'valid-from date'),
+    validTo: certificateDate(certificate.valid_to, 'valid-to date'),
+    fingerprintSha256: certificate.fingerprint256,
+  };
+}
+
+async function defaultConnector(
+  hostname: string,
+  address: string,
+  port: number,
+  signal: AbortSignal,
+  socketFactory: TLSSocketFactory
+): Promise<TLSCertificateEvidence> {
+  const socket = await connectTls(hostname, address, port, signal, socketFactory);
+  try {
+    return evidenceFromSocket(socket, hostname, address, port);
+  } finally {
+    socket.destroy();
+  }
+}
+
+function unknown(detail: string) {
+  return {
+    reason: 'PROBE_FAILED' as const,
+    explanation: `TLS certificate evidence could not be collected: ${detail}`,
+    action: 'RETRY_PROBE' as const,
+    actionLabel: 'Retry TLS certificate probe',
+    blocking: true,
+  };
+}
+
+export async function collectTlsCertificateEvidence(
+  registeredHostname: string,
+  options: TLSCertificateCollectionOptions = {}
+): Promise<EvidenceCheckResult<TLSCertificateEvidence>> {
+  const resolver = options.resolveHostname ?? defaultResolver;
+  const socketFactory = options.socketFactory ?? ((connectOptions) => tls.connect(connectOptions));
+  const connector =
+    options.connector ??
+    ((hostname, address, port, signal) =>
+      defaultConnector(hostname, address, port, signal, socketFactory));
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const now = options.now ?? (() => new Date());
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const hostname = validateHostname(registeredHostname);
+    const addresses = await abortable(resolver(hostname), controller.signal);
+    if (addresses.length === 0) throw new Error('TLS hostname did not resolve');
+    for (const address of addresses) {
+      if (isIP(address) === 0 || address.includes('%')) {
+        throw new Error(`TLS resolver returned a non-IP address: ${address}`);
+      }
+      const addressCheck = checkResolvedIP(address);
+      if (!addressCheck.allowed) {
+        throw new Error(`Unsafe TLS address ${address}: ${addressCheck.reason}`);
+      }
+    }
+
+    const address = [...addresses].sort()[0];
+    const evidence = await abortable(
+      connector(hostname, address, HTTPS_PORT, controller.signal),
+      controller.signal
+    );
+    if (
+      evidence.hostname !== hostname ||
+      evidence.resolvedAddress !== address ||
+      evidence.port !== HTTPS_PORT
+    ) {
+      throw new Error('TLS connector returned mismatched target evidence');
+    }
+    return { status: 'OBSERVED', observedAt: now().toISOString(), evidence };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { status: 'UNKNOWN', unknown: unknown(detail) };
+  } finally {
+    clearTimeout(deadline);
+  }
+}

--- a/apps/web/app/api.ts
+++ b/apps/web/app/api.ts
@@ -11,6 +11,7 @@ import {
   requireAuthMiddleware,
 } from '../hono/middleware/index.js';
 import { apiRoutes } from '../hono/routes/api.js';
+import { mcpRoutes } from '../hono/routes/mcp.js';
 import authRoutes from '../hono/routes/signup.js';
 import type { Env } from '../hono/types.js';
 
@@ -35,6 +36,8 @@ app.use('*', authMiddleware);
 
 // Public API routes (no auth required)
 app.route('/api/auth', authRoutes);
+// MCP authenticates independently with a static bearer-principal map.
+app.route('/mcp', mcpRoutes);
 
 // All other API routes require authentication. enforceTenantIsolation runs as
 // a structural chokepoint right after auth populates the tenant context, so

--- a/apps/web/app/api.ts
+++ b/apps/web/app/api.ts
@@ -11,7 +11,6 @@ import {
   requireAuthMiddleware,
 } from '../hono/middleware/index.js';
 import { apiRoutes } from '../hono/routes/api.js';
-import { mcpRoutes } from '../hono/routes/mcp.js';
 import authRoutes from '../hono/routes/signup.js';
 import type { Env } from '../hono/types.js';
 
@@ -36,10 +35,6 @@ app.use('*', authMiddleware);
 
 // Public API routes (no auth required)
 app.route('/api/auth', authRoutes);
-// MCP authenticates independently with a static bearer-principal map. This handler is
-// served by TanStack Start's /api entrypoint, so its public application path is /api/mcp.
-app.route('/api/mcp', mcpRoutes);
-
 // All other API routes require authentication. enforceTenantIsolation runs as
 // a structural chokepoint right after auth populates the tenant context, so
 // tenant scoping is guaranteed for every authenticated /api route and is not

--- a/apps/web/app/api.ts
+++ b/apps/web/app/api.ts
@@ -36,8 +36,9 @@ app.use('*', authMiddleware);
 
 // Public API routes (no auth required)
 app.route('/api/auth', authRoutes);
-// MCP authenticates independently with a static bearer-principal map.
-app.route('/mcp', mcpRoutes);
+// MCP authenticates independently with a static bearer-principal map. This handler is
+// served by TanStack Start's /api entrypoint, so its public application path is /api/mcp.
+app.route('/api/mcp', mcpRoutes);
 
 // All other API routes require authentication. enforceTenantIsolation runs as
 // a structural chokepoint right after auth populates the tenant context, so

--- a/apps/web/app/components/DomainEvidencePanel.test.ts
+++ b/apps/web/app/components/DomainEvidencePanel.test.ts
@@ -25,6 +25,29 @@ describe('DomainEvidencePanel evidence classification', () => {
     ).toMatchObject({ reason: 'EVIDENCE_STALE', action: 'RUN_FRESH_SCAN' });
   });
 
+  it('places stale and unbaselined TLS evidence in setup rather than current evidence', () => {
+    const stale = {
+      id: 'probe-stale',
+      probeType: 'tls_cert',
+      status: 'success',
+      success: true,
+      errorMessage: null,
+      freshness: 'STALE' as const,
+      probeData: { status: 'OBSERVED' as const },
+    };
+    const missing = { ...stale, freshness: 'MISSING_BASELINE' as const };
+    expect(unknownForEvidence(stale)).toMatchObject({
+      reason: 'EVIDENCE_STALE',
+      action: 'RUN_FRESH_SCAN',
+    });
+    expect(unknownForEvidence(missing)).toMatchObject({
+      reason: 'MISSING_BASELINE',
+      action: 'ACCEPT_BASELINE',
+    });
+    expect(isCurrentEvidence(stale)).toBe(false);
+    expect(isCurrentEvidence(missing)).toBe(false);
+  });
+
   it('never classifies an UNKNOWN payload as current evidence', () => {
     expect(
       isCurrentEvidence({

--- a/apps/web/app/components/DomainEvidencePanel.test.ts
+++ b/apps/web/app/components/DomainEvidencePanel.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { deduplicateSetup, isCurrentEvidence, unknownForEvidence } from './DomainEvidencePanel.js';
+
+describe('DomainEvidencePanel evidence classification', () => {
+  it('deduplicates repeated setup actions', () => {
+    const setup = {
+      reason: 'PURPOSE_UNDECLARED',
+      explanation: 'Declare purpose first.',
+      action: 'DECLARE_PURPOSE',
+      actionLabel: 'Declare domain purpose',
+    };
+    expect(deduplicateSetup([setup, { ...setup }])).toEqual([setup]);
+  });
+
+  it('places metadata-light UNKNOWN evidence in setup with a fresh-scan action', () => {
+    expect(
+      unknownForEvidence({
+        id: 'probe-unknown',
+        probeType: 'http',
+        status: 'error',
+        success: false,
+        errorMessage: null,
+        probeData: { status: 'UNKNOWN' },
+      })
+    ).toMatchObject({ reason: 'EVIDENCE_STALE', action: 'RUN_FRESH_SCAN' });
+  });
+
+  it('never classifies an UNKNOWN payload as current evidence', () => {
+    expect(
+      isCurrentEvidence({
+        id: 'probe-1',
+        probeType: 'http',
+        status: 'success',
+        success: true,
+        errorMessage: null,
+        probeData: { status: 'UNKNOWN' },
+      })
+    ).toBe(false);
+    expect(
+      isCurrentEvidence({
+        id: 'probe-2',
+        probeType: 'http',
+        status: 'success',
+        success: true,
+        errorMessage: null,
+        probeData: { status: 'OBSERVED' },
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/app/components/DomainEvidencePanel.tsx
+++ b/apps/web/app/components/DomainEvidencePanel.tsx
@@ -1,0 +1,148 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useId } from 'react';
+
+export type Unknown = {
+  reason: string;
+  explanation: string;
+  action: string;
+  actionLabel: string;
+};
+
+type ProfileResponse = {
+  profile: { purpose: string; criticality: string; responsibleActorId?: string | null } | null;
+  setup: Unknown | null;
+};
+
+export type EvidenceResponse = {
+  snapshotId: string | null;
+  evidence: Array<{
+    id: string;
+    probeType: string;
+    status: string;
+    success: boolean;
+    errorMessage: string | null;
+    probeData?: { check?: string; status?: 'OBSERVED' | 'UNKNOWN'; unknown?: Unknown };
+  }>;
+};
+
+export function deduplicateSetup(setup: Unknown[]): Unknown[] {
+  return [
+    ...new Map(
+      setup.map((unknown) => [
+        `${unknown.reason}-${unknown.action}-${unknown.explanation}`,
+        unknown,
+      ])
+    ).values(),
+  ];
+}
+
+export function isCurrentEvidence(item: EvidenceResponse['evidence'][number]): boolean {
+  return item.success && item.probeData?.status !== 'UNKNOWN' && !item.probeData?.unknown;
+}
+
+export function unknownForEvidence(
+  item: EvidenceResponse['evidence'][number]
+): Unknown | undefined {
+  if (item.probeData?.unknown) return item.probeData.unknown;
+  if (item.probeData?.status !== 'UNKNOWN') return undefined;
+  return {
+    reason: 'EVIDENCE_STALE',
+    explanation: item.errorMessage || `${item.probeType} evidence is incomplete.`,
+    action: 'RUN_FRESH_SCAN',
+    actionLabel: 'Run a fresh scan',
+  };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, { credentials: 'include' });
+  if (!response.ok) throw new Error(`Evidence request failed (${response.status})`);
+  return response.json() as Promise<T>;
+}
+
+export function DomainEvidencePanel({ domain }: { domain: string }) {
+  const headingId = useId();
+  const queryClient = useQueryClient();
+  const profile = useQuery({
+    queryKey: ['domain-profile', domain],
+    queryFn: () => fetchJson<ProfileResponse>(`/api/domains/${encodeURIComponent(domain)}/profile`),
+  });
+  const evidence = useQuery({
+    queryKey: ['domain-evidence', domain],
+    queryFn: () =>
+      fetchJson<EvidenceResponse>(`/api/domains/${encodeURIComponent(domain)}/evidence`),
+  });
+
+  if (profile.isLoading || evidence.isLoading) {
+    return (
+      <p className="text-sm text-gray-500" role="status">
+        Loading evidence coverage…
+      </p>
+    );
+  }
+  if (profile.error || evidence.error) {
+    return (
+      <div className="text-sm text-gray-600" role="alert">
+        Evidence setup status is currently unavailable.
+        <button
+          type="button"
+          className="ml-2 font-medium underline"
+          onClick={() => {
+            void queryClient.invalidateQueries({ queryKey: ['domain-profile', domain] });
+            void queryClient.invalidateQueries({ queryKey: ['domain-evidence', domain] });
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const setup = [
+    ...(profile.data?.setup ? [profile.data.setup] : []),
+    ...(evidence.data?.evidence
+      .map(unknownForEvidence)
+      .filter((unknown): unknown is Unknown => Boolean(unknown)) ?? []),
+  ];
+  const uniqueSetup = deduplicateSetup(setup);
+  const observed = evidence.data?.evidence.filter(isCurrentEvidence) ?? [];
+
+  return (
+    <section className="space-y-3" aria-labelledby={headingId}>
+      <div>
+        <h3 id={headingId} className="font-semibold text-gray-900">
+          Evidence coverage
+        </h3>
+        <p className="text-sm text-gray-500">
+          Known risk and completed evidence are separate. Unknown checks are never healthy.
+        </p>
+      </div>
+      {uniqueSetup.length > 0 ? (
+        <div
+          className="rounded-lg border border-amber-200 bg-amber-50 p-3"
+          data-testid="domain-needs-setup-evidence"
+        >
+          <h4 className="font-medium text-amber-900">Needs setup/evidence</h4>
+          <ul className="mt-2 space-y-2 text-sm text-amber-900">
+            {uniqueSetup.map((unknown) => (
+              <li key={`${unknown.reason}-${unknown.action}-${unknown.explanation}`}>
+                <span className="font-medium">{unknown.actionLabel}:</span> {unknown.explanation}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {profile.data?.profile ? (
+        <p className="text-sm text-gray-600">
+          Purpose: <span className="font-medium">{profile.data.profile.purpose}</span> ·
+          Criticality: <span className="font-medium">{profile.data.profile.criticality}</span>
+        </p>
+      ) : null}
+      {observed.length > 0 ? (
+        <p className="text-sm text-green-700" data-testid="domain-current-evidence">
+          {observed.length} probe observation{observed.length === 1 ? '' : 's'} recorded with
+          current evidence.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/components/DomainEvidencePanel.tsx
+++ b/apps/web/app/components/DomainEvidencePanel.tsx
@@ -21,6 +21,7 @@ export type EvidenceResponse = {
     status: string;
     success: boolean;
     errorMessage: string | null;
+    freshness?: 'CURRENT' | 'STALE' | 'MISSING_BASELINE' | 'NOT_BASELINE_GATED';
     probeData?: { check?: string; status?: 'OBSERVED' | 'UNKNOWN'; unknown?: Unknown };
   }>;
 };
@@ -37,12 +38,34 @@ export function deduplicateSetup(setup: Unknown[]): Unknown[] {
 }
 
 export function isCurrentEvidence(item: EvidenceResponse['evidence'][number]): boolean {
-  return item.success && item.probeData?.status !== 'UNKNOWN' && !item.probeData?.unknown;
+  return (
+    item.success &&
+    item.probeData?.status !== 'UNKNOWN' &&
+    !item.probeData?.unknown &&
+    item.freshness !== 'STALE' &&
+    item.freshness !== 'MISSING_BASELINE'
+  );
 }
 
 export function unknownForEvidence(
   item: EvidenceResponse['evidence'][number]
 ): Unknown | undefined {
+  if (item.freshness === 'MISSING_BASELINE') {
+    return {
+      reason: 'MISSING_BASELINE',
+      explanation: `${item.probeType} evidence needs an accepted baseline before it can be considered current.`,
+      action: 'ACCEPT_BASELINE',
+      actionLabel: 'Accept baseline',
+    };
+  }
+  if (item.freshness === 'STALE') {
+    return {
+      reason: 'EVIDENCE_STALE',
+      explanation: `${item.probeType} evidence is older than its accepted baseline policy allows.`,
+      action: 'RUN_FRESH_SCAN',
+      actionLabel: 'Run a fresh scan',
+    };
+  }
   if (item.probeData?.unknown) return item.probeData.unknown;
   if (item.probeData?.status !== 'UNKNOWN') return undefined;
   return {

--- a/apps/web/app/components/MailFindingsPanel.tsx
+++ b/apps/web/app/components/MailFindingsPanel.tsx
@@ -8,7 +8,6 @@
 import type { Finding, Suggestion } from '@dns-ops/db/schema';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { ConfirmDialog } from './ui/ConfirmDialog.js';
 import { EmptyState, ErrorState, LoadingState } from './ui/StateDisplay.js';
 
 interface MailFindingsPanelProps {
@@ -398,28 +397,9 @@ interface MailSuggestionCardProps {
   domain: string;
 }
 
-function MailSuggestionCard({ suggestion, domain }: MailSuggestionCardProps) {
+function MailSuggestionCard({ suggestion, domain: _domain }: MailSuggestionCardProps) {
   const queryClient = useQueryClient();
-  const [showConfirm, setShowConfirm] = useState(false);
-
   const isPending = !suggestion.appliedAt && !suggestion.dismissedAt;
-
-  const applyMutation = useMutation({
-    mutationFn: async () => {
-      const response = await fetch(`/api/suggestions/${suggestion.id}/apply`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ confirmApply: suggestion.reviewOnly ? true : undefined }),
-      });
-      if (!response.ok) {
-        const error = (await response.json()) as { error?: string; code?: string };
-        throw new Error(error.error || 'Failed to apply suggestion');
-      }
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['mail-findings'] });
-    },
-  });
 
   const dismissMutation = useMutation({
     mutationFn: async () => {
@@ -435,102 +415,57 @@ function MailSuggestionCard({ suggestion, domain }: MailSuggestionCardProps) {
     },
   });
 
-  const handleApply = () => {
-    if (suggestion.reviewOnly && !showConfirm) {
-      setShowConfirm(true);
-      return;
-    }
-    applyMutation.mutate();
-  };
-
-  const handleDismiss = () => {
-    dismissMutation.mutate();
-  };
-
   return (
-    <>
-      <div
-        className={`p-3 rounded-lg ${
-          suggestion.reviewOnly
-            ? 'bg-amber-100/50 border border-amber-200'
-            : 'bg-blue-50 border border-blue-200'
-        }`}
-      >
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex-1">
-            <div className="flex items-center gap-2">
-              <h6 className="font-medium text-gray-900">{suggestion.title}</h6>
-              {suggestion.reviewOnly && (
-                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-200 text-amber-800">
-                  ⚠️ Review Required
-                </span>
-              )}
-            </div>
-            <p className="text-sm text-gray-600 mt-1">{suggestion.description}</p>
-            <div className="mt-2 p-2 bg-white/50 rounded text-sm font-mono text-gray-700 whitespace-pre-wrap">
-              {suggestion.action}
+    <div
+      className={`p-3 rounded-lg ${
+        suggestion.reviewOnly
+          ? 'bg-amber-100/50 border border-amber-200'
+          : 'bg-blue-50 border border-blue-200'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h6 className="font-medium text-gray-900">{suggestion.title}</h6>
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-200 text-amber-800">
+              Guidance only
+            </span>
+          </div>
+          <p className="text-sm text-gray-600 mt-1">{suggestion.description}</p>
+          <div className="mt-2 p-2 bg-white/50 rounded text-sm text-gray-700 whitespace-pre-wrap">
+            <strong>Playbook reference:</strong> {suggestion.action.replace(/^Playbook:\s*/, '')}
+            <div className="mt-1 text-xs text-amber-800">
+              Requires provider and domain-purpose confirmation. No executable mutation is
+              available.
             </div>
           </div>
         </div>
-
-        {isPending && (
-          <div className="mt-3 flex items-center gap-2 pt-2 border-t border-gray-200/50">
-            <button
-              type="button"
-              onClick={handleApply}
-              disabled={applyMutation.isPending || dismissMutation.isPending}
-              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-            >
-              {applyMutation.isPending ? 'Applying...' : 'Apply'}
-            </button>
-            <button
-              type="button"
-              onClick={handleDismiss}
-              disabled={applyMutation.isPending || dismissMutation.isPending}
-              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-            >
-              {dismissMutation.isPending ? 'Dismissing...' : 'Dismiss'}
-            </button>
-          </div>
-        )}
-
-        {suggestion.appliedAt && (
-          <div className="mt-2 pt-2 border-t border-gray-200/50 text-xs text-green-600">
-            ✓ Applied {suggestion.appliedBy ? `by ${suggestion.appliedBy}` : ''}
-          </div>
-        )}
-
-        {suggestion.dismissedAt && (
-          <div className="mt-2 pt-2 border-t border-gray-200/50 text-xs text-gray-500">
-            Dismissed {suggestion.dismissedBy ? `by ${suggestion.dismissedBy}` : ''}
-          </div>
-        )}
       </div>
 
-      <ConfirmDialog
-        isOpen={showConfirm}
-        title="Apply Review-Only Suggestion?"
-        message={
-          <div className="space-y-3">
-            <p>
-              This suggestion is marked as <strong>review-required</strong> because it may have
-              significant impact:
-            </p>
-            <ul className="list-disc list-inside text-sm text-gray-600">
-              <li>Risk posture: {suggestion.riskPosture}</li>
-              <li>Blast radius: {suggestion.blastRadius.replace(/-/g, ' ')}</li>
-            </ul>
-            <p className="text-amber-700 font-medium">
-              This change may affect mail delivery for {domain}. Proceed with caution.
-            </p>
-          </div>
-        }
-        confirmLabel="Apply Anyway"
-        cancelLabel="Cancel"
-        variant="warning"
-        onConfirm={handleApply}
-        onCancel={() => setShowConfirm(false)}
-      />
-    </>
+      {isPending && (
+        <div className="mt-3 flex items-center gap-2 pt-2 border-t border-gray-200/50">
+          <button
+            type="button"
+            onClick={() => dismissMutation.mutate()}
+            disabled={dismissMutation.isPending}
+            className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            {dismissMutation.isPending ? 'Hiding...' : 'Hide guidance'}
+          </button>
+        </div>
+      )}
+
+      {suggestion.appliedAt && (
+        <div className="mt-2 pt-2 border-t border-gray-200/50 text-xs text-green-600">
+          Previously acknowledged {suggestion.appliedBy ? `by ${suggestion.appliedBy}` : ''}
+        </div>
+      )}
+
+      {suggestion.dismissedAt && (
+        <div className="mt-2 pt-2 border-t border-gray-200/50 text-xs text-gray-500">
+          Dismissed {suggestion.dismissedBy ? `by ${suggestion.dismissedBy}` : ''}
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/app/components/MailFindingsPanel.tsx
+++ b/apps/web/app/components/MailFindingsPanel.tsx
@@ -32,6 +32,18 @@ interface MailFindingsData {
   domain: string;
   rulesetVersion: string;
   persisted: boolean;
+  evaluationCoverage: {
+    state: 'COMPLETE' | 'PARTIAL';
+    errors: Array<{
+      ruleId: string;
+      message: string;
+      status: 'UNKNOWN';
+      unknown: {
+        explanation: string;
+        actionLabel: string;
+      };
+    }>;
+  };
   mailConfig: MailConfig;
   findings: Finding[];
   suggestions: Suggestion[];
@@ -80,6 +92,23 @@ export function MailFindingsPanel({ snapshotId }: MailFindingsPanelProps) {
 
   return (
     <div className="space-y-6">
+      {data.evaluationCoverage.state === 'PARTIAL' && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-4" role="status">
+          <h4 className="font-semibold text-amber-900">Needs setup/evidence</h4>
+          <p className="mt-1 text-sm text-amber-800">
+            One or more checks could not be evaluated. Missing results are UNKNOWN, not healthy.
+          </p>
+          <ul className="mt-3 space-y-2">
+            {data.evaluationCoverage.errors.map((evaluationError) => (
+              <li key={evaluationError.ruleId} className="text-sm text-amber-900">
+                <strong>{evaluationError.ruleId}:</strong> {evaluationError.unknown.explanation}{' '}
+                <span className="font-medium">{evaluationError.unknown.actionLabel}.</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <div className="bg-gradient-to-r from-indigo-50 to-purple-50 rounded-lg p-4 border border-indigo-100">
         <div className="flex items-center justify-between">
           <div>
@@ -89,7 +118,15 @@ export function MailFindingsPanel({ snapshotId }: MailFindingsPanelProps) {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <ScoreCircle score={mailConfig.securityScore} />
+            {data.evaluationCoverage.state === 'COMPLETE' ? (
+              <ScoreCircle score={mailConfig.securityScore} />
+            ) : (
+              <div className="rounded-full border-4 border-gray-300 px-3 py-4 text-center text-xs font-semibold text-gray-600">
+                Score
+                <br />
+                unavailable
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -145,9 +182,11 @@ export function MailFindingsPanel({ snapshotId }: MailFindingsPanelProps) {
           )}
         </div>
 
-        {findings.length === 0 && (
+        {findings.length === 0 && data.evaluationCoverage.state === 'COMPLETE' && (
           <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-            <p className="text-green-800 text-sm">✓ No mail configuration issues detected.</p>
+            <p className="text-green-800 text-sm">
+              ✓ No mail configuration issues detected by the checks that completed.
+            </p>
           </div>
         )}
 

--- a/apps/web/app/components/PortfolioSearchPanel.tsx
+++ b/apps/web/app/components/PortfolioSearchPanel.tsx
@@ -22,6 +22,10 @@ interface SearchResult {
   zoneManagement: ZoneManagement;
   findings: Array<{ severity: Severity; summary?: string }>;
   findingsEvaluated: boolean;
+  evaluationCoverage: {
+    state: 'COMPLETE' | 'PARTIAL';
+    errors: Array<{ unknown: { explanation: string; actionLabel: string } }>;
+  };
   latestSnapshot: {
     id: string;
     createdAt: string;
@@ -366,7 +370,12 @@ function SearchResultCard({ result }: { result: SearchResult }) {
 
       <div className="mt-3 text-sm text-gray-600">
         {!result.findingsEvaluated ? (
-          <span>Rules not evaluated yet.</span>
+          <span>
+            Needs setup/evidence. {result.evaluationCoverage.errors[0]?.unknown.explanation}{' '}
+            <strong>
+              {result.evaluationCoverage.errors[0]?.unknown.actionLabel ?? 'Run a fresh scan'}.
+            </strong>
+          </span>
         ) : result.findings.length === 0 ? (
           <span>No matching findings for the current filters.</span>
         ) : (

--- a/apps/web/app/components/SimulationPanel.tsx
+++ b/apps/web/app/components/SimulationPanel.tsx
@@ -1,23 +1,21 @@
 /**
  * Simulation Panel Component
  *
- * Shows proposed DNS changes for actionable findings, with dry-run results
- * showing which findings would resolve, remain, or be introduced.
+ * Shows non-executable playbook guidance for generic findings. Concrete local
+ * simulation remains unavailable until provider-confirmed values are complete.
  */
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { EmptyState, ErrorState, LoadingState } from './ui/StateDisplay.js';
 
-interface ProposedChange {
-  action: 'add' | 'modify' | 'remove';
-  name: string;
-  type: string;
-  currentValues: string[];
-  proposedValues: string[];
-  rationale: string;
-  findingType: string;
-  risk: 'low' | 'medium' | 'high';
+interface GuidanceOnlySuggestion {
+  kind: 'GUIDANCE_ONLY';
+  title: string;
+  explanation: string;
+  playbookId: string;
+  requiresProviderConfirmation: boolean;
+  executableMutation: null;
 }
 
 interface SimFinding {
@@ -28,20 +26,16 @@ interface SimFinding {
 }
 
 interface SimulationResult {
+  mode: 'GUIDANCE_ONLY';
   domain: string;
-  detectedProvider: string;
-  proposedChanges: ProposedChange[];
+  detectedProvider: 'unknown';
+  proposedChanges: [];
+  guidanceOnlySuggestions: GuidanceOnlySuggestion[];
   currentFindings: SimFinding[];
-  projectedFindings: SimFinding[];
-  resolvedFindings: SimFinding[];
-  remainingFindings: SimFinding[];
-  newFindings: SimFinding[];
   summary: {
-    changesProposed: number;
-    findingsBefore: number;
-    findingsAfter: number;
-    findingsResolved: number;
-    findingsNew: number;
+    changesProposed: 0;
+    guidanceProvided: number;
+    currentFindings: number;
   };
 }
 
@@ -49,24 +43,12 @@ interface SimulationPanelProps {
   snapshotId: string | null;
 }
 
-const RISK_COLORS: Record<string, string> = {
-  low: '#16a34a',
-  medium: '#d97706',
-  high: '#dc2626',
-};
-
 const SEVERITY_COLORS: Record<string, string> = {
   critical: '#dc2626',
   high: '#ea580c',
   medium: '#d97706',
   low: '#2563eb',
   info: '#6b7280',
-};
-
-const ACTION_LABELS: Record<string, string> = {
-  add: 'Add',
-  modify: 'Modify',
-  remove: 'Remove',
 };
 
 async function runSimulationFetch(snapshotId: string): Promise<SimulationResult> {
@@ -78,7 +60,7 @@ async function runSimulationFetch(snapshotId: string): Promise<SimulationResult>
   });
 
   if (!response.ok) {
-    let errorMessage = `Simulation failed (${response.status})`;
+    let errorMessage = `Guidance request failed (${response.status})`;
     try {
       const errData = (await response.json()) as { error?: string };
       if (errData.error) errorMessage = errData.error;
@@ -120,14 +102,14 @@ export function SimulationPanel({ snapshotId }: SimulationPanelProps) {
       <EmptyState
         icon="shield"
         title="No snapshot available"
-        description="Collect data first, then simulate fixes."
+        description="Collect data first, then review remediation guidance."
         size="sm"
       />
     );
   }
 
   if (isLoading) {
-    return <LoadingState message="Running simulation..." />;
+    return <LoadingState message="Generating guidance..." />;
   }
 
   if (error) {
@@ -139,7 +121,7 @@ export function SimulationPanel({ snapshotId }: SimulationPanelProps) {
     return (
       <div style={{ textAlign: 'center', padding: '2rem' }}>
         <p style={{ color: '#6b7280', marginBottom: '1rem' }}>
-          Simulate DNS changes to see which findings would be resolved.
+          Generate non-executable playbook guidance for current findings.
         </p>
         <button
           type="button"
@@ -154,7 +136,7 @@ export function SimulationPanel({ snapshotId }: SimulationPanelProps) {
             fontWeight: 500,
           }}
         >
-          Run Simulation
+          Generate Guidance
         </button>
       </div>
     );
@@ -174,108 +156,44 @@ export function SimulationPanel({ snapshotId }: SimulationPanelProps) {
           border: '1px solid #e2e8f0',
         }}
       >
-        <SummaryPill label="Changes" value={result.summary.changesProposed} />
-        <SummaryPill label="Findings before" value={result.summary.findingsBefore} />
-        <SummaryPill
-          label="After"
-          value={result.summary.findingsAfter}
-          color={
-            result.summary.findingsAfter < result.summary.findingsBefore ? '#16a34a' : undefined
-          }
-        />
-        <SummaryPill label="Resolved" value={result.summary.findingsResolved} color="#16a34a" />
-        {result.summary.findingsNew > 0 && (
-          <SummaryPill label="New" value={result.summary.findingsNew} color="#d97706" />
-        )}
-        {result.detectedProvider !== 'unknown' && (
-          <span
-            style={{
-              padding: '0.25rem 0.75rem',
-              backgroundColor: '#eff6ff',
-              borderRadius: '9999px',
-              fontSize: '0.75rem',
-              color: '#2563eb',
-            }}
-          >
-            Provider: {result.detectedProvider}
-          </span>
-        )}
+        <SummaryPill label="Guidance" value={result.summary.guidanceProvided} />
+        <SummaryPill label="Current findings" value={result.summary.currentFindings} />
       </div>
 
-      {/* Proposed changes */}
-      {result.proposedChanges.length > 0 && (
+      {result.guidanceOnlySuggestions.length > 0 && (
         <section>
-          <h4
-            style={{
-              fontSize: '0.875rem',
-              fontWeight: 600,
-              marginBottom: '0.5rem',
-            }}
-          >
-            Proposed DNS Changes
+          <h4 style={{ fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+            Guidance only
           </h4>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '0.5rem',
-            }}
-          >
-            {result.proposedChanges.map((change) => (
-              <ChangeCard key={`${change.action}-${change.name}-${change.type}`} change={change} />
+          <p style={{ color: '#92400e', fontSize: '0.75rem', marginBottom: '0.75rem' }}>
+            No executable mutation is available. Confirm provider, domain purpose, and exact values
+            before planning a local simulation.
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            {result.guidanceOnlySuggestions.map((guidance) => (
+              <div
+                key={guidance.playbookId}
+                style={{ padding: '0.75rem', border: '1px solid #fcd34d', borderRadius: '6px' }}
+              >
+                <strong>{guidance.title}</strong>
+                <p style={{ marginTop: '0.25rem', color: '#4b5563', fontSize: '0.875rem' }}>
+                  {guidance.explanation}
+                </p>
+                <p style={{ marginTop: '0.25rem', color: '#92400e', fontSize: '0.75rem' }}>
+                  Playbook: {guidance.playbookId}
+                </p>
+              </div>
             ))}
           </div>
         </section>
       )}
 
-      {/* Resolved findings */}
-      {result.resolvedFindings.length > 0 && (
+      {result.currentFindings.length > 0 && (
         <section>
-          <h4
-            style={{
-              fontSize: '0.875rem',
-              fontWeight: 600,
-              marginBottom: '0.5rem',
-              color: '#16a34a',
-            }}
-          >
-            ✅ Findings Resolved ({result.resolvedFindings.length})
+          <h4 style={{ fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+            Current findings ({result.currentFindings.length})
           </h4>
-          <FindingsList findings={result.resolvedFindings} />
-        </section>
-      )}
-
-      {/* New findings (warnings) */}
-      {result.newFindings.length > 0 && (
-        <section>
-          <h4
-            style={{
-              fontSize: '0.875rem',
-              fontWeight: 600,
-              marginBottom: '0.5rem',
-              color: '#d97706',
-            }}
-          >
-            ⚠️ New Findings Introduced ({result.newFindings.length})
-          </h4>
-          <FindingsList findings={result.newFindings} />
-        </section>
-      )}
-
-      {/* Remaining findings */}
-      {result.remainingFindings.length > 0 && (
-        <section>
-          <h4
-            style={{
-              fontSize: '0.875rem',
-              fontWeight: 600,
-              marginBottom: '0.5rem',
-              color: '#6b7280',
-            }}
-          >
-            Remaining ({result.remainingFindings.length})
-          </h4>
-          <FindingsList findings={result.remainingFindings} />
+          <FindingsList findings={result.currentFindings} />
         </section>
       )}
 
@@ -297,7 +215,7 @@ export function SimulationPanel({ snapshotId }: SimulationPanelProps) {
             fontSize: '0.75rem',
           }}
         >
-          Re-run Simulation
+          Refresh Guidance
         </button>
       </div>
     </div>
@@ -320,102 +238,6 @@ function SummaryPill({ label, value, color }: { label: string; value: number; co
     >
       {label}: <strong style={{ color: color || 'inherit' }}>{value}</strong>
     </span>
-  );
-}
-
-function ChangeCard({ change }: { change: ProposedChange }) {
-  return (
-    <div
-      style={{
-        padding: '0.75rem 1rem',
-        border: '1px solid #e2e8f0',
-        borderRadius: '8px',
-        borderLeft: `4px solid ${RISK_COLORS[change.risk] || '#6b7280'}`,
-        backgroundColor: 'white',
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '0.5rem',
-          marginBottom: '0.375rem',
-        }}
-      >
-        <span
-          style={{
-            padding: '0.125rem 0.375rem',
-            borderRadius: '4px',
-            fontSize: '0.625rem',
-            fontWeight: 700,
-            textTransform: 'uppercase',
-            color: 'white',
-            backgroundColor:
-              change.action === 'add'
-                ? '#16a34a'
-                : change.action === 'remove'
-                  ? '#dc2626'
-                  : '#d97706',
-          }}
-        >
-          {ACTION_LABELS[change.action]}
-        </span>
-        <code style={{ fontSize: '0.8125rem', fontWeight: 600 }}>
-          {change.name} {change.type}
-        </code>
-        <span
-          style={{
-            fontSize: '0.625rem',
-            color: RISK_COLORS[change.risk],
-            fontWeight: 600,
-          }}
-        >
-          {change.risk} risk
-        </span>
-      </div>
-
-      {/* Current → Proposed diff */}
-      {change.currentValues.length > 0 && (
-        <div
-          style={{
-            fontSize: '0.75rem',
-            fontFamily: 'monospace',
-            color: '#dc2626',
-            backgroundColor: '#fef2f2',
-            padding: '0.25rem 0.5rem',
-            borderRadius: '4px',
-            marginBottom: '0.25rem',
-          }}
-        >
-          − {change.currentValues.join(', ')}
-        </div>
-      )}
-      {change.proposedValues.length > 0 && (
-        <div
-          style={{
-            fontSize: '0.75rem',
-            fontFamily: 'monospace',
-            color: '#16a34a',
-            backgroundColor: '#f0fdf4',
-            padding: '0.25rem 0.5rem',
-            borderRadius: '4px',
-            marginBottom: '0.25rem',
-          }}
-        >
-          + {change.proposedValues.join(', ')}
-        </div>
-      )}
-
-      <p
-        style={{
-          fontSize: '0.75rem',
-          color: '#6b7280',
-          margin: '0.25rem 0 0',
-        }}
-      >
-        {change.rationale}
-      </p>
-    </div>
   );
 }
 

--- a/apps/web/app/components/SnapshotHistoryPanel.tsx
+++ b/apps/web/app/components/SnapshotHistoryPanel.tsx
@@ -23,6 +23,10 @@ interface SnapshotListItem {
   createdAt: string;
   rulesetVersionId: string | null;
   findingsEvaluated: boolean;
+  evaluationCoverage: {
+    state: 'COMPLETE' | 'PARTIAL';
+    errors: Array<{ unknown: { explanation: string; actionLabel: string } }>;
+  };
   queryScope: { names: string[]; types: string[]; vantages: string[] };
 }
 
@@ -299,8 +303,11 @@ export function SnapshotHistoryPanel({ domain }: SnapshotHistoryPanelProps) {
                       Evaluated
                     </span>
                   ) : (
-                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                      Pending
+                    <span
+                      className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800"
+                      title={`${snap.evaluationCoverage.errors[0]?.unknown.explanation ?? 'Evaluation coverage is incomplete'} ${snap.evaluationCoverage.errors[0]?.unknown.actionLabel ?? 'Run a fresh scan'}.`}
+                    >
+                      UNKNOWN — run fresh scan
                     </span>
                   )}
                 </td>

--- a/apps/web/app/lib/evidence-query-cache.test.ts
+++ b/apps/web/app/lib/evidence-query-cache.test.ts
@@ -1,0 +1,55 @@
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+import {
+  clearAuthenticatedQueryCache,
+  didPrincipalChange,
+  invalidateDomainEvidenceQueries,
+  isAuthenticationCacheEpochKey,
+} from './evidence-query-cache.js';
+
+describe('evidence query cache isolation', () => {
+  it('recognizes cross-tab authentication cache notifications', () => {
+    expect(isAuthenticationCacheEpochKey('dns-ops-auth-cache-epoch')).toBe(true);
+    expect(isAuthenticationCacheEpochKey('other-key')).toBe(false);
+  });
+
+  it('detects a principal change across independent browser-tab session refreshes', () => {
+    expect(
+      didPrincipalChange('tenant-a:operator@example.com', 'tenant-b:operator@example.com')
+    ).toBe(true);
+    expect(
+      didPrincipalChange('tenant-a:operator@example.com', 'tenant-a:operator@example.com')
+    ).toBe(false);
+  });
+
+  it('resets active observers as well as inactive previous-principal evidence', async () => {
+    const client = new QueryClient();
+    client.setQueryData(['domain-evidence', 'shared.example'], { tenant: 'previous' });
+    client.setQueryData(['domain-profile', 'shared.example'], { tenant: 'previous' });
+
+    const observer = new QueryObserver(client, {
+      queryKey: ['domain-evidence', 'shared.example'],
+      queryFn: async () => ({ tenant: 'new' }),
+      enabled: false,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    await clearAuthenticatedQueryCache(client);
+
+    expect(client.getQueryData(['domain-evidence', 'shared.example'])).toBeUndefined();
+    expect(observer.getCurrentResult().data).toBeUndefined();
+    unsubscribe();
+    expect(client.getQueryData(['domain-profile', 'shared.example'])).toBeUndefined();
+  });
+
+  it('invalidates profile and evidence after a fresh scan', async () => {
+    const client = new QueryClient();
+    client.setQueryData(['domain-evidence', 'example.com'], { snapshot: 'old' });
+    client.setQueryData(['domain-profile', 'example.com'], { purpose: 'WEB' });
+
+    await invalidateDomainEvidenceQueries(client, 'example.com');
+
+    expect(client.getQueryState(['domain-evidence', 'example.com'])?.isInvalidated).toBe(true);
+    expect(client.getQueryState(['domain-profile', 'example.com'])?.isInvalidated).toBe(true);
+  });
+});

--- a/apps/web/app/lib/evidence-query-cache.ts
+++ b/apps/web/app/lib/evidence-query-cache.ts
@@ -1,0 +1,38 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+const AUTH_CACHE_EPOCH_KEY = 'dns-ops-auth-cache-epoch';
+
+export function notifyAuthenticationChange(): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(AUTH_CACHE_EPOCH_KEY, String(Date.now()));
+  }
+}
+
+export function isAuthenticationCacheEpochKey(key: string | null): boolean {
+  return key === AUTH_CACHE_EPOCH_KEY;
+}
+
+export function didPrincipalChange(previous: string | null, next: string | null): boolean {
+  return previous !== next;
+}
+
+/** Clear all tenant-bound query results whenever the authenticated principal changes. */
+export async function clearAuthenticatedQueryCache(queryClient: QueryClient): Promise<void> {
+  // resetQueries notifies active observers and clears their result data;
+  // clear() alone removes cache entries but can leave mounted observers rendering
+  // the prior principal's last result.
+  await queryClient.cancelQueries();
+  await queryClient.resetQueries();
+  queryClient.removeQueries({ type: 'inactive' });
+}
+
+/** Refresh profile/evidence alongside the domain snapshot after a new scan. */
+export async function invalidateDomainEvidenceQueries(
+  queryClient: QueryClient,
+  domain: string
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ['domain-evidence', domain] }),
+    queryClient.invalidateQueries({ queryKey: ['domain-profile', domain] }),
+  ]);
+}

--- a/apps/web/app/routes/__root.tsx
+++ b/apps/web/app/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import {
   createRootRoute,
   HeadContent,
@@ -11,6 +11,12 @@ import {
 } from '@tanstack/react-router';
 import { useEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
+import {
+  clearAuthenticatedQueryCache,
+  didPrincipalChange,
+  isAuthenticationCacheEpochKey,
+  notifyAuthenticationChange,
+} from '../lib/evidence-query-cache.js';
 import '../styles/app.css';
 
 export const Route = createRootRoute({
@@ -31,7 +37,17 @@ function AuthNav() {
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const isLoggingOut = useRef(false);
+  const principalRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (isAuthenticationCacheEpochKey(event.key)) void clearAuthenticatedQueryCache(queryClient);
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [queryClient]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: only pathname matters for re-checking auth
   useEffect(() => {
@@ -40,14 +56,25 @@ function AuthNav() {
       isLoggingOut.current = false;
       return;
     }
+    void clearAuthenticatedQueryCache(queryClient);
     fetch('/api/auth/me', { credentials: 'include' })
       .then((res) => res.json())
       .then((raw) => {
         const data = raw as Record<string, unknown>;
         if (data.authenticated) {
+          const email = (data.email as string | undefined) || null;
+          const tenant = (data.tenant as string | undefined) || null;
+          const principal = `${tenant ?? ''}:${email ?? ''}`;
+          if (didPrincipalChange(principalRef.current, principal)) {
+            void clearAuthenticatedQueryCache(queryClient);
+            principalRef.current = principal;
+          }
           setIsAuthenticated(true);
-          setUserEmail((data.email as string | undefined) || null);
+          setUserEmail(email);
         } else {
+          if (didPrincipalChange(principalRef.current, null))
+            void clearAuthenticatedQueryCache(queryClient);
+          principalRef.current = null;
           setIsAuthenticated(false);
           setUserEmail(null);
         }
@@ -61,6 +88,8 @@ function AuthNav() {
       method: 'POST',
       credentials: 'include',
     });
+    await clearAuthenticatedQueryCache(queryClient);
+    notifyAuthenticationChange();
     flushSync(() => {
       setIsAuthenticated(false);
       setUserEmail(null);

--- a/apps/web/app/routes/domain/$domain.tsx
+++ b/apps/web/app/routes/domain/$domain.tsx
@@ -293,13 +293,30 @@ function Domain360Page() {
         </div>
 
         {snapshot ? (
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <ZoneManagementBadge type={snapshot.zoneManagement} />
-            <ResultStateBadge state={snapshot.resultState} />
-            <span className="text-sm text-gray-500 tabular-nums">
-              Last updated: {new Date(snapshot.createdAt).toLocaleString()}
-            </span>
-          </div>
+          <>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <ZoneManagementBadge type={snapshot.zoneManagement} />
+              <ResultStateBadge state={snapshot.resultState} />
+              <span className="text-sm text-gray-500 tabular-nums">
+                Last updated: {new Date(snapshot.createdAt).toLocaleString()}
+              </span>
+            </div>
+            {snapshot.metadata?.authoritativeEvidence?.state === 'UNKNOWN' && (
+              <div className="mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+                <strong>Authoritative evidence UNKNOWN.</strong>{' '}
+                {snapshot.metadata.authoritativeEvidence.unknown?.explanation}{' '}
+                <button
+                  type="button"
+                  onClick={handleRefresh}
+                  disabled={refreshMutation.isPending}
+                  className="font-semibold underline disabled:opacity-50"
+                >
+                  {snapshot.metadata.authoritativeEvidence.unknown?.actionLabel ??
+                    'Retry authoritative DNS collection'}
+                </button>
+              </div>
+            )}
+          </>
         ) : loaderError ? (
           <div
             className={`mt-4 p-4 rounded-lg border ${

--- a/apps/web/app/routes/domain/$domain.tsx
+++ b/apps/web/app/routes/domain/$domain.tsx
@@ -520,9 +520,9 @@ function OverviewTab({
 
       {SIMULATION_ENABLED && (
         <div>
-          <h3 className="font-semibold text-gray-900 mb-2">Fix Simulation</h3>
+          <h3 className="font-semibold text-gray-900 mb-2">Remediation Guidance</h3>
           <p className="text-sm text-gray-500 mb-3">
-            Simulate DNS changes to see which findings would be resolved.
+            Review non-executable playbooks. Exact changes require confirmed provider context.
           </p>
           <SimulationPanel snapshotId={snapshot.id} />
         </div>

--- a/apps/web/app/routes/domain/$domain.tsx
+++ b/apps/web/app/routes/domain/$domain.tsx
@@ -6,6 +6,7 @@ import { AuthPending } from '../../components/AuthPending.js';
 import { DelegationPanel } from '../../components/DelegationPanel.js';
 import { DiscoveredSelectors } from '../../components/DiscoveredSelectors.js';
 import { DNSViews } from '../../components/DNSViews.js';
+import { DomainEvidencePanel } from '../../components/DomainEvidencePanel.js';
 import { MailFindingsPanel } from '../../components/MailFindingsPanel.js';
 import { MailDiagnostics } from '../../components/mail/index.js';
 import { NotesPanel } from '../../components/NotesPanel.js';
@@ -47,6 +48,7 @@ const ALL_TABS: DomainTabId[] = DELEGATION_ENABLED ? [...BASE_TABS, 'delegation'
 const VALID_TABS: DomainTabId[] = ALL_TABS;
 
 import { requireAuthGuard } from '../../lib/auth-guard.js';
+import { invalidateDomainEvidenceQueries } from '../../lib/evidence-query-cache.js';
 
 export const Route = createFileRoute('/domain/$domain')({
   component: Domain360Page,
@@ -183,6 +185,7 @@ function Domain360Page() {
         window.history.replaceState(window.history.state, '', url.toString());
       }
       queryClient.invalidateQueries({ queryKey: ['domain-data', domain] });
+      void invalidateDomainEvidenceQueries(queryClient, domain);
       queryClient.invalidateQueries({ queryKey: ['domain-resolve', domain, true] });
       queryClient.invalidateQueries({ queryKey: ['notes'] });
       queryClient.invalidateQueries({ queryKey: ['tags'] });
@@ -484,6 +487,8 @@ function OverviewTab({
           <p className="text-gray-500">No DNS evidence available yet for {domain}.</p>
         </div>
 
+        <DomainEvidencePanel domain={domain} />
+
         <div className="space-y-4">
           <div>
             <h3 className="font-semibold text-gray-900">Operator Context</h3>
@@ -517,6 +522,8 @@ function OverviewTab({
           color={errorCount > 0 ? 'red' : 'gray'}
         />
       </div>
+
+      <DomainEvidencePanel domain={domain} />
 
       {SIMULATION_ENABLED && (
         <div>

--- a/apps/web/app/routes/login.tsx
+++ b/apps/web/app/routes/login.tsx
@@ -1,5 +1,10 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useId, useState } from 'react';
+import {
+  clearAuthenticatedQueryCache,
+  notifyAuthenticationChange,
+} from '../lib/evidence-query-cache.js';
 
 export const Route = createFileRoute('/login')({
   component: LoginPage,
@@ -7,6 +12,7 @@ export const Route = createFileRoute('/login')({
 
 function LoginPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const emailId = useId();
   const passwordId = useId();
   const [email, setEmail] = useState('');
@@ -36,6 +42,8 @@ function LoginPage() {
       const data = (await response.json()) as Record<string, unknown>;
 
       if (response.ok) {
+        await clearAuthenticatedQueryCache(queryClient);
+        notifyAuthenticationChange();
         navigate({ to: '/' });
       } else {
         setError((data.error as string | undefined) || 'Login failed');

--- a/apps/web/app/ssr.tsx
+++ b/apps/web/app/ssr.tsx
@@ -1,5 +1,16 @@
 import { getRouterManifest } from '@tanstack/react-start/router-manifest';
 import { createStartHandler, defaultStreamHandler } from '@tanstack/react-start/server';
+import { mcpServer } from '../hono/routes/mcp-server.js';
 import { createRouter } from './router.js';
 
-export default createStartHandler({ createRouter, getRouterManifest })(defaultStreamHandler);
+/**
+ * `/mcp` is a server-only transport endpoint. Keeping it here avoids importing
+ * Hono, PostgreSQL, or Node-only security code into the browser route graph.
+ */
+export default createStartHandler({ createRouter, getRouterManifest })(async (context) => {
+  const url = new URL(context.request.url);
+  if (url.pathname === '/mcp' && context.request.method === 'POST') {
+    return mcpServer.fetch(context.request, {});
+  }
+  return defaultStreamHandler(context);
+});

--- a/apps/web/hono/lib/guidance.ts
+++ b/apps/web/hono/lib/guidance.ts
@@ -1,0 +1,31 @@
+import type { GuidanceOnlySuggestion } from '@dns-ops/contracts';
+import type { Suggestion } from '@dns-ops/db';
+import { guidanceForFindingType } from '@dns-ops/rules';
+
+export function guidanceForPersistedFinding(findingType: string): GuidanceOnlySuggestion {
+  return (
+    guidanceForFindingType(findingType) ?? {
+      kind: 'GUIDANCE_ONLY',
+      title: 'Review the evidence and applicable operator playbook',
+      explanation:
+        'Confirm ownership, dependencies, and exact provider context before planning any change.',
+      playbookId: 'operations.manual-evidence-review',
+      requiresProviderConfirmation: false,
+      executableMutation: null,
+    }
+  );
+}
+
+export function sanitizePersistedSuggestion(
+  suggestion: Suggestion,
+  findingType: string
+): Suggestion {
+  const guidance = guidanceForPersistedFinding(findingType);
+  return {
+    ...suggestion,
+    title: guidance.title,
+    description: guidance.explanation,
+    action: `Playbook: ${guidance.playbookId}`,
+    reviewOnly: true,
+  };
+}

--- a/apps/web/hono/lib/mcp-auth.test.ts
+++ b/apps/web/hono/lib/mcp-auth.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  authenticateMcpBearer,
+  hashMcpToken,
+  parseMcpPrincipals,
+  requireMcpScope,
+} from './mcp-auth.js';
+
+const token = 'this-is-a-long-random-mcp-token-value-1234567890';
+const secret = JSON.stringify([
+  {
+    tokenHash: hashMcpToken(token),
+    tenantId: 'tenant-a',
+    actorId: 'actor-a',
+    scopes: ['CASE_READ', 'SCAN_REQUEST'],
+  },
+]);
+
+describe('MCP static principal authentication', () => {
+  it('derives tenant, actor, and scopes solely from a token hash', () => {
+    const principal = authenticateMcpBearer(`Bearer ${token}`, parseMcpPrincipals(secret));
+    expect(principal).toMatchObject({ tenantId: 'tenant-a', actorId: 'actor-a' });
+    expect(principal?.scopes.has('SCAN_REQUEST')).toBe(true);
+  });
+
+  it('rejects disabled, malformed, and unknown bearer tokens', () => {
+    const disabled = parseMcpPrincipals(
+      JSON.stringify([
+        {
+          tokenHash: hashMcpToken(token),
+          tenantId: 'tenant-a',
+          actorId: 'actor-a',
+          scopes: [],
+          disabled: true,
+        },
+      ])
+    );
+    expect(authenticateMcpBearer(`Bearer ${token}`, disabled)).toBeNull();
+    expect(authenticateMcpBearer('Bearer short', parseMcpPrincipals(secret))).toBeNull();
+    expect(authenticateMcpBearer(`Bearer ${token}x`, parseMcpPrincipals(secret))).toBeNull();
+  });
+
+  it('rejects raw tokens and invalid principal configuration', () => {
+    expect(() =>
+      parseMcpPrincipals(
+        JSON.stringify([{ tokenHash: token, tenantId: 't', actorId: 'a', scopes: [] }])
+      )
+    ).toThrow('invalid fields');
+    const principal = authenticateMcpBearer(`Bearer ${token}`, parseMcpPrincipals(secret));
+    expect(principal).not.toBeNull();
+    if (!principal) throw new Error('Expected test principal');
+    expect(() => requireMcpScope(principal, 'CASE_WRITE')).toThrow('scope denied');
+  });
+});

--- a/apps/web/hono/lib/mcp-auth.test.ts
+++ b/apps/web/hono/lib/mcp-auth.test.ts
@@ -7,34 +7,30 @@ import {
 } from './mcp-auth.js';
 
 const token = 'this-is-a-long-random-mcp-token-value-1234567890';
-const secret = JSON.stringify([
-  {
-    tokenHash: hashMcpToken(token),
-    tenantId: 'tenant-a',
-    actorId: 'actor-a',
-    scopes: ['CASE_READ', 'SCAN_REQUEST'],
-  },
-]);
+const tenantId = '11111111-1111-4111-8111-111111111111';
+const principal = {
+  principalId: 'mcp-operator-a',
+  actorId: 'actor-a',
+  tenantId,
+  tokenSha256: hashMcpToken(token),
+  scopes: ['CASE_READ', 'SCAN_REQUEST'],
+  enabled: true,
+};
+const secret = JSON.stringify([principal]);
 
 describe('MCP static principal authentication', () => {
-  it('derives tenant, actor, and scopes solely from a token hash', () => {
-    const principal = authenticateMcpBearer(`Bearer ${token}`, parseMcpPrincipals(secret));
-    expect(principal).toMatchObject({ tenantId: 'tenant-a', actorId: 'actor-a' });
-    expect(principal?.scopes.has('SCAN_REQUEST')).toBe(true);
+  it('derives principal, tenant, actor, and scopes solely from a token hash', () => {
+    const authenticated = authenticateMcpBearer(`Bearer ${token}`, parseMcpPrincipals(secret));
+    expect(authenticated).toMatchObject({
+      principalId: 'mcp-operator-a',
+      tenantId,
+      actorId: 'actor-a',
+    });
+    expect(authenticated?.scopes.has('SCAN_REQUEST')).toBe(true);
   });
 
   it('rejects disabled, malformed, and unknown bearer tokens', () => {
-    const disabled = parseMcpPrincipals(
-      JSON.stringify([
-        {
-          tokenHash: hashMcpToken(token),
-          tenantId: 'tenant-a',
-          actorId: 'actor-a',
-          scopes: [],
-          disabled: true,
-        },
-      ])
-    );
+    const disabled = parseMcpPrincipals(JSON.stringify([{ ...principal, enabled: false }]));
     expect(authenticateMcpBearer(`Bearer ${token}`, disabled)).toBeNull();
     expect(authenticateMcpBearer('Bearer short', parseMcpPrincipals(secret))).toBeNull();
     expect(authenticateMcpBearer(`Bearer ${token}x`, parseMcpPrincipals(secret))).toBeNull();
@@ -42,13 +38,11 @@ describe('MCP static principal authentication', () => {
 
   it('rejects raw tokens and invalid principal configuration', () => {
     expect(() =>
-      parseMcpPrincipals(
-        JSON.stringify([{ tokenHash: token, tenantId: 't', actorId: 'a', scopes: [] }])
-      )
+      parseMcpPrincipals(JSON.stringify([{ ...principal, tokenSha256: token }]))
     ).toThrow('invalid fields');
-    const principal = authenticateMcpBearer(`Bearer ${token}`, parseMcpPrincipals(secret));
-    expect(principal).not.toBeNull();
-    if (!principal) throw new Error('Expected test principal');
-    expect(() => requireMcpScope(principal, 'CASE_WRITE')).toThrow('scope denied');
+    const authenticated = authenticateMcpBearer(`Bearer ${token}`, parseMcpPrincipals(secret));
+    expect(authenticated).not.toBeNull();
+    if (!authenticated) throw new Error('Expected test principal');
+    expect(() => requireMcpScope(authenticated, 'CASE_WRITE')).toThrow('scope denied');
   });
 });

--- a/apps/web/hono/lib/mcp-auth.ts
+++ b/apps/web/hono/lib/mcp-auth.ts
@@ -1,0 +1,82 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+export const MCP_SCOPES = ['CASE_READ', 'CASE_WRITE', 'SCAN_REQUEST'] as const;
+export type McpScope = (typeof MCP_SCOPES)[number];
+
+export interface McpPrincipal {
+  tokenHash: string;
+  tenantId: string;
+  actorId: string;
+  scopes: McpScope[];
+  disabled?: boolean;
+}
+
+export interface AuthenticatedMcpPrincipal {
+  tenantId: string;
+  actorId: string;
+  scopes: ReadonlySet<McpScope>;
+}
+
+export function hashMcpToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function parseMcpPrincipals(secret: string | undefined): McpPrincipal[] {
+  if (!secret) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(secret);
+  } catch {
+    throw new Error('MCP principal configuration is invalid JSON');
+  }
+  if (!Array.isArray(parsed)) throw new Error('MCP principal configuration must be an array');
+  return parsed.map((candidate) => {
+    if (!candidate || typeof candidate !== 'object') throw new Error('MCP principal is invalid');
+    const value = candidate as Record<string, unknown>;
+    if (
+      typeof value.tokenHash !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(value.tokenHash) ||
+      typeof value.tenantId !== 'string' ||
+      !value.tenantId ||
+      typeof value.actorId !== 'string' ||
+      !value.actorId ||
+      !Array.isArray(value.scopes) ||
+      value.scopes.some((scope) => !MCP_SCOPES.includes(scope as McpScope)) ||
+      (typeof value.disabled !== 'undefined' && typeof value.disabled !== 'boolean')
+    )
+      throw new Error('MCP principal has invalid fields');
+    return {
+      tokenHash: value.tokenHash,
+      tenantId: value.tenantId,
+      actorId: value.actorId,
+      scopes: value.scopes as McpScope[],
+      disabled: value.disabled as boolean | undefined,
+    };
+  });
+}
+
+function fixedEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, 'hex');
+  const rightBuffer = Buffer.from(right, 'hex');
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export function authenticateMcpBearer(
+  authorization: string | undefined,
+  principals: readonly McpPrincipal[]
+): AuthenticatedMcpPrincipal | null {
+  const match = authorization?.match(/^Bearer ([A-Za-z0-9_-]{32,})$/);
+  if (!match) return null;
+  const tokenHash = hashMcpToken(match[1]);
+  const principal = principals.find((candidate) => fixedEqual(candidate.tokenHash, tokenHash));
+  if (!principal || principal.disabled) return null;
+  return {
+    tenantId: principal.tenantId,
+    actorId: principal.actorId,
+    scopes: new Set(principal.scopes),
+  };
+}
+
+export function requireMcpScope(principal: AuthenticatedMcpPrincipal, scope: McpScope): void {
+  if (!principal.scopes.has(scope)) throw new Error('MCP scope denied');
+}

--- a/apps/web/hono/lib/mcp-auth.ts
+++ b/apps/web/hono/lib/mcp-auth.ts
@@ -10,14 +10,16 @@ export const MCP_SCOPES = [
 export type McpScope = (typeof MCP_SCOPES)[number];
 
 export interface McpPrincipal {
-  tokenHash: string;
-  tenantId: string;
+  principalId: string;
   actorId: string;
+  tenantId: string;
+  tokenSha256: string;
   scopes: McpScope[];
-  disabled?: boolean;
+  enabled: boolean;
 }
 
 export interface AuthenticatedMcpPrincipal {
+  principalId: string;
   tenantId: string;
   actorId: string;
   scopes: ReadonlySet<McpScope>;
@@ -40,23 +42,28 @@ export function parseMcpPrincipals(secret: string | undefined): McpPrincipal[] {
     if (!candidate || typeof candidate !== 'object') throw new Error('MCP principal is invalid');
     const value = candidate as Record<string, unknown>;
     if (
-      typeof value.tokenHash !== 'string' ||
-      !/^[a-f0-9]{64}$/.test(value.tokenHash) ||
+      typeof value.principalId !== 'string' ||
+      !value.principalId ||
+      typeof value.tokenSha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(value.tokenSha256) ||
       typeof value.tenantId !== 'string' ||
-      !value.tenantId ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        value.tenantId
+      ) ||
       typeof value.actorId !== 'string' ||
       !value.actorId ||
       !Array.isArray(value.scopes) ||
       value.scopes.some((scope) => !MCP_SCOPES.includes(scope as McpScope)) ||
-      (typeof value.disabled !== 'undefined' && typeof value.disabled !== 'boolean')
+      typeof value.enabled !== 'boolean'
     )
       throw new Error('MCP principal has invalid fields');
     return {
-      tokenHash: value.tokenHash,
+      principalId: value.principalId,
+      tokenSha256: value.tokenSha256,
       tenantId: value.tenantId,
       actorId: value.actorId,
       scopes: value.scopes as McpScope[],
-      disabled: value.disabled as boolean | undefined,
+      enabled: value.enabled,
     };
   });
 }
@@ -74,9 +81,10 @@ export function authenticateMcpBearer(
   const match = authorization?.match(/^Bearer ([A-Za-z0-9_-]{32,})$/);
   if (!match) return null;
   const tokenHash = hashMcpToken(match[1]);
-  const principal = principals.find((candidate) => fixedEqual(candidate.tokenHash, tokenHash));
-  if (!principal || principal.disabled) return null;
+  const principal = principals.find((candidate) => fixedEqual(candidate.tokenSha256, tokenHash));
+  if (!principal || !principal.enabled) return null;
   return {
+    principalId: principal.principalId,
     tenantId: principal.tenantId,
     actorId: principal.actorId,
     scopes: new Set(principal.scopes),

--- a/apps/web/hono/lib/mcp-auth.ts
+++ b/apps/web/hono/lib/mcp-auth.ts
@@ -1,6 +1,12 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 
-export const MCP_SCOPES = ['CASE_READ', 'CASE_WRITE', 'SCAN_REQUEST'] as const;
+export const MCP_SCOPES = [
+  'DOMAIN_READ',
+  'SIGNAL_READ',
+  'CASE_READ',
+  'CASE_WRITE',
+  'SCAN_REQUEST',
+] as const;
 export type McpScope = (typeof MCP_SCOPES)[number];
 
 export interface McpPrincipal {

--- a/apps/web/hono/lib/mcp-case-command-service.failure.test.ts
+++ b/apps/web/hono/lib/mcp-case-command-service.failure.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  claim: vi.fn(),
+  complete: vi.fn(),
+  openCanonicalCase: vi.fn(),
+}));
+
+vi.mock('@dns-ops/db', () => ({
+  McpCommandRepository: class {
+    claim = mocks.claim;
+    complete = mocks.complete;
+  },
+  OperationalConditionService: class {
+    openCanonicalCase = mocks.openCanonicalCase;
+  },
+}));
+
+import { McpCaseCommandService } from './mcp-case-command-service.js';
+
+describe('McpCaseCommandService command failures', () => {
+  it('persists a deterministic failed case-open result instead of leaving the command pending', async () => {
+    mocks.claim.mockResolvedValue({ state: 'CLAIMED', command: { id: 'command-1' } });
+    mocks.openCanonicalCase.mockRejectedValue(new Error('database unavailable'));
+    mocks.complete.mockResolvedValue(undefined);
+
+    const service = new McpCaseCommandService({} as never, {
+      tenantId: 'tenant-1',
+      principalId: 'principal-1',
+      actorId: 'actor-1',
+      scopes: new Set(['CASE_WRITE']),
+    });
+
+    await expect(
+      service.caseOpen({
+        domainId: 'domain-1',
+        conditionKey: 'mail.no-spf-record',
+        idempotencyKey: 'key-1',
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: 'COMMAND_FAILED', message: 'Case open failed' },
+      replayed: false,
+    });
+    expect(mocks.complete).toHaveBeenCalledWith(
+      'tenant-1',
+      'command-1',
+      expect.objectContaining({ error: expect.objectContaining({ code: 'COMMAND_FAILED' }) }),
+      undefined,
+      'FAILED'
+    );
+  });
+});

--- a/apps/web/hono/lib/mcp-case-command-service.failure.test.ts
+++ b/apps/web/hono/lib/mcp-case-command-service.failure.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   claim: vi.fn(),
@@ -21,6 +21,8 @@ vi.mock('@dns-ops/db', () => ({
 import { McpCaseCommandService } from './mcp-case-command-service.js';
 
 describe('McpCaseCommandService command failures', () => {
+  afterEach(() => vi.clearAllMocks());
+
   it('persists a deterministic failed case-open result instead of leaving the command pending', async () => {
     mocks.claim.mockResolvedValue({ state: 'CLAIMED', command: { id: 'command-1' } });
     mocks.openCanonicalCase.mockRejectedValue(new Error('database unavailable'));
@@ -50,6 +52,45 @@ describe('McpCaseCommandService command failures', () => {
       expect.objectContaining({ error: expect.objectContaining({ code: 'COMMAND_FAILED' }) }),
       undefined,
       'FAILED'
+    );
+  });
+
+  it('replays a duplicate case-open key without another canonical-service invocation', async () => {
+    const response = {
+      ok: true,
+      value: { case: { id: 'case-1' }, signal: { id: 'signal-1' } },
+      replayed: false,
+    } as const;
+    mocks.claim
+      .mockResolvedValueOnce({ state: 'CLAIMED', command: { id: 'command-1' } })
+      .mockResolvedValueOnce({ state: 'REPLAY', command: { id: 'command-1', response } });
+    mocks.openCanonicalCase.mockResolvedValue({
+      case: { id: 'case-1' },
+      signal: { id: 'signal-1' },
+    });
+    mocks.complete.mockResolvedValue(undefined);
+
+    const service = new McpCaseCommandService({} as never, {
+      tenantId: 'tenant-1',
+      principalId: 'principal-1',
+      actorId: 'actor-1',
+      scopes: new Set(['CASE_WRITE']),
+    });
+    const input = {
+      domainId: 'domain-1',
+      conditionKey: 'mail.no-spf-record',
+      idempotencyKey: 'key-replay',
+    };
+
+    await expect(service.caseOpen(input)).resolves.toEqual(response);
+    await expect(service.caseOpen(input)).resolves.toEqual({ ...response, replayed: true });
+    expect(mocks.openCanonicalCase).toHaveBeenCalledTimes(1);
+    expect(mocks.complete).toHaveBeenCalledWith(
+      'tenant-1',
+      'command-1',
+      response,
+      'case-1',
+      'COMPLETED'
     );
   });
 

--- a/apps/web/hono/lib/mcp-case-command-service.failure.test.ts
+++ b/apps/web/hono/lib/mcp-case-command-service.failure.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   claim: vi.fn(),
   complete: vi.fn(),
   openCanonicalCase: vi.fn(),
+  setCaseDisposition: vi.fn(),
 }));
 
 vi.mock('@dns-ops/db', () => ({
@@ -13,6 +14,7 @@ vi.mock('@dns-ops/db', () => ({
   },
   OperationalConditionService: class {
     openCanonicalCase = mocks.openCanonicalCase;
+    setCaseDisposition = mocks.setCaseDisposition;
   },
 }));
 
@@ -46,6 +48,41 @@ describe('McpCaseCommandService command failures', () => {
       'tenant-1',
       'command-1',
       expect.objectContaining({ error: expect.objectContaining({ code: 'COMMAND_FAILED' }) }),
+      undefined,
+      'FAILED'
+    );
+  });
+
+  it('persists a stale expectedVersion result with no internal exception leakage', async () => {
+    mocks.claim.mockResolvedValue({ state: 'CLAIMED', command: { id: 'command-2' } });
+    mocks.setCaseDisposition.mockRejectedValue(
+      Object.assign(new Error('database conflict detail'), { code: 'OPERATION_CONFLICT' })
+    );
+    mocks.complete.mockResolvedValue(undefined);
+
+    const service = new McpCaseCommandService({} as never, {
+      tenantId: 'tenant-1',
+      principalId: 'principal-1',
+      actorId: 'actor-1',
+      scopes: new Set(['CASE_WRITE']),
+    });
+
+    await expect(
+      service.caseSetDisposition({
+        caseId: 'case-1',
+        disposition: 'ACKNOWLEDGED',
+        expectedVersion: 1,
+        idempotencyKey: 'key-2',
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: 'CASE_VERSION_STALE', message: 'Case version is stale' },
+      replayed: false,
+    });
+    expect(mocks.complete).toHaveBeenCalledWith(
+      'tenant-1',
+      'command-2',
+      expect.objectContaining({ error: expect.objectContaining({ code: 'CASE_VERSION_STALE' }) }),
       undefined,
       'FAILED'
     );

--- a/apps/web/hono/lib/mcp-case-command-service.test.ts
+++ b/apps/web/hono/lib/mcp-case-command-service.test.ts
@@ -1,0 +1,25 @@
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import { describe, expect, it } from 'vitest';
+import { McpCaseCommandService } from './mcp-case-command-service.js';
+
+describe('McpCaseCommandService', () => {
+  it('does not access persistence without CASE_WRITE', async () => {
+    const db = {
+      select: async () => {
+        throw new Error('must not reach persistence');
+      },
+    } as unknown as IDatabaseAdapter;
+    const service = new McpCaseCommandService(db, {
+      tenantId: 'tenant-1',
+      actorId: 'actor-1',
+      scopes: new Set(['CASE_READ']),
+    });
+    await expect(
+      service.caseOpen({
+        domainId: 'domain-1',
+        conditionKey: 'condition-1',
+        idempotencyKey: 'key-1',
+      })
+    ).rejects.toThrow('MCP scope denied');
+  });
+});

--- a/apps/web/hono/lib/mcp-case-command-service.test.ts
+++ b/apps/web/hono/lib/mcp-case-command-service.test.ts
@@ -11,6 +11,7 @@ describe('McpCaseCommandService', () => {
     } as unknown as IDatabaseAdapter;
     const service = new McpCaseCommandService(db, {
       tenantId: 'tenant-1',
+      principalId: 'principal-1',
       actorId: 'actor-1',
       scopes: new Set(['CASE_READ']),
     });

--- a/apps/web/hono/lib/mcp-case-command-service.ts
+++ b/apps/web/hono/lib/mcp-case-command-service.ts
@@ -1,0 +1,138 @@
+import { createHash } from 'node:crypto';
+import {
+  type IDatabaseAdapter,
+  McpCommandRepository,
+  OperationalConditionService,
+} from '@dns-ops/db';
+import { type AuthenticatedMcpPrincipal, requireMcpScope } from './mcp-auth.js';
+
+export type McpCommandResult =
+  | { ok: true; value: Record<string, unknown>; replayed: boolean }
+  | { ok: false; error: { code: string; message: string }; replayed: boolean };
+
+function fingerprint(value: Record<string, unknown>): string {
+  const canonical = JSON.stringify(
+    Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)))
+  );
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+function errorResult(code: string, message: string): McpCommandResult {
+  return { ok: false, error: { code, message }, replayed: false };
+}
+
+function replayResult(response: Record<string, unknown>): McpCommandResult {
+  return response as McpCommandResult;
+}
+
+/** Command adapter used by MCP only; all principal data is bearer-derived. */
+export class McpCaseCommandService {
+  constructor(
+    private db: IDatabaseAdapter,
+    private principal: AuthenticatedMcpPrincipal
+  ) {}
+
+  async caseOpen(input: {
+    domainId: string;
+    conditionKey: string;
+    idempotencyKey: string;
+  }): Promise<McpCommandResult> {
+    requireMcpScope(this.principal, 'CASE_WRITE');
+    if (!input.domainId || !input.conditionKey || !input.idempotencyKey) {
+      return errorResult(
+        'INVALID_ARGUMENT',
+        'domainId, conditionKey, and idempotencyKey are required'
+      );
+    }
+    const commands = new McpCommandRepository(this.db);
+    const claim = await commands.claim({
+      tenantId: this.principal.tenantId,
+      actorId: this.principal.actorId,
+      operation: 'case_open',
+      idempotencyKey: input.idempotencyKey,
+      requestFingerprint: fingerprint(input),
+    });
+    if (claim.state === 'REPLAY') {
+      if (!claim.command.response) throw new Error('Completed MCP command has no response');
+      return { ...replayResult(claim.command.response), replayed: true };
+    }
+    const found = await new OperationalConditionService(this.db).openCanonicalCase(
+      this.principal.tenantId,
+      input.domainId,
+      input.conditionKey
+    );
+    const result: McpCommandResult = found
+      ? { ok: true, value: { case: found.case, signal: found.signal }, replayed: false }
+      : errorResult('NOT_FOUND', 'Active canonical case not found');
+    await commands.complete(
+      this.principal.tenantId,
+      claim.command.id,
+      result as unknown as Record<string, unknown>,
+      found?.case.id,
+      result.ok ? 'COMPLETED' : 'FAILED'
+    );
+    return result;
+  }
+
+  async caseSetDisposition(input: {
+    caseId: string;
+    disposition: string;
+    expectedVersion: number;
+    idempotencyKey: string;
+  }): Promise<McpCommandResult> {
+    requireMcpScope(this.principal, 'CASE_WRITE');
+    if (
+      !input.caseId ||
+      !input.disposition ||
+      !input.idempotencyKey ||
+      !Number.isInteger(input.expectedVersion)
+    ) {
+      return errorResult(
+        'INVALID_ARGUMENT',
+        'caseId, disposition, expectedVersion, and idempotencyKey are required'
+      );
+    }
+    const commands = new McpCommandRepository(this.db);
+    const claim = await commands.claim({
+      tenantId: this.principal.tenantId,
+      actorId: this.principal.actorId,
+      operation: 'case_set_disposition',
+      idempotencyKey: input.idempotencyKey,
+      requestFingerprint: fingerprint(input),
+    });
+    if (claim.state === 'REPLAY') {
+      if (!claim.command.response) throw new Error('Completed MCP command has no response');
+      return { ...replayResult(claim.command.response), replayed: true };
+    }
+    let result: McpCommandResult;
+    try {
+      const updated = await new OperationalConditionService(this.db).setCaseDisposition({
+        tenantId: this.principal.tenantId,
+        actorId: this.principal.actorId,
+        caseId: input.caseId,
+        disposition: input.disposition,
+        expectedVersion: input.expectedVersion,
+      });
+      result = updated
+        ? { ok: true, value: { case: updated }, replayed: false }
+        : errorResult('NOT_FOUND', 'Case not found');
+    } catch (error) {
+      const code =
+        typeof error === 'object' && error && 'code' in error && error.code === 'OPERATION_CONFLICT'
+          ? 'CASE_VERSION_STALE'
+          : 'COMMAND_FAILED';
+      result = errorResult(
+        code,
+        code === 'CASE_VERSION_STALE' ? 'Case version is stale' : 'Case disposition update failed'
+      );
+    }
+    await commands.complete(
+      this.principal.tenantId,
+      claim.command.id,
+      result as unknown as Record<string, unknown>,
+      result.ok ? input.caseId : undefined,
+      result.ok ? 'COMPLETED' : 'FAILED'
+    );
+    return result;
+  }
+}

--- a/apps/web/hono/lib/mcp-case-command-service.ts
+++ b/apps/web/hono/lib/mcp-case-command-service.ts
@@ -56,19 +56,28 @@ export class McpCaseCommandService {
       if (!claim.command.response) throw new Error('Completed MCP command has no response');
       return { ...replayResult(claim.command.response), replayed: true };
     }
-    const found = await new OperationalConditionService(this.db).openCanonicalCase(
-      this.principal.tenantId,
-      input.domainId,
-      input.conditionKey
-    );
-    const result: McpCommandResult = found
-      ? { ok: true, value: { case: found.case, signal: found.signal }, replayed: false }
-      : errorResult('NOT_FOUND', 'Active canonical case not found');
+    let result: McpCommandResult;
+    let resourceId: string | undefined;
+    try {
+      const found = await new OperationalConditionService(this.db).openCanonicalCase(
+        this.principal.tenantId,
+        input.domainId,
+        input.conditionKey
+      );
+      if (found) {
+        resourceId = found.case.id;
+        result = { ok: true, value: { case: found.case, signal: found.signal }, replayed: false };
+      } else {
+        result = errorResult('NOT_FOUND', 'Active canonical case not found');
+      }
+    } catch {
+      result = errorResult('COMMAND_FAILED', 'Case open failed');
+    }
     await commands.complete(
       this.principal.tenantId,
       claim.command.id,
       result as unknown as Record<string, unknown>,
-      found?.case.id,
+      resourceId,
       result.ok ? 'COMPLETED' : 'FAILED'
     );
     return result;

--- a/apps/web/hono/lib/mcp-dispatch.test.ts
+++ b/apps/web/hono/lib/mcp-dispatch.test.ts
@@ -1,0 +1,30 @@
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import type { Context } from 'hono';
+import { describe, expect, it } from 'vitest';
+import type { Env } from '../types.js';
+import { dispatchMcpTool, toMcpDispatchError } from './mcp-dispatch.js';
+
+describe('MCP tool dispatch', () => {
+  it('rejects unknown and malformed tools before persistence', async () => {
+    const context = {} as Context<Env>;
+    const db = {} as IDatabaseAdapter;
+    const principal = {
+      tenantId: 'tenant-1',
+      actorId: 'actor-1',
+      scopes: new Set(['DOMAIN_READ'] as const),
+    };
+    await expect(dispatchMcpTool(context, db, principal, 'unknown_tool', {})).rejects.toMatchObject(
+      { code: -32601 }
+    );
+    await expect(
+      dispatchMcpTool(context, db, principal, 'domain_get_profile', {})
+    ).rejects.toMatchObject({ code: -32602 });
+  });
+
+  it('maps unexpected exceptions without internal leakage', () => {
+    expect(toMcpDispatchError(new Error('database connection password=x'))).toMatchObject({
+      code: -32603,
+      message: 'Tool execution failed',
+    });
+  });
+});

--- a/apps/web/hono/lib/mcp-dispatch.test.ts
+++ b/apps/web/hono/lib/mcp-dispatch.test.ts
@@ -10,6 +10,7 @@ describe('MCP tool dispatch', () => {
     const db = {} as IDatabaseAdapter;
     const principal = {
       tenantId: 'tenant-1',
+      principalId: 'principal-1',
       actorId: 'actor-1',
       scopes: new Set(['DOMAIN_READ'] as const),
     };

--- a/apps/web/hono/lib/mcp-dispatch.ts
+++ b/apps/web/hono/lib/mcp-dispatch.ts
@@ -1,0 +1,120 @@
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import type { Context } from 'hono';
+import type { Env } from '../types.js';
+import { type AuthenticatedMcpPrincipal, requireMcpScope } from './mcp-auth.js';
+import { McpCaseCommandService } from './mcp-case-command-service.js';
+import { McpNotFoundError, McpReadService } from './mcp-read-service.js';
+import { McpScanService } from './mcp-scan-service.js';
+import { getMcpTool } from './mcp-tools.js';
+
+export class McpDispatchError extends Error {
+  constructor(
+    readonly code: number,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+function argumentsObject(value: unknown, toolName: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new McpDispatchError(-32602, `${toolName} arguments must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function validateArguments(name: string, value: unknown): Record<string, unknown> {
+  const tool = getMcpTool(name);
+  if (!tool) throw new McpDispatchError(-32601, 'Tool not found');
+  const args = argumentsObject(value, name);
+  for (const required of tool.inputSchema.required) {
+    if (!(required in args)) throw new McpDispatchError(-32602, `${name} requires ${required}`);
+  }
+  for (const [key, argument] of Object.entries(args)) {
+    const schema = tool.inputSchema.properties[key];
+    if (!schema || typeof argument !== schema.type) {
+      throw new McpDispatchError(-32602, `${name} has invalid ${key}`);
+    }
+  }
+  return args;
+}
+
+function toolResult(value: unknown) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value) }],
+    structuredContent: value,
+  };
+}
+
+export async function dispatchMcpTool(
+  context: Context<Env>,
+  db: IDatabaseAdapter,
+  principal: AuthenticatedMcpPrincipal,
+  name: string,
+  rawArguments: unknown
+) {
+  const tool = getMcpTool(name);
+  if (!tool) throw new McpDispatchError(-32601, 'Tool not found');
+  const args = validateArguments(name, rawArguments);
+  requireMcpScope(principal, tool.requiredScope);
+  const read = new McpReadService(db, principal);
+  let value: unknown;
+  switch (name) {
+    case 'domain_search':
+      value = await read.domainSearch((args.query as string | undefined) ?? '');
+      break;
+    case 'domain_get_profile':
+      value = await read.domainProfile(args.domainId as string);
+      break;
+    case 'domain_get_posture':
+      value = await read.domainPosture(args.domainId as string);
+      break;
+    case 'snapshot_compare':
+      value = await read.snapshotCompare(
+        args.domainId as string,
+        args.leftSnapshotId as string,
+        args.rightSnapshotId as string
+      );
+      break;
+    case 'evidence_get':
+      value = await read.evidence(args.snapshotId as string);
+      break;
+    case 'signal_list':
+      value = await read.signalList(args.domainId as string | undefined);
+      break;
+    case 'case_get':
+      value = await read.caseGet(args.caseId as string);
+      break;
+    case 'case_open':
+      value = await new McpCaseCommandService(db, principal).caseOpen(
+        args as { domainId: string; conditionKey: string; idempotencyKey: string }
+      );
+      break;
+    case 'case_set_disposition':
+      value = await new McpCaseCommandService(db, principal).caseSetDisposition(
+        args as {
+          caseId: string;
+          disposition: string;
+          expectedVersion: number;
+          idempotencyKey: string;
+        }
+      );
+      break;
+    case 'scan_request':
+      value = await new McpScanService(context, db, principal).request(
+        args as { domainId: string; idempotencyKey: string }
+      );
+      break;
+    default:
+      throw new McpDispatchError(-32601, 'Tool not found');
+  }
+  return toolResult(value);
+}
+
+export function toMcpDispatchError(error: unknown): McpDispatchError {
+  if (error instanceof McpDispatchError) return error;
+  if (error instanceof McpNotFoundError) return new McpDispatchError(-32004, 'Resource not found');
+  if (error instanceof Error && error.message === 'MCP scope denied')
+    return new McpDispatchError(-32003, 'Scope denied');
+  return new McpDispatchError(-32603, 'Tool execution failed');
+}

--- a/apps/web/hono/lib/mcp-read-service.test.ts
+++ b/apps/web/hono/lib/mcp-read-service.test.ts
@@ -1,0 +1,33 @@
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import { describe, expect, it } from 'vitest';
+import { McpReadService } from './mcp-read-service.js';
+
+describe('McpReadService', () => {
+  it('re-checks the resource scope before accessing persistence', async () => {
+    const db = {
+      select: async () => {
+        throw new Error('persistence must not be reached');
+      },
+    } as unknown as IDatabaseAdapter;
+    const service = new McpReadService(db, {
+      tenantId: 'tenant-1',
+      actorId: 'actor-1',
+      scopes: new Set(['CASE_READ']),
+    });
+    await expect(service.domainSearch()).rejects.toThrow('MCP scope denied');
+  });
+
+  it('does not let a case-read principal enumerate signals', async () => {
+    const db = {
+      select: async () => {
+        throw new Error('persistence must not be reached');
+      },
+    } as unknown as IDatabaseAdapter;
+    const service = new McpReadService(db, {
+      tenantId: 'tenant-1',
+      actorId: 'actor-1',
+      scopes: new Set(['CASE_READ']),
+    });
+    await expect(service.signalList()).rejects.toThrow('MCP scope denied');
+  });
+});

--- a/apps/web/hono/lib/mcp-read-service.test.ts
+++ b/apps/web/hono/lib/mcp-read-service.test.ts
@@ -10,6 +10,7 @@ describe('McpReadService', () => {
       },
     } as unknown as IDatabaseAdapter;
     const service = new McpReadService(db, {
+      principalId: 'principal-1',
       tenantId: 'tenant-1',
       actorId: 'actor-1',
       scopes: new Set(['CASE_READ']),
@@ -24,6 +25,7 @@ describe('McpReadService', () => {
       },
     } as unknown as IDatabaseAdapter;
     const service = new McpReadService(db, {
+      principalId: 'principal-1',
       tenantId: 'tenant-1',
       actorId: 'actor-1',
       scopes: new Set(['CASE_READ']),

--- a/apps/web/hono/lib/mcp-read-service.ts
+++ b/apps/web/hono/lib/mcp-read-service.ts
@@ -1,0 +1,148 @@
+import {
+  DomainProfileRepository,
+  DomainRepository,
+  FindingRepository,
+  type IDatabaseAdapter,
+  OperationalConditionService,
+  ProbeObservationRepository,
+  RecordSetRepository,
+  SnapshotRepository,
+} from '@dns-ops/db';
+import { compareSnapshots } from '@dns-ops/parsing';
+import { type AuthenticatedMcpPrincipal, requireMcpScope } from './mcp-auth.js';
+
+export class McpNotFoundError extends Error {
+  constructor() {
+    super('Resource not found');
+  }
+}
+
+/** Shared tenant/scope enforcement for MCP read operations. */
+export class McpReadService {
+  constructor(
+    private db: IDatabaseAdapter,
+    private principal: AuthenticatedMcpPrincipal
+  ) {}
+
+  async domainSearch(query = '') {
+    requireMcpScope(this.principal, 'DOMAIN_READ');
+    return new DomainRepository(this.db).findAll(
+      { tenantId: this.principal.tenantId, search: query.slice(0, 100) },
+      { limit: 50 }
+    );
+  }
+
+  async domainProfile(domainId: string) {
+    requireMcpScope(this.principal, 'DOMAIN_READ');
+    const domain = await this.ownedDomain(domainId);
+    const profile = await new DomainProfileRepository(this.db).findByDomainId(
+      domain.id,
+      this.principal.tenantId
+    );
+    return { domain, profile, setupRequired: !profile || profile.purpose === 'UNKNOWN' };
+  }
+
+  async domainPosture(domainId: string) {
+    requireMcpScope(this.principal, 'DOMAIN_READ');
+    const domain = await this.ownedDomain(domainId);
+    const snapshots = await new SnapshotRepository(this.db).findByDomain(domain.id, 1);
+    const latestSnapshot = snapshots[0] ?? null;
+    const findings = latestSnapshot
+      ? await new FindingRepository(this.db).findBySnapshotId(latestSnapshot.id)
+      : [];
+    const cases = await new OperationalConditionService(this.db).listCases(
+      this.principal.tenantId,
+      domain.id
+    );
+    return {
+      domain,
+      latestSnapshot,
+      findings,
+      signals: cases.map((item) => item.signal),
+      cases: cases.map((item) => item.case),
+      setupRequired: !latestSnapshot || latestSnapshot.resultState !== 'complete',
+    };
+  }
+
+  async evidence(snapshotId: string) {
+    requireMcpScope(this.principal, 'DOMAIN_READ');
+    const snapshot = await this.ownedSnapshot(snapshotId);
+    const [records, findings, probes] = await Promise.all([
+      new RecordSetRepository(this.db).findBySnapshotId(snapshot.id),
+      new FindingRepository(this.db).findBySnapshotId(snapshot.id),
+      new ProbeObservationRepository(this.db).findBySnapshotId(snapshot.id),
+    ]);
+    return { snapshot, records, findings, probes, incomplete: snapshot.resultState !== 'complete' };
+  }
+
+  async snapshotCompare(domainId: string, leftSnapshotId: string, rightSnapshotId: string) {
+    requireMcpScope(this.principal, 'DOMAIN_READ');
+    const domain = await this.ownedDomain(domainId);
+    const [left, right] = await Promise.all([
+      new SnapshotRepository(this.db).findById(leftSnapshotId),
+      new SnapshotRepository(this.db).findById(rightSnapshotId),
+    ]);
+    if (!left || !right || left.domainId !== domain.id || right.domainId !== domain.id) {
+      throw new McpNotFoundError();
+    }
+    const recordRepo = new RecordSetRepository(this.db);
+    const findingRepo = new FindingRepository(this.db);
+    const [leftRecords, rightRecords, leftFindings, rightFindings] = await Promise.all([
+      recordRepo.findBySnapshotId(left.id),
+      recordRepo.findBySnapshotId(right.id),
+      findingRepo.findBySnapshotId(left.id),
+      findingRepo.findBySnapshotId(right.id),
+    ]);
+    return compareSnapshots(
+      {
+        id: left.id,
+        createdAt: left.createdAt,
+        rulesetVersion: String(left.rulesetVersionId ?? 'unknown'),
+        queriedNames: left.queriedNames,
+        queriedTypes: left.queriedTypes,
+        vantages: left.vantages,
+      },
+      {
+        id: right.id,
+        createdAt: right.createdAt,
+        rulesetVersion: String(right.rulesetVersionId ?? 'unknown'),
+        queriedNames: right.queriedNames,
+        queriedTypes: right.queriedTypes,
+        vantages: right.vantages,
+      },
+      leftRecords,
+      rightRecords,
+      left.resultState === 'complete' ? leftFindings : [],
+      right.resultState === 'complete' ? rightFindings : []
+    );
+  }
+
+  async signalList(domainId?: string) {
+    requireMcpScope(this.principal, 'SIGNAL_READ');
+    if (domainId) await this.ownedDomain(domainId);
+    return new OperationalConditionService(this.db).listCases(this.principal.tenantId, domainId);
+  }
+
+  async caseGet(caseId: string) {
+    requireMcpScope(this.principal, 'CASE_READ');
+    const result = await new OperationalConditionService(this.db).getCase(
+      this.principal.tenantId,
+      caseId
+    );
+    if (!result) throw new McpNotFoundError();
+    return result;
+  }
+
+  private async ownedDomain(domainId: string) {
+    const domain = await new DomainRepository(this.db).findById(domainId);
+    if (!domain || domain.tenantId !== this.principal.tenantId) throw new McpNotFoundError();
+    return domain;
+  }
+
+  private async ownedSnapshot(snapshotId: string) {
+    const snapshot = await new SnapshotRepository(this.db).findById(snapshotId);
+    if (!snapshot) throw new McpNotFoundError();
+    await this.ownedDomain(snapshot.domainId);
+    return snapshot;
+  }
+}

--- a/apps/web/hono/lib/mcp-scan-rate-limit.test.ts
+++ b/apps/web/hono/lib/mcp-scan-rate-limit.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { consumeMcpScanQuota, resetMcpScanQuotaForTest } from './mcp-scan-rate-limit.js';
 
-afterEach(resetMcpScanQuotaForTest);
+afterEach(() => {
+  resetMcpScanQuotaForTest();
+  vi.useRealTimers();
+});
 
 describe('MCP scan quota', () => {
   it('enforces the collector-aligned per-tenant ten-request window', () => {
@@ -12,6 +15,16 @@ describe('MCP scan quota', () => {
       allowed: false,
       retryAfterSeconds: expect.any(Number),
     });
+  });
+
+  it('refills one token after six seconds, like the collector token bucket', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-29T18:20:00.000Z'));
+    for (let index = 0; index < 10; index += 1) consumeMcpScanQuota('tenant-a');
+    expect(consumeMcpScanQuota('tenant-a')).toMatchObject({ allowed: false });
+
+    vi.advanceTimersByTime(6_000);
+    expect(consumeMcpScanQuota('tenant-a')).toEqual({ allowed: true, remaining: 0 });
   });
 
   it('isolates quota buckets by tenant', () => {

--- a/apps/web/hono/lib/mcp-scan-rate-limit.test.ts
+++ b/apps/web/hono/lib/mcp-scan-rate-limit.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { consumeMcpScanQuota, resetMcpScanQuotaForTest } from './mcp-scan-rate-limit.js';
+
+afterEach(resetMcpScanQuotaForTest);
+
+describe('MCP scan quota', () => {
+  it('enforces the collector-aligned per-tenant ten-request window', () => {
+    for (let index = 0; index < 10; index += 1) {
+      expect(consumeMcpScanQuota('tenant-a')).toMatchObject({ allowed: true });
+    }
+    expect(consumeMcpScanQuota('tenant-a')).toMatchObject({
+      allowed: false,
+      retryAfterSeconds: expect.any(Number),
+    });
+  });
+
+  it('isolates quota buckets by tenant', () => {
+    for (let index = 0; index < 10; index += 1) consumeMcpScanQuota('tenant-a');
+    expect(consumeMcpScanQuota('tenant-a')).toMatchObject({ allowed: false });
+    expect(consumeMcpScanQuota('tenant-b')).toMatchObject({ allowed: true, remaining: 9 });
+  });
+});

--- a/apps/web/hono/lib/mcp-scan-rate-limit.ts
+++ b/apps/web/hono/lib/mcp-scan-rate-limit.ts
@@ -1,36 +1,34 @@
 const SCAN_LIMIT = 10;
 const SCAN_WINDOW_MS = 60_000;
 
-type Bucket = { remaining: number; resetAt: number };
+type Bucket = { tokens: number; lastRefill: number };
 
 const buckets = new Map<string, Bucket>();
 
 /**
- * Limits new MCP scan requests per tenant. Replayed idempotent commands bypass
- * this guard in McpScanService and return their saved result. The collector
- * keeps its own equivalent limit as the service-of-record boundary.
+ * Limits new MCP scan requests per tenant with the same ten-token, one-minute
+ * incremental-refill algorithm used by the collector. Replayed idempotent
+ * commands bypass this guard in McpScanService and return their saved result.
  */
 export function consumeMcpScanQuota(
   tenantId: string
 ): { allowed: true; remaining: number } | { allowed: false; retryAfterSeconds: number } {
   const now = Date.now();
-  const existing = buckets.get(tenantId);
-  const bucket =
-    !existing || existing.resetAt <= now
-      ? { remaining: SCAN_LIMIT, resetAt: now + SCAN_WINDOW_MS }
-      : existing;
-
-  if (bucket.remaining <= 0) {
-    buckets.set(tenantId, bucket);
-    return {
-      allowed: false,
-      retryAfterSeconds: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
-    };
+  const bucket = buckets.get(tenantId) ?? { tokens: SCAN_LIMIT, lastRefill: now };
+  const tokensToAdd = Math.floor(((now - bucket.lastRefill) / SCAN_WINDOW_MS) * SCAN_LIMIT);
+  if (tokensToAdd > 0) {
+    bucket.tokens = Math.min(SCAN_LIMIT, bucket.tokens + tokensToAdd);
+    bucket.lastRefill = now;
   }
 
-  bucket.remaining -= 1;
+  if (bucket.tokens <= 0) {
+    buckets.set(tenantId, bucket);
+    return { allowed: false, retryAfterSeconds: Math.ceil(SCAN_WINDOW_MS / 1000) };
+  }
+
+  bucket.tokens -= 1;
   buckets.set(tenantId, bucket);
-  return { allowed: true, remaining: bucket.remaining };
+  return { allowed: true, remaining: bucket.tokens };
 }
 
 /** Test-only reset; production uses process-local fixed-window buckets. */

--- a/apps/web/hono/lib/mcp-scan-rate-limit.ts
+++ b/apps/web/hono/lib/mcp-scan-rate-limit.ts
@@ -1,0 +1,39 @@
+const SCAN_LIMIT = 10;
+const SCAN_WINDOW_MS = 60_000;
+
+type Bucket = { remaining: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+
+/**
+ * Limits new MCP scan requests per tenant. Replayed idempotent commands bypass
+ * this guard in McpScanService and return their saved result. The collector
+ * keeps its own equivalent limit as the service-of-record boundary.
+ */
+export function consumeMcpScanQuota(
+  tenantId: string
+): { allowed: true; remaining: number } | { allowed: false; retryAfterSeconds: number } {
+  const now = Date.now();
+  const existing = buckets.get(tenantId);
+  const bucket =
+    !existing || existing.resetAt <= now
+      ? { remaining: SCAN_LIMIT, resetAt: now + SCAN_WINDOW_MS }
+      : existing;
+
+  if (bucket.remaining <= 0) {
+    buckets.set(tenantId, bucket);
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    };
+  }
+
+  bucket.remaining -= 1;
+  buckets.set(tenantId, bucket);
+  return { allowed: true, remaining: bucket.remaining };
+}
+
+/** Test-only reset; production uses process-local fixed-window buckets. */
+export function resetMcpScanQuotaForTest(): void {
+  buckets.clear();
+}

--- a/apps/web/hono/lib/mcp-scan-service.command.test.ts
+++ b/apps/web/hono/lib/mcp-scan-service.command.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findById: vi.fn(),
+  claim: vi.fn(),
+  complete: vi.fn(),
+  proxyToCollector: vi.fn(),
+}));
+
+vi.mock('@dns-ops/db', () => ({
+  DomainRepository: class {
+    findById = mocks.findById;
+  },
+  McpCommandRepository: class {
+    claim = mocks.claim;
+    complete = mocks.complete;
+  },
+}));
+
+vi.mock('./collector-proxy.js', () => ({ proxyToCollector: mocks.proxyToCollector }));
+
+import { McpScanService } from './mcp-scan-service.js';
+
+function service() {
+  return new McpScanService({} as never, {} as never, {
+    tenantId: 'tenant-1',
+    principalId: 'principal-1',
+    actorId: 'actor-1',
+    scopes: new Set(['SCAN_REQUEST']),
+  });
+}
+
+describe('McpScanService command controls', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('denies a cross-tenant registered-domain ID before claiming or proxying a scan', async () => {
+    mocks.findById.mockResolvedValue({
+      id: 'domain-other',
+      tenantId: 'tenant-other',
+      normalizedName: 'other.example',
+    });
+
+    await expect(
+      service().request({ domainId: 'domain-other', idempotencyKey: 'key-1' })
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Registered domain not found' },
+      replayed: false,
+    });
+    expect(mocks.claim).not.toHaveBeenCalled();
+    expect(mocks.proxyToCollector).not.toHaveBeenCalled();
+  });
+
+  it('replays a completed scan command without making another collector request', async () => {
+    mocks.findById.mockResolvedValue({
+      id: 'domain-1',
+      tenantId: 'tenant-1',
+      normalizedName: 'example.com',
+    });
+    mocks.claim.mockResolvedValue({
+      state: 'REPLAY',
+      command: {
+        id: 'command-1',
+        response: { ok: true, value: { snapshotId: 'snapshot-1' }, replayed: false },
+      },
+    });
+
+    await expect(
+      service().request({ domainId: 'domain-1', idempotencyKey: 'key-1' })
+    ).resolves.toEqual({
+      ok: true,
+      value: { snapshotId: 'snapshot-1' },
+      replayed: true,
+    });
+    expect(mocks.proxyToCollector).not.toHaveBeenCalled();
+    expect(mocks.complete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/hono/lib/mcp-scan-service.command.test.ts
+++ b/apps/web/hono/lib/mcp-scan-service.command.test.ts
@@ -19,6 +19,7 @@ vi.mock('@dns-ops/db', () => ({
 
 vi.mock('./collector-proxy.js', () => ({ proxyToCollector: mocks.proxyToCollector }));
 
+import { consumeMcpScanQuota, resetMcpScanQuotaForTest } from './mcp-scan-rate-limit.js';
 import { McpScanService } from './mcp-scan-service.js';
 
 function service() {
@@ -31,7 +32,10 @@ function service() {
 }
 
 describe('McpScanService command controls', () => {
-  afterEach(() => vi.clearAllMocks());
+  afterEach(() => {
+    vi.clearAllMocks();
+    resetMcpScanQuotaForTest();
+  });
 
   it('denies a cross-tenant registered-domain ID before claiming or proxying a scan', async () => {
     mocks.findById.mockResolvedValue({
@@ -74,5 +78,32 @@ describe('McpScanService command controls', () => {
     });
     expect(mocks.proxyToCollector).not.toHaveBeenCalled();
     expect(mocks.complete).not.toHaveBeenCalled();
+  });
+
+  it('persists a rate-limited command without proxying a collector scan', async () => {
+    mocks.findById.mockResolvedValue({
+      id: 'domain-1',
+      tenantId: 'tenant-1',
+      normalizedName: 'example.com',
+    });
+    mocks.claim.mockResolvedValue({ state: 'CLAIMED', command: { id: 'command-1' } });
+    mocks.complete.mockResolvedValue(undefined);
+    for (let index = 0; index < 10; index += 1) consumeMcpScanQuota('tenant-1');
+
+    await expect(
+      service().request({ domainId: 'domain-1', idempotencyKey: 'key-rate-limited' })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'RATE_LIMITED' },
+      replayed: false,
+    });
+    expect(mocks.proxyToCollector).not.toHaveBeenCalled();
+    expect(mocks.complete).toHaveBeenCalledWith(
+      'tenant-1',
+      'command-1',
+      expect.objectContaining({ error: { code: 'RATE_LIMITED', message: expect.any(String) } }),
+      undefined,
+      'FAILED'
+    );
   });
 });

--- a/apps/web/hono/lib/mcp-scan-service.command.test.ts
+++ b/apps/web/hono/lib/mcp-scan-service.command.test.ts
@@ -106,4 +106,32 @@ describe('McpScanService command controls', () => {
       'FAILED'
     );
   });
+
+  it('persists a collector-proxy rejection rather than leaving the claimed command pending', async () => {
+    mocks.findById.mockResolvedValue({
+      id: 'domain-1',
+      tenantId: 'tenant-1',
+      normalizedName: 'example.com',
+    });
+    mocks.claim.mockResolvedValue({ state: 'CLAIMED', command: { id: 'command-1' } });
+    mocks.proxyToCollector.mockRejectedValue(new Error('network failure'));
+    mocks.complete.mockResolvedValue(undefined);
+
+    await expect(
+      service().request({ domainId: 'domain-1', idempotencyKey: 'key-proxy-rejected' })
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: 'COLLECTOR_UNAVAILABLE', message: 'Collector unavailable' },
+      replayed: false,
+    });
+    expect(mocks.complete).toHaveBeenCalledWith(
+      'tenant-1',
+      'command-1',
+      expect.objectContaining({
+        error: expect.objectContaining({ code: 'COLLECTOR_UNAVAILABLE' }),
+      }),
+      undefined,
+      'FAILED'
+    );
+  });
 });

--- a/apps/web/hono/lib/mcp-scan-service.test.ts
+++ b/apps/web/hono/lib/mcp-scan-service.test.ts
@@ -1,0 +1,24 @@
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import type { Context } from 'hono';
+import { describe, expect, it } from 'vitest';
+import type { Env } from '../types.js';
+import { McpScanService } from './mcp-scan-service.js';
+
+describe('McpScanService', () => {
+  it('does not access domains or collector without SCAN_REQUEST', async () => {
+    const context = {} as Context<Env>;
+    const db = {
+      select: async () => {
+        throw new Error('persistence must not be reached');
+      },
+    } as unknown as IDatabaseAdapter;
+    const service = new McpScanService(context, db, {
+      tenantId: 'tenant-1',
+      actorId: 'actor-1',
+      scopes: new Set(['CASE_WRITE']),
+    });
+    await expect(
+      service.request({ domainId: 'domain-1', idempotencyKey: 'key-1' })
+    ).rejects.toThrow('MCP scope denied');
+  });
+});

--- a/apps/web/hono/lib/mcp-scan-service.test.ts
+++ b/apps/web/hono/lib/mcp-scan-service.test.ts
@@ -14,6 +14,7 @@ describe('McpScanService', () => {
     } as unknown as IDatabaseAdapter;
     const service = new McpScanService(context, db, {
       tenantId: 'tenant-1',
+      principalId: 'principal-1',
       actorId: 'actor-1',
       scopes: new Set(['CASE_WRITE']),
     });

--- a/apps/web/hono/lib/mcp-scan-service.ts
+++ b/apps/web/hono/lib/mcp-scan-service.ts
@@ -1,0 +1,99 @@
+import { createHash } from 'node:crypto';
+import { DomainRepository, type IDatabaseAdapter, McpCommandRepository } from '@dns-ops/db';
+import type { Context } from 'hono';
+import type { Env } from '../types.js';
+import { proxyToCollector } from './collector-proxy.js';
+import { type AuthenticatedMcpPrincipal, requireMcpScope } from './mcp-auth.js';
+
+function fingerprint(input: Record<string, unknown>): string {
+  return createHash('sha256')
+    .update(JSON.stringify(Object.entries(input).sort()))
+    .digest('hex');
+}
+
+export class McpScanService {
+  constructor(
+    private context: Context<Env>,
+    private db: IDatabaseAdapter,
+    private principal: AuthenticatedMcpPrincipal
+  ) {}
+
+  async request(input: { domainId: string; idempotencyKey: string }) {
+    requireMcpScope(this.principal, 'SCAN_REQUEST');
+    if (!input.domainId || !input.idempotencyKey) {
+      return {
+        ok: false,
+        error: { code: 'INVALID_ARGUMENT', message: 'domainId and idempotencyKey are required' },
+        replayed: false,
+      };
+    }
+    const domain = await new DomainRepository(this.db).findById(input.domainId);
+    if (!domain || domain.tenantId !== this.principal.tenantId) {
+      return {
+        ok: false,
+        error: { code: 'NOT_FOUND', message: 'Registered domain not found' },
+        replayed: false,
+      };
+    }
+    const commands = new McpCommandRepository(this.db);
+    const claim = await commands.claim({
+      tenantId: this.principal.tenantId,
+      actorId: this.principal.actorId,
+      operation: 'scan_request',
+      idempotencyKey: input.idempotencyKey,
+      requestFingerprint: fingerprint(input),
+    });
+    if (claim.state === 'REPLAY') {
+      if (!claim.command.response) throw new Error('Completed MCP command has no response');
+      return { ...(claim.command.response as object), replayed: true };
+    }
+    const proxied = await proxyToCollector(this.context, {
+      path: '/api/collect/domain',
+      method: 'POST',
+      body: JSON.stringify({
+        domain: domain.normalizedName,
+        zoneManagement: domain.zoneManagement,
+        triggeredBy: this.principal.actorId,
+      }),
+    });
+    if (proxied instanceof Response) {
+      const result = {
+        ok: false,
+        error: { code: 'COLLECTOR_UNAVAILABLE', message: 'Collector unavailable' },
+        replayed: false,
+      };
+      await commands.complete(
+        this.principal.tenantId,
+        claim.command.id,
+        result,
+        undefined,
+        'FAILED'
+      );
+      return result;
+    }
+    const result:
+      | { ok: true; value: Record<string, unknown>; replayed: false }
+      | { ok: false; error: { code: string; message: string }; replayed: false } = proxied.ok
+      ? { ok: true, value: proxied.json as Record<string, unknown>, replayed: false }
+      : {
+          ok: false,
+          error: {
+            code: `COLLECTOR_${proxied.status}`,
+            message: 'Collector rejected scan request',
+          },
+          replayed: false,
+        };
+    const resourceId =
+      result.ok && typeof result.value.snapshotId === 'string'
+        ? result.value.snapshotId
+        : undefined;
+    await commands.complete(
+      this.principal.tenantId,
+      claim.command.id,
+      result,
+      resourceId,
+      result.ok ? 'COMPLETED' : 'FAILED'
+    );
+    return result;
+  }
+}

--- a/apps/web/hono/lib/mcp-scan-service.ts
+++ b/apps/web/hono/lib/mcp-scan-service.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { DomainRepository, type IDatabaseAdapter, McpCommandRepository } from '@dns-ops/db';
 import type { Context } from 'hono';
 import type { Env } from '../types.js';
-import { proxyToCollector } from './collector-proxy.js';
+import { type ProxyResult, proxyToCollector } from './collector-proxy.js';
 import { type AuthenticatedMcpPrincipal, requireMcpScope } from './mcp-auth.js';
 import { consumeMcpScanQuota } from './mcp-scan-rate-limit.js';
 
@@ -68,15 +68,32 @@ export class McpScanService {
       );
       return result;
     }
-    const proxied = await proxyToCollector(this.context, {
-      path: '/api/collect/domain',
-      method: 'POST',
-      body: JSON.stringify({
-        domain: domain.normalizedName,
-        zoneManagement: domain.zoneManagement,
-        triggeredBy: this.principal.actorId,
-      }),
-    });
+    let proxied: Response | ProxyResult;
+    try {
+      proxied = await proxyToCollector(this.context, {
+        path: '/api/collect/domain',
+        method: 'POST',
+        body: JSON.stringify({
+          domain: domain.normalizedName,
+          zoneManagement: domain.zoneManagement,
+          triggeredBy: this.principal.actorId,
+        }),
+      });
+    } catch {
+      const result = {
+        ok: false,
+        error: { code: 'COLLECTOR_UNAVAILABLE', message: 'Collector unavailable' },
+        replayed: false,
+      };
+      await commands.complete(
+        this.principal.tenantId,
+        claim.command.id,
+        result,
+        undefined,
+        'FAILED'
+      );
+      return result;
+    }
     if (proxied instanceof Response) {
       const result = {
         ok: false,

--- a/apps/web/hono/lib/mcp-scan-service.ts
+++ b/apps/web/hono/lib/mcp-scan-service.ts
@@ -4,6 +4,7 @@ import type { Context } from 'hono';
 import type { Env } from '../types.js';
 import { proxyToCollector } from './collector-proxy.js';
 import { type AuthenticatedMcpPrincipal, requireMcpScope } from './mcp-auth.js';
+import { consumeMcpScanQuota } from './mcp-scan-rate-limit.js';
 
 function fingerprint(input: Record<string, unknown>): string {
   return createHash('sha256')
@@ -46,6 +47,26 @@ export class McpScanService {
     if (claim.state === 'REPLAY') {
       if (!claim.command.response) throw new Error('Completed MCP command has no response');
       return { ...(claim.command.response as object), replayed: true };
+    }
+    const quota = consumeMcpScanQuota(this.principal.tenantId);
+    if (!quota.allowed) {
+      const result = {
+        ok: false,
+        error: {
+          code: 'RATE_LIMITED',
+          message: `Scan rate limit exceeded. Try again in ${quota.retryAfterSeconds} seconds.`,
+        },
+        retryAfterSeconds: quota.retryAfterSeconds,
+        replayed: false,
+      };
+      await commands.complete(
+        this.principal.tenantId,
+        claim.command.id,
+        result,
+        undefined,
+        'FAILED'
+      );
+      return result;
     }
     const proxied = await proxyToCollector(this.context, {
       path: '/api/collect/domain',

--- a/apps/web/hono/lib/mcp-tools.test.ts
+++ b/apps/web/hono/lib/mcp-tools.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getMcpTool, MCP_TOOL_NAMES, MCP_TOOLS } from './mcp-tools.js';
+
+describe('MCP Phase 1 tool contract', () => {
+  it('exposes exactly the approved ten tools', () => {
+    expect(MCP_TOOLS).toHaveLength(10);
+    expect(MCP_TOOLS.map((tool) => tool.name)).toEqual(MCP_TOOL_NAMES);
+  });
+
+  it('requires idempotency only for command tools and scopes every tool', () => {
+    for (const tool of MCP_TOOLS) {
+      expect(tool.requiredScope).toBeTruthy();
+      if (!tool.readOnly) expect(tool.inputSchema.required).toContain('idempotencyKey');
+    }
+  });
+
+  it('does not resolve unapproved tools', () => {
+    expect(getMcpTool('provider_mutate')).toBeUndefined();
+  });
+});

--- a/apps/web/hono/lib/mcp-tools.test.ts
+++ b/apps/web/hono/lib/mcp-tools.test.ts
@@ -14,6 +14,13 @@ describe('MCP Phase 1 tool contract', () => {
     }
   });
 
+  it('assigns least-privilege Phase 1 read scopes', () => {
+    expect(getMcpTool('domain_search')?.requiredScope).toBe('DOMAIN_READ');
+    expect(getMcpTool('evidence_get')?.requiredScope).toBe('DOMAIN_READ');
+    expect(getMcpTool('signal_list')?.requiredScope).toBe('SIGNAL_READ');
+    expect(getMcpTool('case_get')?.requiredScope).toBe('CASE_READ');
+  });
+
   it('does not resolve unapproved tools', () => {
     expect(getMcpTool('provider_mutate')).toBeUndefined();
   });

--- a/apps/web/hono/lib/mcp-tools.ts
+++ b/apps/web/hono/lib/mcp-tools.ts
@@ -1,0 +1,117 @@
+export const MCP_TOOL_NAMES = [
+  'domain_search',
+  'domain_get_profile',
+  'domain_get_posture',
+  'snapshot_compare',
+  'evidence_get',
+  'signal_list',
+  'case_get',
+  'case_open',
+  'case_set_disposition',
+  'scan_request',
+] as const;
+
+export type McpToolName = (typeof MCP_TOOL_NAMES)[number];
+
+export interface McpToolDefinition {
+  name: McpToolName;
+  readOnly: boolean;
+  requiredScope: 'CASE_READ' | 'CASE_WRITE' | 'SCAN_REQUEST';
+  inputSchema: {
+    type: 'object';
+    required: readonly string[];
+    properties: Record<string, { type: string }>;
+  };
+}
+
+const id = { type: 'string' };
+const idempotencyKey = { type: 'string' };
+
+/** Phase 1's closed-world MCP contract. Never append ad-hoc tools. */
+export const MCP_TOOLS: readonly McpToolDefinition[] = [
+  {
+    name: 'domain_search',
+    readOnly: true,
+    requiredScope: 'CASE_READ',
+    inputSchema: { type: 'object', required: [], properties: { query: { type: 'string' } } },
+  },
+  {
+    name: 'domain_get_profile',
+    readOnly: true,
+    requiredScope: 'CASE_READ',
+    inputSchema: { type: 'object', required: ['domainId'], properties: { domainId: id } },
+  },
+  {
+    name: 'domain_get_posture',
+    readOnly: true,
+    requiredScope: 'CASE_READ',
+    inputSchema: { type: 'object', required: ['domainId'], properties: { domainId: id } },
+  },
+  {
+    name: 'snapshot_compare',
+    readOnly: true,
+    requiredScope: 'CASE_READ',
+    inputSchema: {
+      type: 'object',
+      required: ['domainId', 'leftSnapshotId', 'rightSnapshotId'],
+      properties: { domainId: id, leftSnapshotId: id, rightSnapshotId: id },
+    },
+  },
+  {
+    name: 'evidence_get',
+    readOnly: true,
+    requiredScope: 'CASE_READ',
+    inputSchema: { type: 'object', required: ['snapshotId'], properties: { snapshotId: id } },
+  },
+  {
+    name: 'signal_list',
+    readOnly: true,
+    requiredScope: 'CASE_READ',
+    inputSchema: { type: 'object', required: [], properties: { domainId: id } },
+  },
+  {
+    name: 'case_get',
+    readOnly: true,
+    requiredScope: 'CASE_READ',
+    inputSchema: { type: 'object', required: ['caseId'], properties: { caseId: id } },
+  },
+  {
+    name: 'case_open',
+    readOnly: false,
+    requiredScope: 'CASE_WRITE',
+    inputSchema: {
+      type: 'object',
+      required: ['domainId', 'conditionKey', 'idempotencyKey'],
+      properties: { domainId: id, conditionKey: { type: 'string' }, idempotencyKey },
+    },
+  },
+  {
+    name: 'case_set_disposition',
+    readOnly: false,
+    requiredScope: 'CASE_WRITE',
+    inputSchema: {
+      type: 'object',
+      required: ['caseId', 'disposition', 'expectedVersion', 'idempotencyKey'],
+      properties: {
+        caseId: id,
+        disposition: { type: 'string' },
+        expectedVersion: { type: 'number' },
+        idempotencyKey,
+      },
+    },
+  },
+  {
+    name: 'scan_request',
+    readOnly: false,
+    requiredScope: 'SCAN_REQUEST',
+    inputSchema: {
+      type: 'object',
+      required: ['domainId', 'idempotencyKey'],
+      properties: { domainId: id, idempotencyKey },
+    },
+  },
+];
+
+export function getMcpTool(name: string): McpToolDefinition | undefined {
+  return MCP_TOOLS.find((tool) => tool.name === name);
+}

--- a/apps/web/hono/lib/mcp-tools.ts
+++ b/apps/web/hono/lib/mcp-tools.ts
@@ -16,7 +16,7 @@ export type McpToolName = (typeof MCP_TOOL_NAMES)[number];
 export interface McpToolDefinition {
   name: McpToolName;
   readOnly: boolean;
-  requiredScope: 'CASE_READ' | 'CASE_WRITE' | 'SCAN_REQUEST';
+  requiredScope: 'DOMAIN_READ' | 'SIGNAL_READ' | 'CASE_READ' | 'CASE_WRITE' | 'SCAN_REQUEST';
   inputSchema: {
     type: 'object';
     required: readonly string[];
@@ -32,25 +32,25 @@ export const MCP_TOOLS: readonly McpToolDefinition[] = [
   {
     name: 'domain_search',
     readOnly: true,
-    requiredScope: 'CASE_READ',
+    requiredScope: 'DOMAIN_READ',
     inputSchema: { type: 'object', required: [], properties: { query: { type: 'string' } } },
   },
   {
     name: 'domain_get_profile',
     readOnly: true,
-    requiredScope: 'CASE_READ',
+    requiredScope: 'DOMAIN_READ',
     inputSchema: { type: 'object', required: ['domainId'], properties: { domainId: id } },
   },
   {
     name: 'domain_get_posture',
     readOnly: true,
-    requiredScope: 'CASE_READ',
+    requiredScope: 'DOMAIN_READ',
     inputSchema: { type: 'object', required: ['domainId'], properties: { domainId: id } },
   },
   {
     name: 'snapshot_compare',
     readOnly: true,
-    requiredScope: 'CASE_READ',
+    requiredScope: 'DOMAIN_READ',
     inputSchema: {
       type: 'object',
       required: ['domainId', 'leftSnapshotId', 'rightSnapshotId'],
@@ -60,13 +60,13 @@ export const MCP_TOOLS: readonly McpToolDefinition[] = [
   {
     name: 'evidence_get',
     readOnly: true,
-    requiredScope: 'CASE_READ',
+    requiredScope: 'DOMAIN_READ',
     inputSchema: { type: 'object', required: ['snapshotId'], properties: { snapshotId: id } },
   },
   {
     name: 'signal_list',
     readOnly: true,
-    requiredScope: 'CASE_READ',
+    requiredScope: 'SIGNAL_READ',
     inputSchema: { type: 'object', required: [], properties: { domainId: id } },
   },
   {

--- a/apps/web/hono/lib/migrate.ts
+++ b/apps/web/hono/lib/migrate.ts
@@ -6,7 +6,7 @@
  */
 
 import { access, readdir, readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { IDatabaseAdapter } from '@dns-ops/db';
 import { sql } from 'drizzle-orm';
 import { getWebLogger } from '../middleware/error-tracking.js';
@@ -57,9 +57,11 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 async function resolveMigrationsDir(): Promise<string> {
+  const cwd = process.cwd();
+  const workspaceRoots = [cwd, dirname(cwd), dirname(dirname(cwd))];
   const candidates = [
     process.env.DNS_OPS_MIGRATIONS_DIR,
-    join(process.cwd(), 'packages', 'db', 'src', 'migrations'),
+    ...workspaceRoots.map((root) => join(root, 'packages', 'db', 'src', 'migrations')),
   ].filter((candidate): candidate is string => Boolean(candidate));
 
   for (const candidate of candidates) {

--- a/apps/web/hono/routes/api.ts
+++ b/apps/web/hono/routes/api.ts
@@ -23,6 +23,7 @@ import {
 } from '../middleware/validation.js';
 import type { Env } from '../types.js';
 import { alertRoutes } from './alerts.js';
+import { caseRoutes } from './cases.js';
 import { delegationRoutes } from './delegation.js';
 import { domainProfileRoutes } from './domain-profile.js';
 import { findingsRoutes } from './findings.js';
@@ -173,6 +174,7 @@ apiRoutes.route('/snapshots', snapshotRoutes);
 apiRoutes.use('/migrate/*', requireAdminAccess);
 apiRoutes.route('/migrate', migrateRoutes);
 apiRoutes.route('/domains', domainProfileRoutes);
+apiRoutes.route('/cases', caseRoutes);
 apiRoutes.route('/portfolio', portfolioRoutes);
 apiRoutes.route('/ruleset-versions', rulesetVersionRoutes);
 apiRoutes.route('/monitoring', monitoringRoutes);

--- a/apps/web/hono/routes/api.ts
+++ b/apps/web/hono/routes/api.ts
@@ -24,6 +24,7 @@ import {
 import type { Env } from '../types.js';
 import { alertRoutes } from './alerts.js';
 import { delegationRoutes } from './delegation.js';
+import { domainProfileRoutes } from './domain-profile.js';
 import { findingsRoutes } from './findings.js';
 import { fleetReportRoutes } from './fleet-report.js';
 import { legacyToolsRoutes } from './legacy-tools.js';
@@ -171,6 +172,7 @@ apiRoutes.route('/mail', providerTemplateRoutes);
 apiRoutes.route('/snapshots', snapshotRoutes);
 apiRoutes.use('/migrate/*', requireAdminAccess);
 apiRoutes.route('/migrate', migrateRoutes);
+apiRoutes.route('/domains', domainProfileRoutes);
 apiRoutes.route('/portfolio', portfolioRoutes);
 apiRoutes.route('/ruleset-versions', rulesetVersionRoutes);
 apiRoutes.route('/monitoring', monitoringRoutes);

--- a/apps/web/hono/routes/auth-policy-matrix.test.ts
+++ b/apps/web/hono/routes/auth-policy-matrix.test.ts
@@ -135,6 +135,8 @@ export const AUTH_POLICY_MATRIX: RoutePolicy[] = [
   // Tenant-scoped domain profile and setup/evidence reads
   { path: '/api/domains/:domain/profile', method: 'GET', policy: 'auth-read' },
   { path: '/api/domains/:domain/evidence', method: 'GET', policy: 'auth-read' },
+  { path: '/api/cases', method: 'GET', policy: 'auth-read' },
+  { path: '/api/cases/:caseId', method: 'GET', policy: 'auth-read' },
   // Delegation routes
   { path: '/api/snapshot/:snapshotId/delegation', method: 'GET', policy: 'auth-read' },
   { path: '/api/domain/:domain/delegation/latest', method: 'GET', policy: 'auth-read' },
@@ -233,6 +235,7 @@ export const AUTH_POLICY_MATRIX: RoutePolicy[] = [
   // Tenant-scoped domain profile declaration
   { path: '/api/domains/:domain/profile', method: 'PUT', policy: 'auth-write' },
   { path: '/api/domains/:domain/baselines', method: 'POST', policy: 'auth-write' },
+  { path: '/api/cases/:caseId/disposition', method: 'PATCH', policy: 'auth-write' },
   // Domain collection (write operation)
   { path: '/api/collect/domain', method: 'POST', policy: 'auth-write' },
   // Mail collection (write operation)

--- a/apps/web/hono/routes/auth-policy-matrix.test.ts
+++ b/apps/web/hono/routes/auth-policy-matrix.test.ts
@@ -132,6 +132,9 @@ export const AUTH_POLICY_MATRIX: RoutePolicy[] = [
   // =============================================================================
   // AUTH-READ ROUTES - requireAuth (default for most read operations)
   // =============================================================================
+  // Tenant-scoped domain profile and setup/evidence reads
+  { path: '/api/domains/:domain/profile', method: 'GET', policy: 'auth-read' },
+  { path: '/api/domains/:domain/evidence', method: 'GET', policy: 'auth-read' },
   // Delegation routes
   { path: '/api/snapshot/:snapshotId/delegation', method: 'GET', policy: 'auth-read' },
   { path: '/api/domain/:domain/delegation/latest', method: 'GET', policy: 'auth-read' },
@@ -227,6 +230,8 @@ export const AUTH_POLICY_MATRIX: RoutePolicy[] = [
   // =============================================================================
   // AUTH-WRITE ROUTES - requireWritePermission (mutating operations)
   // =============================================================================
+  // Tenant-scoped domain profile declaration
+  { path: '/api/domains/:domain/profile', method: 'PUT', policy: 'auth-write' },
   // Domain collection (write operation)
   { path: '/api/collect/domain', method: 'POST', policy: 'auth-write' },
   // Mail collection (write operation)

--- a/apps/web/hono/routes/auth-policy-matrix.test.ts
+++ b/apps/web/hono/routes/auth-policy-matrix.test.ts
@@ -232,6 +232,7 @@ export const AUTH_POLICY_MATRIX: RoutePolicy[] = [
   // =============================================================================
   // Tenant-scoped domain profile declaration
   { path: '/api/domains/:domain/profile', method: 'PUT', policy: 'auth-write' },
+  { path: '/api/domains/:domain/baselines', method: 'POST', policy: 'auth-write' },
   // Domain collection (write operation)
   { path: '/api/collect/domain', method: 'POST', policy: 'auth-write' },
   // Mail collection (write operation)

--- a/apps/web/hono/routes/cases.test.ts
+++ b/apps/web/hono/routes/cases.test.ts
@@ -1,0 +1,59 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+import type { Env } from '../types.js';
+
+const listCases = vi.fn();
+const getCase = vi.fn();
+const setCaseDisposition = vi.fn();
+vi.mock('@dns-ops/db', () => ({
+  OperationalConditionService: class {
+    listCases = listCases;
+    getCase = getCase;
+    setCaseDisposition = setCaseDisposition;
+  },
+}));
+
+import { caseRoutes } from './cases.js';
+
+function app(tenantId = 'tenant-1', actorId = 'actor-1') {
+  const server = new Hono<Env>();
+  server.use('*', async (c, next) => {
+    c.set('db', {} as Env['Variables']['db']);
+    c.set('tenantId', tenantId);
+    c.set('actorId', actorId);
+    await next();
+  });
+  server.route('/cases', caseRoutes);
+  return server;
+}
+
+describe('caseRoutes', () => {
+  it('passes only request-context tenant scope to list and get operations', async () => {
+    listCases.mockResolvedValueOnce([]);
+    getCase.mockResolvedValueOnce(null);
+    const server = app();
+    expect((await server.request('/cases?domainId=domain-1')).status).toBe(200);
+    expect(listCases).toHaveBeenLastCalledWith('tenant-1', 'domain-1');
+    expect((await server.request('/cases/case-foreign')).status).toBe(404);
+    expect(getCase).toHaveBeenLastCalledWith('tenant-1', 'case-foreign');
+  });
+
+  it('uses actor context and returns a stable stale-version conflict', async () => {
+    setCaseDisposition.mockRejectedValueOnce(
+      Object.assign(new Error('stale'), { code: 'OPERATION_CONFLICT' })
+    );
+    const response = await app().request('/cases/case-1/disposition', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ disposition: 'Investigating', expectedVersion: 2 }),
+    });
+    expect(response.status).toBe(409);
+    expect(setCaseDisposition).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      actorId: 'actor-1',
+      caseId: 'case-1',
+      disposition: 'Investigating',
+      expectedVersion: 2,
+    });
+  });
+});

--- a/apps/web/hono/routes/cases.ts
+++ b/apps/web/hono/routes/cases.ts
@@ -1,0 +1,60 @@
+import { OperationalConditionService } from '@dns-ops/db';
+import { Hono } from 'hono';
+import { requireAuth, requireWritePermission } from '../middleware/authorization.js';
+import type { Env } from '../types.js';
+
+export const caseRoutes = new Hono<Env>();
+caseRoutes.use('*', requireAuth);
+
+caseRoutes.get('/', async (c) => {
+  const tenantId = c.get('tenantId');
+  if (!tenantId) return c.json({ error: 'Tenant context required' }, 401);
+  const domainId = c.req.query('domainId');
+  const cases = await new OperationalConditionService(c.get('db')).listCases(tenantId, domainId);
+  return c.json({ cases });
+});
+
+caseRoutes.get('/:caseId', async (c) => {
+  const tenantId = c.get('tenantId');
+  if (!tenantId) return c.json({ error: 'Tenant context required' }, 401);
+  const result = await new OperationalConditionService(c.get('db')).getCase(
+    tenantId,
+    c.req.param('caseId')
+  );
+  if (!result) return c.json({ error: 'Case not found' }, 404);
+  return c.json(result);
+});
+
+caseRoutes.patch('/:caseId/disposition', requireWritePermission, async (c) => {
+  const tenantId = c.get('tenantId');
+  const actorId = c.get('actorId');
+  if (!tenantId || !actorId) return c.json({ error: 'Tenant context required' }, 401);
+  const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body || typeof body.disposition !== 'string' || !Number.isInteger(body.expectedVersion)) {
+    return c.json({ error: 'Invalid case disposition request' }, 400);
+  }
+  try {
+    const updated = await new OperationalConditionService(c.get('db')).setCaseDisposition({
+      tenantId,
+      actorId,
+      caseId: c.req.param('caseId'),
+      disposition: body.disposition,
+      expectedVersion: body.expectedVersion as number,
+    });
+    if (!updated) return c.json({ error: 'Case not found' }, 404);
+    return c.json({ case: updated });
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error &&
+      'code' in error &&
+      error.code === 'OPERATION_CONFLICT'
+    ) {
+      return c.json({ error: 'Case version is stale', code: 'CASE_VERSION_STALE' }, 409);
+    }
+    return c.json(
+      { error: error instanceof Error ? error.message : 'Case disposition update failed' },
+      400
+    );
+  }
+});

--- a/apps/web/hono/routes/domain-profile.test.ts
+++ b/apps/web/hono/routes/domain-profile.test.ts
@@ -143,6 +143,20 @@ describe('domainProfileRoutes', () => {
     expect(response.status).toBe(404);
   });
 
+  it('keeps an explicitly UNKNOWN purpose in the actionable setup lane', async () => {
+    const { app } = createApp();
+    await app.request('/example.com/profile', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ purpose: 'UNKNOWN', criticality: 'NORMAL' }),
+    });
+    const response = await app.request('/example.com/profile');
+    await expect(response.json()).resolves.toMatchObject({
+      profile: { purpose: 'UNKNOWN' },
+      setup: { reason: 'PURPOSE_UNDECLARED', action: 'DECLARE_PURPOSE' },
+    });
+  });
+
   it('rejects unauthenticated and invalid profile writes', async () => {
     const unauthenticated = createApp('tenant-1', 'tenant-1', 'actor-1', false).app;
     const unauthorized = await unauthenticated.request('/example.com/profile', {

--- a/apps/web/hono/routes/domain-profile.test.ts
+++ b/apps/web/hono/routes/domain-profile.test.ts
@@ -1,0 +1,188 @@
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import {
+  auditEvents,
+  domainProfiles,
+  domains,
+  probeObservations,
+  snapshots,
+} from '@dns-ops/db/schema';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import type { Env } from '../types.js';
+import { domainProfileRoutes } from './domain-profile.js';
+
+function params(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
+  const candidate = condition as {
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
+  };
+  if (candidate.constructor?.name === 'Param') return [candidate.value];
+  return (candidate.queryChunks ?? []).flatMap(params);
+}
+
+function createApp(
+  tenantId = 'tenant-1',
+  domainTenantId = 'tenant-1',
+  actorId = 'actor-1',
+  authenticated = true
+) {
+  const domain = {
+    id: 'domain-1',
+    name: 'example.com',
+    normalizedName: 'example.com',
+    tenantId: domainTenantId,
+    zoneManagement: 'unknown',
+    metadata: null,
+    punycodeName: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as never;
+  const snapshotsForDomain = [
+    {
+      id: 'snapshot-old',
+      domainId: 'domain-1',
+      createdAt: new Date('2025-01-01T00:00:00Z'),
+      metadata: null,
+    },
+    {
+      id: 'snapshot-1',
+      domainId: 'domain-1',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      metadata: null,
+    },
+  ] as never[];
+  const profiles: Array<Record<string, unknown>> = [];
+  const probes = [
+    {
+      id: 'probe-1',
+      snapshotId: 'snapshot-1',
+      probeType: 'tls_cert',
+      status: 'error',
+      hostname: 'example.com',
+      port: 443,
+      success: false,
+      errorMessage: 'timeout',
+      probedAt: new Date(),
+      responseTimeMs: null,
+      probeData: { check: 'TLS_CERTIFICATE', status: 'UNKNOWN' },
+    },
+  ];
+  const audits: unknown[] = [];
+  const db = {
+    async selectWhere(table: unknown, condition: unknown) {
+      const values = params(condition);
+      if (table === domains) return values.includes('example.com') ? [domain] : [];
+      if (table === snapshots) return values.includes('domain-1') ? snapshotsForDomain : [];
+      if (table === probeObservations) return values.includes('snapshot-1') ? probes : [];
+      if (table === domainProfiles)
+        return profiles.filter((profile) => values.includes(profile.tenantId));
+      return [];
+    },
+    async selectOne(table: unknown, condition: unknown) {
+      const values = params(condition);
+      if (table === domains)
+        return values.includes('domain-1') && values.includes(tenantId) ? domain : undefined;
+      if (table === domainProfiles)
+        return profiles.find(
+          (profile) => values.includes(profile.domainId) && values.includes(profile.tenantId)
+        );
+      return undefined;
+    },
+    async insert(table: unknown, values: Record<string, unknown>) {
+      if (table === auditEvents) {
+        const row = { id: 'audit-1', createdAt: new Date(), ...values };
+        audits.push(row);
+        return row;
+      }
+      if (table === domainProfiles) {
+        const row = { createdAt: new Date(), updatedAt: new Date(), ...values };
+        profiles.push(row);
+        return row;
+      }
+      throw new Error('Unexpected insert');
+    },
+    async updateOne(table: unknown, values: Record<string, unknown>) {
+      if (table === domainProfiles && profiles[0]) {
+        Object.assign(profiles[0] as object, values);
+        return profiles[0];
+      }
+      return undefined;
+    },
+    async transaction<T>(callback: (tx: IDatabaseAdapter) => Promise<T>) {
+      return callback(db as unknown as IDatabaseAdapter);
+    },
+  };
+  const app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    c.set('db', db as unknown as IDatabaseAdapter);
+    if (authenticated) {
+      c.set('tenantId', tenantId);
+      c.set('actorId', actorId);
+    }
+    await next();
+  });
+  app.route('/', domainProfileRoutes);
+  return { app, audits };
+}
+
+describe('domainProfileRoutes', () => {
+  it('returns actionable setup state for a tenant-owned undeclared profile', async () => {
+    const { app } = createApp();
+    const response = await app.request('/example.com/profile');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      setup: { reason: 'PURPOSE_UNDECLARED', action: 'DECLARE_PURPOSE' },
+    });
+  });
+
+  it('hides domains from a different tenant', async () => {
+    const { app } = createApp('tenant-2', 'tenant-1');
+    const response = await app.request('/example.com/evidence');
+    expect(response.status).toBe(404);
+  });
+
+  it('rejects unauthenticated and invalid profile writes', async () => {
+    const unauthenticated = createApp('tenant-1', 'tenant-1', 'actor-1', false).app;
+    const unauthorized = await unauthenticated.request('/example.com/profile', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    const { app } = createApp();
+    const invalid = await app.request('/example.com/profile', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ purpose: 'NOT_A_PURPOSE', criticality: 'HIGH' }),
+    });
+    expect(unauthorized.status).toBe(401);
+    expect(invalid.status).toBe(400);
+  });
+
+  it('writes a validated profile with an attributed atomic audit event', async () => {
+    const { app, audits } = createApp();
+    const response = await app.request('/example.com/profile', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json', 'user-agent': 'vitest' },
+      body: JSON.stringify({ purpose: 'WEB', criticality: 'HIGH', responsibleActorId: 'owner-1' }),
+    });
+    expect(response.status).toBe(200);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      action: 'domain_profile_updated',
+      actorId: 'actor-1',
+      tenantId: 'tenant-1',
+    });
+  });
+
+  it('returns only latest snapshot external evidence', async () => {
+    const { app } = createApp();
+    const response = await app.request('/example.com/evidence');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      snapshotId: 'snapshot-1',
+      evidence: [{ probeType: 'tls_cert' }],
+    });
+  });
+});

--- a/apps/web/hono/routes/domain-profile.test.ts
+++ b/apps/web/hono/routes/domain-profile.test.ts
@@ -174,6 +174,29 @@ describe('domainProfileRoutes', () => {
     expect(invalid.status).toBe(400);
   });
 
+  it('rejects unauthenticated and malformed baseline acceptance', async () => {
+    const unauthenticated = createApp('tenant-1', 'tenant-1', 'actor-1', false).app;
+    const denied = await unauthenticated.request('/example.com/baselines', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    const { app } = createApp();
+    const invalid = await app.request('/example.com/baselines', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        signalKind: 'TLS_CERTIFICATE_REGRESSION',
+        sourceSnapshotId: 'snapshot-1',
+        discriminator: 'example.com:443',
+        maxEvidenceAgeSeconds: 60,
+        policy: { kind: 'SPF_PRESENT' },
+      }),
+    });
+    expect(denied.status).toBe(401);
+    expect(invalid.status).toBe(400);
+  });
+
   it('writes a validated profile with an attributed atomic audit event', async () => {
     const { app, audits } = createApp();
     const response = await app.request('/example.com/profile', {

--- a/apps/web/hono/routes/domain-profile.test.ts
+++ b/apps/web/hono/routes/domain-profile.test.ts
@@ -3,6 +3,7 @@ import {
   auditEvents,
   domainProfiles,
   domains,
+  operationalConditionBaselines,
   probeObservations,
   snapshots,
 } from '@dns-ops/db/schema';
@@ -54,6 +55,7 @@ function createApp(
     },
   ] as never[];
   const profiles: Array<Record<string, unknown>> = [];
+  const baselines: Array<Record<string, unknown>> = [];
   const probes = [
     {
       id: 'probe-1',
@@ -78,12 +80,17 @@ function createApp(
       if (table === probeObservations) return values.includes('snapshot-1') ? probes : [];
       if (table === domainProfiles)
         return profiles.filter((profile) => values.includes(profile.tenantId));
+      if (table === operationalConditionBaselines)
+        return baselines.filter((baseline) => values.includes(baseline.tenantId));
       return [];
     },
     async selectOne(table: unknown, condition: unknown) {
       const values = params(condition);
-      if (table === domains)
-        return values.includes('domain-1') && values.includes(tenantId) ? domain : undefined;
+      if (table === domains) return values.includes('domain-1') ? domain : undefined;
+      if (table === snapshots)
+        return values.includes('snapshot-1')
+          ? { ...(snapshotsForDomain[1] as object), resultState: 'complete' }
+          : undefined;
       if (table === domainProfiles)
         return profiles.find(
           (profile) => values.includes(profile.domainId) && values.includes(profile.tenantId)
@@ -99,6 +106,17 @@ function createApp(
       if (table === domainProfiles) {
         const row = { createdAt: new Date(), updatedAt: new Date(), ...values };
         profiles.push(row);
+        return row;
+      }
+      if (table === operationalConditionBaselines) {
+        const row = {
+          id: `baseline-${baselines.length + 1}`,
+          acceptedAt: new Date(),
+          supersededAt: null,
+          supersededBy: null,
+          ...values,
+        };
+        baselines.push(row);
         return row;
       }
       throw new Error('Unexpected insert');
@@ -195,6 +213,37 @@ describe('domainProfileRoutes', () => {
     });
     expect(denied.status).toBe(401);
     expect(invalid.status).toBe(400);
+  });
+
+  it('accepts a tenant-owned complete TLS baseline and writes an attributed audit event', async () => {
+    const { app, audits } = createApp();
+    const response = await app.request('/example.com/baselines', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'user-agent': 'vitest' },
+      body: JSON.stringify({
+        signalKind: 'TLS_CERTIFICATE_REGRESSION',
+        sourceSnapshotId: 'snapshot-1',
+        discriminator: 'example.com:443',
+        maxEvidenceAgeSeconds: 60,
+        policy: {
+          kind: 'TLS_CERTIFICATE',
+          requireHostnameAuthorized: true,
+          requireChainAuthorized: true,
+          minimumRemainingValiditySeconds: 0,
+        },
+      }),
+    });
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      baseline: { tenantId: 'tenant-1', domainId: 'domain-1', discriminator: 'example.com:443' },
+    });
+    expect(audits).toContainEqual(
+      expect.objectContaining({
+        action: 'operational_baseline_accepted',
+        actorId: 'actor-1',
+        tenantId: 'tenant-1',
+      })
+    );
   });
 
   it('writes a validated profile with an attributed atomic audit event', async () => {

--- a/apps/web/hono/routes/domain-profile.ts
+++ b/apps/web/hono/routes/domain-profile.ts
@@ -6,6 +6,7 @@ import {
 import {
   DomainProfileRepository,
   DomainRepository,
+  OperationalBaselineRepository,
   ProbeObservationRepository,
   SnapshotRepository,
 } from '@dns-ops/db';
@@ -62,6 +63,62 @@ domainProfileRoutes.get('/:domain/evidence', async (c) => {
     snapshotId: snapshots[0].id,
     evidence: probes.filter((probe) => ['rdap', 'tls_cert', 'http'].includes(probe.probeType)),
   });
+});
+
+domainProfileRoutes.post('/:domain/baselines', requireWritePermission, async (c) => {
+  const tenantId = c.get('tenantId');
+  const actorId = c.get('actorId');
+  const domain = await ownedDomain(c);
+  if (!tenantId || !actorId || !domain) return c.json({ error: 'Domain not found' }, 404);
+  const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+  const maxEvidenceAgeSeconds = body?.maxEvidenceAgeSeconds;
+  if (
+    !body ||
+    typeof body.sourceSnapshotId !== 'string' ||
+    typeof body.discriminator !== 'string' ||
+    typeof maxEvidenceAgeSeconds !== 'number' ||
+    !Number.isInteger(maxEvidenceAgeSeconds)
+  ) {
+    return c.json({ error: 'Invalid baseline request' }, 400);
+  }
+  const signalKind = body.signalKind;
+  const policy = body.policy;
+  const validTls =
+    signalKind === 'TLS_CERTIFICATE_REGRESSION' &&
+    policy &&
+    typeof policy === 'object' &&
+    (policy as Record<string, unknown>).kind === 'TLS_CERTIFICATE' &&
+    typeof (policy as Record<string, unknown>).requireHostnameAuthorized === 'boolean' &&
+    typeof (policy as Record<string, unknown>).requireChainAuthorized === 'boolean' &&
+    Number.isInteger((policy as Record<string, unknown>).minimumRemainingValiditySeconds);
+  const validSpf =
+    signalKind === 'MAIL_DNS_CONFIGURATION_REGRESSION' &&
+    body.discriminator.trim().toLowerCase() === 'spf' &&
+    policy &&
+    typeof policy === 'object' &&
+    (policy as Record<string, unknown>).kind === 'SPF_PRESENT';
+  if (!validTls && !validSpf) return c.json({ error: 'Unsupported baseline policy' }, 400);
+  try {
+    const baseline = await new OperationalBaselineRepository(c.get('db')).accept({
+      tenantId,
+      domainId: domain.id,
+      kind: signalKind as 'TLS_CERTIFICATE_REGRESSION' | 'MAIL_DNS_CONFIGURATION_REGRESSION',
+      discriminator: body.discriminator,
+      sourceSnapshotId: body.sourceSnapshotId,
+      policy: policy as never,
+      maxEvidenceAgeSeconds,
+      actorId,
+      actorEmail: c.get('actorEmail') ?? null,
+      ipAddress: getRequestClientIp(c) ?? null,
+      userAgent: c.req.header('user-agent') ?? null,
+    });
+    return c.json({ baseline }, 201);
+  } catch (error) {
+    return c.json(
+      { error: error instanceof Error ? error.message : 'Baseline acceptance failed' },
+      400
+    );
+  }
 });
 
 domainProfileRoutes.put('/:domain/profile', requireWritePermission, async (c) => {

--- a/apps/web/hono/routes/domain-profile.ts
+++ b/apps/web/hono/routes/domain-profile.ts
@@ -1,0 +1,97 @@
+import {
+  DOMAIN_CRITICALITIES,
+  DOMAIN_PURPOSES,
+  purposeUndeclaredUnknown,
+} from '@dns-ops/contracts';
+import {
+  DomainProfileRepository,
+  DomainRepository,
+  ProbeObservationRepository,
+  SnapshotRepository,
+} from '@dns-ops/db';
+import { type Context, Hono } from 'hono';
+import { getRequestClientIp } from '../lib/request-context.js';
+import { requireAuth, requireWritePermission } from '../middleware/authorization.js';
+import {
+  enumValue,
+  optionalString,
+  validateBody,
+  validationErrorResponse,
+} from '../middleware/validation.js';
+import type { Env } from '../types.js';
+
+export const domainProfileRoutes = new Hono<Env>();
+domainProfileRoutes.use('*', requireAuth);
+
+async function ownedDomain(c: Context<Env>) {
+  const tenantId = c.get('tenantId');
+  if (!tenantId) return null;
+  return new DomainRepository(c.get('db')).findByNameForTenant(c.req.param('domain'), tenantId);
+}
+
+domainProfileRoutes.get('/:domain/profile', async (c) => {
+  const tenantId = c.get('tenantId');
+  const domain = await ownedDomain(c);
+  if (!tenantId || !domain) return c.json({ error: 'Domain not found' }, 404);
+  const profile = await new DomainProfileRepository(c.get('db')).findByDomainId(
+    domain.id,
+    tenantId
+  );
+  return c.json({
+    domain: domain.normalizedName,
+    profile,
+    setup: profile ? null : purposeUndeclaredUnknown('Domain evidence'),
+  });
+});
+
+domainProfileRoutes.get('/:domain/evidence', async (c) => {
+  const tenantId = c.get('tenantId');
+  const domain = await ownedDomain(c);
+  if (!tenantId || !domain) return c.json({ error: 'Domain not found' }, 404);
+  const snapshots = await new SnapshotRepository(c.get('db')).findByDomain(domain.id, 1);
+  if (!snapshots[0])
+    return c.json({ domain: domain.normalizedName, snapshotId: null, evidence: [] });
+  const probes = await new ProbeObservationRepository(c.get('db')).findBySnapshotId(
+    snapshots[0].id
+  );
+  return c.json({
+    domain: domain.normalizedName,
+    snapshotId: snapshots[0].id,
+    evidence: probes.filter((probe) => ['rdap', 'tls_cert', 'http'].includes(probe.probeType)),
+  });
+});
+
+domainProfileRoutes.put('/:domain/profile', requireWritePermission, async (c) => {
+  const tenantId = c.get('tenantId');
+  const actorId = c.get('actorId');
+  const domain = await ownedDomain(c);
+  if (!tenantId || !actorId || !domain) return c.json({ error: 'Domain not found' }, 404);
+  const validation = await validateBody(c, {
+    purpose: enumValue('purpose', DOMAIN_PURPOSES),
+    criticality: enumValue('criticality', DOMAIN_CRITICALITIES),
+    responsibleActorId: optionalString('responsibleActorId', { maxLength: 100 }),
+  });
+  if (!validation.success) return validationErrorResponse(c, validation.error);
+  if (!validation.data.purpose || !validation.data.criticality) {
+    return c.json({ error: 'Invalid profile values' }, 400);
+  }
+  const repo = new DomainProfileRepository(c.get('db'));
+  const { purpose, criticality, responsibleActorId } = validation.data;
+  const profile = await repo.setWithAudit(
+    {
+      domainId: domain.id,
+      tenantId,
+      purpose: purpose as (typeof DOMAIN_PURPOSES)[number],
+      criticality: criticality as (typeof DOMAIN_CRITICALITIES)[number],
+      responsibleActorId,
+    },
+    {
+      actorId,
+      actorEmail: c.get('actorEmail') ?? null,
+      tenantId,
+      ipAddress: getRequestClientIp(c) ?? null,
+      userAgent: c.req.header('user-agent') ?? null,
+    }
+  );
+  return c.json({ profile });
+});

--- a/apps/web/hono/routes/domain-profile.ts
+++ b/apps/web/hono/routes/domain-profile.ts
@@ -58,10 +58,41 @@ domainProfileRoutes.get('/:domain/evidence', async (c) => {
   const probes = await new ProbeObservationRepository(c.get('db')).findBySnapshotId(
     snapshots[0].id
   );
+  const baselines = await new OperationalBaselineRepository(c.get('db')).listActive(
+    tenantId,
+    domain.id
+  );
+  const now = Date.now();
+  const evidence = probes
+    .filter((probe) => ['rdap', 'tls_cert', 'http'].includes(probe.probeType))
+    .map((probe) => {
+      const data = probe.probeData as {
+        check?: string;
+        evidence?: { hostname?: string; port?: number };
+      } | null;
+      if (data?.check !== 'TLS_CERTIFICATE' || !data.evidence?.hostname || !data.evidence.port) {
+        return { ...probe, freshness: 'NOT_BASELINE_GATED' as const };
+      }
+      const discriminator = `${data.evidence.hostname}:${data.evidence.port}`.toLowerCase();
+      const baseline = baselines.find(
+        (candidate) =>
+          candidate.kind === 'TLS_CERTIFICATE_REGRESSION' &&
+          candidate.discriminator === discriminator
+      );
+      if (!baseline) return { ...probe, freshness: 'MISSING_BASELINE' as const };
+      return {
+        ...probe,
+        freshness:
+          now - probe.probedAt.getTime() > baseline.maxEvidenceAgeSeconds * 1000
+            ? ('STALE' as const)
+            : ('CURRENT' as const),
+      };
+    });
   return c.json({
     domain: domain.normalizedName,
     snapshotId: snapshots[0].id,
-    evidence: probes.filter((probe) => ['rdap', 'tls_cert', 'http'].includes(probe.probeType)),
+    activeBaselineIds: baselines.map((baseline) => baseline.id),
+    evidence,
   });
 });
 

--- a/apps/web/hono/routes/domain-profile.ts
+++ b/apps/web/hono/routes/domain-profile.ts
@@ -40,7 +40,10 @@ domainProfileRoutes.get('/:domain/profile', async (c) => {
   return c.json({
     domain: domain.normalizedName,
     profile,
-    setup: profile ? null : purposeUndeclaredUnknown('Domain evidence'),
+    setup:
+      !profile || profile.purpose === 'UNKNOWN'
+        ? purposeUndeclaredUnknown('Domain evidence')
+        : null,
   });
 });
 

--- a/apps/web/hono/routes/findings.runtime.test.ts
+++ b/apps/web/hono/routes/findings.runtime.test.ts
@@ -277,9 +277,9 @@ describe('findingsRoutes runtime', () => {
           {
             id: 'sug-1',
             findingId: 'finding-1',
-            title: 'Fix authoritative',
-            description: 'Fix it',
-            action: 'manual',
+            title: 'Legacy executable suggestion',
+            description: 'Copy this value',
+            action: 'Add TXT record: v=spf1 include:_spf.google.com ~all',
           },
         ],
       });
@@ -293,6 +293,7 @@ describe('findingsRoutes runtime', () => {
         idempotent: boolean;
         persisted: boolean;
         summary: { totalFindings: number; dnsFindings: number; mailFindings: number };
+        suggestions: Array<{ title: string; description: string; action: string }>;
       };
       expect(json.snapshotId).toBe('snap-1');
       expect(json.idempotent).toBe(true);
@@ -300,6 +301,13 @@ describe('findingsRoutes runtime', () => {
       expect(json.summary.totalFindings).toBe(1);
       expect(json.summary.dnsFindings).toBe(1);
       expect(json.summary.mailFindings).toBe(0);
+      expect(json.suggestions).toEqual([
+        expect.objectContaining({
+          title: 'Review the evidence and applicable operator playbook',
+          action: 'Playbook: operations.manual-evidence-review',
+        }),
+      ]);
+      expect(JSON.stringify(json.suggestions)).not.toContain('_spf.google.com');
     });
 
     it('evaluates and persists findings when no cached version exists', async () => {

--- a/apps/web/hono/routes/findings.runtime.test.ts
+++ b/apps/web/hono/routes/findings.runtime.test.ts
@@ -837,5 +837,57 @@ describe('findingsRoutes runtime', () => {
       expect(json.summary.totalFindings).toBe(1);
       expect(json.mailConfig.hasSpf).toBe(true);
     });
+
+    it('FIX-01: exposes partial UNKNOWN coverage even when no mail issue finding exists', async () => {
+      const evaluationCoverage = {
+        state: 'PARTIAL',
+        errors: [
+          {
+            code: 'RULE_EXECUTION_FAILED',
+            ruleId: 'mail.test-throw',
+            message: 'Rule mail.test-throw could not be evaluated',
+            status: 'UNKNOWN',
+            unknown: {
+              reason: 'CHECK_EVALUATION_FAILED',
+              explanation: 'The mail check failed before it produced a trustworthy result.',
+              action: 'RUN_FRESH_SCAN',
+              actionLabel: 'Run a fresh scan',
+              blocking: true,
+            },
+          },
+        ],
+      };
+      const state = makeState({
+        snapshots: [
+          {
+            ...makeState().snapshots[0],
+            resultState: 'partial',
+            metadata: { evaluation: evaluationCoverage },
+          },
+        ],
+        findings: [
+          {
+            id: 'dns-only',
+            snapshotId: 'snap-1',
+            type: 'dns.partial-coverage-unmanaged',
+            title: 'Coverage is partial',
+            severity: 'info',
+            ruleVersion: '1.0.0',
+          },
+        ],
+      });
+      const app = createApp(state);
+
+      const response = await app.request('/api/snapshot/snap-1/findings/mail');
+
+      expect(response.status).toBe(200);
+      const json = (await response.json()) as {
+        findings: unknown[];
+        evaluationCoverage: typeof evaluationCoverage;
+      };
+      expect(json.findings).toEqual([]);
+      expect(json.evaluationCoverage).toEqual(evaluationCoverage);
+      expect(json.evaluationCoverage.errors[0]?.status).toBe('UNKNOWN');
+    });
   });
 });

--- a/apps/web/hono/routes/findings.ts
+++ b/apps/web/hono/routes/findings.ts
@@ -37,6 +37,7 @@ import {
   unmanagedZonePartialCoverageRule,
 } from '@dns-ops/rules';
 import { Hono } from 'hono';
+import { sanitizePersistedSuggestion } from '../lib/guidance.js';
 import { requireAuth, requireWritePermission } from '../middleware/authorization.js';
 import { getWebLogger } from '../middleware/error-tracking.js';
 import type { Env } from '../types.js';
@@ -169,8 +170,17 @@ findingsRoutes.get('/snapshot/:snapshotId/findings', requireAuth, async (c) => {
       const findingIds = existingFindingsForVersion.map((f) => f.id);
       const suggestionsMap = await suggestionRepo.findByFindingIds(findingIds);
 
-      // Flatten suggestions
-      const allSuggestions = [...suggestionsMap.values()].flat();
+      const findingTypeById = new Map(
+        existingFindingsForVersion.map((finding) => [finding.id, finding.type])
+      );
+      const allSuggestions = [...suggestionsMap.values()]
+        .flat()
+        .map((suggestion) =>
+          sanitizePersistedSuggestion(
+            suggestion,
+            findingTypeById.get(suggestion.findingId) ?? 'unknown'
+          )
+        );
 
       // Categorize findings
       const dnsFindings = existingFindingsForVersion.filter((f) => f.type.startsWith('dns.'));
@@ -415,7 +425,15 @@ findingsRoutes.get('/snapshot/:snapshotId/findings/mail', requireAuth, async (c)
     // Get suggestions for mail findings
     const mailFindingIds = mailFindings.map((f) => f.id);
     const suggestionsMap = await suggestionRepo.findByFindingIds(mailFindingIds);
-    const allSuggestions = [...suggestionsMap.values()].flat();
+    const findingTypeById = new Map(mailFindings.map((finding) => [finding.id, finding.type]));
+    const allSuggestions = [...suggestionsMap.values()]
+      .flat()
+      .map((suggestion) =>
+        sanitizePersistedSuggestion(
+          suggestion,
+          findingTypeById.get(suggestion.findingId) ?? 'unknown'
+        )
+      );
 
     // Calculate mail security score from findings (basic analysis)
     const mailConfig = analyzeMailConfiguration(mailFindings);
@@ -1127,18 +1145,19 @@ function analyzeMailConfiguration(
         break;
       case 'mail.no-mx-record':
         config.issues.push('No MX record');
-        config.recommendations.push('Add an MX record');
+        config.recommendations.push('Review playbook mail.mx.purpose-and-provider');
         break;
       case 'mail.spf-present':
         config.hasSpf = true;
-        score += 20;
+        // Phase 0–1 SPF is FIRST_LEVEL_ONLY and cannot receive full-validity credit.
+        score += 10;
         if (finding.severity && finding.severity !== 'info') {
           config.issues.push(`SPF issue: ${finding.severity}`);
         }
         break;
       case 'mail.no-spf-record':
         config.issues.push('No SPF record');
-        config.recommendations.push('Add an SPF record');
+        config.recommendations.push('Review playbook mail.spf.provider-confirmation');
         break;
       case 'mail.dmarc-present':
         config.hasDmarc = true;
@@ -1149,7 +1168,7 @@ function analyzeMailConfiguration(
         break;
       case 'mail.no-dmarc-record':
         config.issues.push('No DMARC record');
-        config.recommendations.push('Add a DMARC record');
+        config.recommendations.push('Review playbook mail.dmarc.monitoring-readiness');
         break;
       case 'mail.dkim-keys-present':
         config.hasDkim = true;
@@ -1158,7 +1177,7 @@ function analyzeMailConfiguration(
       case 'mail.dkim-no-valid-keys':
       case 'mail.no-dkim-queried':
         config.issues.push('DKIM not configured');
-        config.recommendations.push('Configure DKIM');
+        config.recommendations.push('Review playbook mail.dkim.selector-evidence');
         break;
       case 'mail.mta-sts-present':
         config.hasMtaSts = true;

--- a/apps/web/hono/routes/findings.ts
+++ b/apps/web/hono/routes/findings.ts
@@ -5,6 +5,7 @@
  * Includes DNS rules and Mail rules with database persistence.
  */
 
+import { evaluationCoverageOrUnknown } from '@dns-ops/contracts';
 import type { NewFinding, NewSuggestion } from '@dns-ops/db';
 import {
   DkimSelectorRepository,
@@ -182,6 +183,7 @@ findingsRoutes.get('/snapshot/:snapshotId/findings', requireAuth, async (c) => {
         rulesetVersionId,
         persisted: true,
         idempotent: true, // Indicates findings were already present for this ruleset version
+        evaluationCoverage: evaluationCoverageOrUnknown(snapshot.metadata?.evaluation),
         summary: {
           totalFindings: existingFindingsForVersion.length,
           dnsFindings: dnsFindings.length,
@@ -212,9 +214,15 @@ findingsRoutes.get('/snapshot/:snapshotId/findings', requireAuth, async (c) => {
       rulesetVersion: ruleset.version,
     };
 
-    // Evaluate rules
+    // Evaluate rules. Persist explicit coverage so zero findings cannot imply
+    // healthy when an enabled rule failed.
     const engine = new RulesEngine(ruleset);
-    const { findings, suggestions } = engine.evaluate(context);
+    const { findings, suggestions, errors, complete } = engine.evaluate(context);
+    const evaluationCoverage = {
+      state: complete ? ('COMPLETE' as const) : ('PARTIAL' as const),
+      errors,
+    };
+    await snapshotRepo.updateEvaluationCoverage(snapshotId, evaluationCoverage);
 
     // Delete existing findings for this ruleset version only (not other versions)
     // This preserves historical findings from previous ruleset versions
@@ -283,6 +291,7 @@ findingsRoutes.get('/snapshot/:snapshotId/findings', requireAuth, async (c) => {
       evaluated: true,
       idempotent: false, // Indicates findings were freshly evaluated (not cached)
       rulesEvaluated: engine.getEnabledRulesCount(),
+      evaluationCoverage,
       summary: {
         totalFindings: persistedFindings.length,
         dnsFindings: dnsFindings.length,
@@ -375,6 +384,7 @@ findingsRoutes.get('/snapshot/:snapshotId/findings/mail', requireAuth, async (c)
       const mainData = (await mainResponse.json()) as {
         findings?: Array<{ type: string }>;
         categorized?: { mail?: Array<{ type: string }> };
+        evaluationCoverage?: { state: 'COMPLETE' | 'PARTIAL'; errors: unknown[] };
       };
       const evaluatedMailFindings = mainData.categorized?.mail || [];
 
@@ -388,6 +398,8 @@ findingsRoutes.get('/snapshot/:snapshotId/findings/mail', requireAuth, async (c)
         snapshotId,
         domain: domain.name,
         rulesetVersion: CURRENT_RULESET_VERSION,
+        evaluationCoverage:
+          mainData.evaluationCoverage ?? evaluationCoverageOrUnknown(snapshot.metadata?.evaluation),
         summary: {
           totalFindings: evaluatedMailFindings.length,
           dkimSelectorsFound: dkimSelectors.filter((s) => s.found).length,
@@ -416,6 +428,7 @@ findingsRoutes.get('/snapshot/:snapshotId/findings/mail', requireAuth, async (c)
       domain: domain.name,
       rulesetVersion: mailFindings[0]?.ruleVersion || CURRENT_RULESET_VERSION,
       persisted: true,
+      evaluationCoverage: evaluationCoverageOrUnknown(snapshot.metadata?.evaluation),
       summary: {
         totalFindings: mailFindings.length,
         suggestions: allSuggestions.length,
@@ -834,7 +847,7 @@ findingsRoutes.post('/findings/backfill', requireAuth, async (c) => {
       domainName: string;
       findingsCount: number;
       suggestionsCount: number;
-      status: 'success' | 'error';
+      status: 'success' | 'partial' | 'error';
       error?: string;
     }> = [];
 
@@ -894,9 +907,13 @@ findingsRoutes.post('/findings/backfill', requireAuth, async (c) => {
           rulesetVersion: ruleset.version,
         };
 
-        // Evaluate rules
+        // Evaluate rules and preserve incomplete coverage during backfill.
         const engine = new RulesEngine(ruleset);
-        const { findings, suggestions } = engine.evaluate(context);
+        const { findings, suggestions, errors, complete } = engine.evaluate(context);
+        await snapshotRepo.updateEvaluationCoverage(snapshot.id, {
+          state: complete ? 'COMPLETE' : 'PARTIAL',
+          errors,
+        });
 
         // Delete any existing findings for this ruleset version (idempotent)
         await findingRepo.deleteBySnapshotIdAndRulesetVersionId(snapshot.id, rulesetVersionId);
@@ -957,7 +974,7 @@ findingsRoutes.post('/findings/backfill', requireAuth, async (c) => {
           domainName: snapshot.domainName,
           findingsCount: persistedFindings.length,
           suggestionsCount: persistedSuggestions.length,
-          status: 'success',
+          status: complete ? 'success' : 'partial',
         });
       } catch (error) {
         results.push({

--- a/apps/web/hono/routes/mail.runtime.test.ts
+++ b/apps/web/hono/routes/mail.runtime.test.ts
@@ -13,6 +13,8 @@ import { mailRoutes } from './mail.js';
 interface MockState {
   remediationRequests: Array<Record<string, unknown>>;
   auditEvents: Array<Record<string, unknown>>;
+  snapshots?: Array<Record<string, unknown>>;
+  domains?: Array<Record<string, unknown>>;
 }
 
 function getTableName(table: unknown): string {
@@ -44,6 +46,8 @@ function createMockDb(state: MockState): IDatabaseAdapter {
       const tableName = getTableName(table);
       if (tableName === 'remediation_requests') return [...state.remediationRequests];
       if (tableName === 'audit_events') return [...state.auditEvents];
+      if (tableName === 'snapshots') return [...(state.snapshots ?? [])];
+      if (tableName === 'domains') return [...(state.domains ?? [])];
       return [];
     }),
     selectWhere: vi.fn(async (table: unknown, condition: unknown) => {
@@ -64,6 +68,8 @@ function createMockDb(state: MockState): IDatabaseAdapter {
       const param = getConditionParam(condition);
       if (tableName === 'remediation_requests')
         return state.remediationRequests.find((row) => row.id === param);
+      if (tableName === 'snapshots') return state.snapshots?.find((row) => row.id === param);
+      if (tableName === 'domains') return state.domains?.find((row) => row.id === param);
       return undefined;
     }),
     insert: vi.fn(async (table: unknown, values: Record<string, unknown>) => {
@@ -317,6 +323,158 @@ describe('mailRoutes remediation runtime', () => {
       expect(state.auditEvents).toHaveLength(1);
       expect(state.auditEvents[0]?.action).toBe('remediation_request_updated');
       expect(state.auditEvents[0]?.previousValue).toMatchObject({ status: 'open' });
+    });
+
+    it('requires fresh complete evidence before resolution', async () => {
+      const state: MockState = {
+        remediationRequests: [
+          {
+            id: 'rem-1',
+            tenantId: 'tenant-1',
+            domain: 'example.com',
+            status: 'open',
+            priority: 'high',
+            createdAt: new Date(Date.now() - 60_000),
+          },
+        ],
+        auditEvents: [],
+      };
+      const app = createApp(state);
+
+      const response = await app.request('/api/mail/remediation/rem-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'resolved' }),
+      });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({ code: 'FRESH_EVIDENCE_REQUIRED' });
+    });
+
+    it('resolves only with a newer complete same-tenant snapshot', async () => {
+      const snapshotId = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+      const state: MockState = {
+        remediationRequests: [
+          {
+            id: 'rem-1',
+            tenantId: 'tenant-1',
+            domain: 'example.com',
+            status: 'open',
+            priority: 'high',
+            assignedTo: null,
+            notes: null,
+            createdAt: new Date(Date.now() - 60_000),
+          },
+        ],
+        snapshots: [
+          {
+            id: snapshotId,
+            domainId: 'domain-1',
+            domainName: 'example.com',
+            resultState: 'complete',
+            metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+            createdAt: new Date(),
+          },
+        ],
+        domains: [{ id: 'domain-1', tenantId: 'tenant-1', name: 'example.com' }],
+        auditEvents: [],
+      };
+      const app = createApp(state);
+
+      const response = await app.request('/api/mail/remediation/rem-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'resolved', verificationSnapshotId: snapshotId }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(state.auditEvents[0]?.newValue).toMatchObject({ verificationSnapshotId: snapshotId });
+    });
+
+    it('rejects evidence captured before the current reopened lifecycle', async () => {
+      const snapshotId = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+      const state: MockState = {
+        remediationRequests: [
+          {
+            id: 'rem-1',
+            tenantId: 'tenant-1',
+            domain: 'example.com',
+            status: 'open',
+            priority: 'high',
+            createdAt: new Date(Date.now() - 120_000),
+            updatedAt: new Date(),
+          },
+        ],
+        snapshots: [
+          {
+            id: snapshotId,
+            domainId: 'domain-1',
+            domainName: 'example.com',
+            resultState: 'complete',
+            metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+            createdAt: new Date(Date.now() - 30_000),
+          },
+        ],
+        domains: [{ id: 'domain-1', tenantId: 'tenant-1', name: 'example.com' }],
+        auditEvents: [],
+      };
+
+      const response = await createApp(state).request('/api/mail/remediation/rem-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'resolved', verificationSnapshotId: snapshotId }),
+      });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({ code: 'FRESH_EVIDENCE_REQUIRED' });
+    });
+
+    it.each([
+      ['stale', { createdAt: new Date(0) }, 'tenant-1', 409],
+      [
+        'partial',
+        { resultState: 'partial', metadata: { evaluation: { state: 'PARTIAL', errors: [] } } },
+        'tenant-1',
+        409,
+      ],
+      ['wrong-domain', { domainName: 'other.example' }, 'tenant-1', 409],
+      ['cross-tenant', {}, 'other-tenant', 404],
+    ] as const)('rejects %s verification evidence', async (_label, snapshotOverrides, domainTenant, expectedStatus) => {
+      const snapshotId = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+      const state: MockState = {
+        remediationRequests: [
+          {
+            id: 'rem-1',
+            tenantId: 'tenant-1',
+            domain: 'example.com',
+            status: 'open',
+            priority: 'high',
+            createdAt: new Date(Date.now() - 60_000),
+          },
+        ],
+        snapshots: [
+          {
+            id: snapshotId,
+            domainId: 'domain-1',
+            domainName: 'example.com',
+            resultState: 'complete',
+            metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+            createdAt: new Date(),
+            ...snapshotOverrides,
+          },
+        ],
+        domains: [{ id: 'domain-1', tenantId: domainTenant, name: 'example.com' }],
+        auditEvents: [],
+      };
+      const response = await createApp(state).request('/api/mail/remediation/rem-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'resolved', verificationSnapshotId: snapshotId }),
+      });
+
+      expect(response.status).toBe(expectedStatus);
+      expect(state.auditEvents).toHaveLength(0);
+      expect(state.remediationRequests[0]?.status).toBe('open');
     });
 
     it('returns 404 for nonexistent request', async () => {

--- a/apps/web/hono/routes/mail.ts
+++ b/apps/web/hono/routes/mail.ts
@@ -4,7 +4,12 @@
  * API endpoints for mail diagnostics and remediation workflows.
  */
 
-import { AuditEventRepository, RemediationRepository } from '@dns-ops/db';
+import {
+  AuditEventRepository,
+  DomainRepository,
+  RemediationRepository,
+  SnapshotRepository,
+} from '@dns-ops/db';
 import { Hono } from 'hono';
 import { getRequestEnvConfig } from '../config/env.js';
 import { getFeedbackMetrics } from '../lib/metrics.js';
@@ -302,6 +307,7 @@ export const mailRoutes = new Hono<Env>()
       status: enumValue('status', REMEDIATION_STATUSES, false),
       assignedTo: optionalString('assignedTo', { maxLength: 100 }),
       notes: optionalString('notes', { maxLength: 5000 }),
+      verificationSnapshotId: uuid('verificationSnapshotId', false),
     });
 
     if (!validation.success) {
@@ -315,6 +321,53 @@ export const mailRoutes = new Hono<Env>()
     }
 
     const status = validation.data.status ?? existing.status;
+    const isClosing = status === 'resolved' || status === 'closed';
+    let verificationSnapshotId: string | undefined;
+
+    if (isClosing && status !== existing.status) {
+      verificationSnapshotId = validation.data.verificationSnapshotId;
+      if (!verificationSnapshotId) {
+        return c.json(
+          {
+            error: 'A fresh complete snapshot is required to resolve or close remediation work',
+            code: 'FRESH_EVIDENCE_REQUIRED',
+          },
+          409
+        );
+      }
+
+      const snapshot = await new SnapshotRepository(db).findById(verificationSnapshotId);
+      if (!snapshot || snapshot.domainName.toLowerCase() !== existing.domain.toLowerCase()) {
+        return c.json(
+          {
+            error: 'Verification snapshot does not match this remediation domain',
+            code: 'INVALID_EVIDENCE',
+          },
+          409
+        );
+      }
+      const snapshotDomain = await new DomainRepository(db).findById(snapshot.domainId);
+      if (!snapshotDomain || snapshotDomain.tenantId !== tenantId) {
+        return c.json({ error: 'Verification snapshot not found', code: 'INVALID_EVIDENCE' }, 404);
+      }
+      const evaluation = snapshot.metadata?.evaluation;
+      const activeLifecycleStartedAt = existing.updatedAt ?? existing.createdAt;
+      if (
+        snapshot.createdAt <= activeLifecycleStartedAt ||
+        snapshot.resultState !== 'complete' ||
+        evaluation?.state !== 'COMPLETE'
+      ) {
+        return c.json(
+          {
+            error:
+              'Verification snapshot must be newer than the request and have complete evaluation coverage',
+            code: 'FRESH_EVIDENCE_REQUIRED',
+          },
+          409
+        );
+      }
+    }
+
     const remediation = await existingRepo.updateStatus(id, tenantId, status, {
       assignedTo: validation.data.assignedTo,
       notes: validation.data.notes,
@@ -340,6 +393,7 @@ export const mailRoutes = new Hono<Env>()
         status: remediation.status,
         assignedTo: remediation.assignedTo,
         notes: remediation.notes,
+        verificationSnapshotId,
       },
       ipAddress: c.req.header('x-forwarded-for') || c.req.header('x-real-ip'),
       userAgent: c.req.header('user-agent'),

--- a/apps/web/hono/routes/mcp-server.ts
+++ b/apps/web/hono/routes/mcp-server.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono';
+import { dbMiddleware } from '../middleware/db.js';
+import type { Env } from '../types.js';
+import { mcpRoutes } from './mcp.js';
+
+/**
+ * Server-only MCP app. It is mounted from the TanStack SSR entrypoint so `/mcp`
+ * never enters the browser route graph or relies on the `/api` application path.
+ */
+export const mcpServer = new Hono<Env>();
+mcpServer.use('*', dbMiddleware);
+mcpServer.route('/mcp', mcpRoutes);

--- a/apps/web/hono/routes/mcp.harness.test.ts
+++ b/apps/web/hono/routes/mcp.harness.test.ts
@@ -1,0 +1,128 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { hashMcpToken } from '../lib/mcp-auth.js';
+import { McpCaseCommandService } from '../lib/mcp-case-command-service.js';
+import { McpReadService } from '../lib/mcp-read-service.js';
+import { McpScanService } from '../lib/mcp-scan-service.js';
+import type { Env } from '../types.js';
+import { mcpRoutes } from './mcp.js';
+
+const token = 'deterministic-mcp-harness-token-with-sufficient-entropy';
+const tenantId = '11111111-1111-4111-8111-111111111111';
+const env = {
+  MCP_PRINCIPALS_JSON: JSON.stringify([
+    {
+      principalId: 'mcp-harness',
+      tokenSha256: hashMcpToken(token),
+      tenantId,
+      actorId: 'mcp-harness-actor',
+      scopes: ['DOMAIN_READ', 'SIGNAL_READ', 'CASE_READ', 'CASE_WRITE', 'SCAN_REQUEST'],
+      enabled: true,
+    },
+  ]),
+};
+
+function app() {
+  const server = new Hono<Env>();
+  server.route('/mcp', mcpRoutes);
+  return server;
+}
+
+function call(name: string, args: Record<string, unknown>) {
+  return {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: name,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }),
+  };
+}
+
+const cases = [
+  ['domain_search', { query: 'example' }, []],
+  ['domain_get_profile', { domainId: 'domain-a' }, { setupRequired: true }],
+  ['domain_get_posture', { domainId: 'domain-a' }, { setupRequired: false }],
+  [
+    'snapshot_compare',
+    { domainId: 'domain-a', leftSnapshotId: 'snapshot-a', rightSnapshotId: 'snapshot-b' },
+    { changes: [] },
+  ],
+  ['evidence_get', { snapshotId: 'snapshot-a' }, { incomplete: true }],
+  ['signal_list', { domainId: 'domain-a' }, []],
+  ['case_get', { caseId: 'case-a' }, { case: { id: 'case-a' } }],
+  [
+    'case_open',
+    { domainId: 'domain-a', conditionKey: 'mail.no-spf-record', idempotencyKey: 'open-1' },
+    { ok: true, value: { case: { id: 'case-a' } }, replayed: false },
+  ],
+  [
+    'case_set_disposition',
+    { caseId: 'case-a', disposition: 'ACKNOWLEDGED', expectedVersion: 1, idempotencyKey: 'set-1' },
+    { ok: true, value: { case: { id: 'case-a', version: 2 } }, replayed: false },
+  ],
+  [
+    'scan_request',
+    { domainId: 'domain-a', idempotencyKey: 'scan-1' },
+    { ok: true, value: { snapshotId: 'snapshot-a' }, replayed: false },
+  ],
+] as const;
+
+describe('deterministic MCP transport harness', () => {
+  beforeEach(() => {
+    vi.spyOn(McpReadService.prototype, 'domainSearch').mockResolvedValue([]);
+    vi.spyOn(McpReadService.prototype, 'domainProfile').mockResolvedValue({
+      setupRequired: true,
+    } as never);
+    vi.spyOn(McpReadService.prototype, 'domainPosture').mockResolvedValue({
+      setupRequired: false,
+    } as never);
+    vi.spyOn(McpReadService.prototype, 'snapshotCompare').mockResolvedValue({
+      changes: [],
+    } as never);
+    vi.spyOn(McpReadService.prototype, 'evidence').mockResolvedValue({ incomplete: true } as never);
+    vi.spyOn(McpReadService.prototype, 'signalList').mockResolvedValue([]);
+    vi.spyOn(McpReadService.prototype, 'caseGet').mockResolvedValue({
+      case: { id: 'case-a' },
+    } as never);
+    vi.spyOn(McpCaseCommandService.prototype, 'caseOpen').mockResolvedValue({
+      ok: true,
+      value: { case: { id: 'case-a' } },
+      replayed: false,
+    });
+    vi.spyOn(McpCaseCommandService.prototype, 'caseSetDisposition').mockResolvedValue({
+      ok: true,
+      value: { case: { id: 'case-a', version: 2 } },
+      replayed: false,
+    });
+    vi.spyOn(McpScanService.prototype, 'request').mockResolvedValue({
+      ok: true,
+      value: { snapshotId: 'snapshot-a' },
+      replayed: false,
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each(cases)('returns a typed successful result for %s', async (name, args, expected) => {
+    const response = await app().request('/mcp', call(name, args), env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      jsonrpc: '2.0',
+      id: name,
+      result: { structuredContent: expected },
+    });
+  });
+
+  it('rejects every malformed tool schema before invoking a service', async () => {
+    for (const [name] of cases) {
+      const malformedArguments =
+        name === 'domain_search' ? { query: 1 } : name === 'signal_list' ? { domainId: 1 } : {};
+      const response = await app().request('/mcp', call(name, malformedArguments), env);
+      expect(response.status, name).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: { code: -32602 } });
+    }
+  });
+});

--- a/apps/web/hono/routes/mcp.test.ts
+++ b/apps/web/hono/routes/mcp.test.ts
@@ -84,8 +84,8 @@ describe('MCP discovery transport', () => {
       env
     );
     expect(invalid.status).toBe(400);
-    const missing = await app().request('/mcp', rpc('tools/call'), env);
-    expect(missing.status).toBe(404);
-    await expect(missing.json()).resolves.toMatchObject({ error: { code: -32601 } });
+    const invalidCall = await app().request('/mcp', rpc('tools/call'), env);
+    expect(invalidCall.status).toBe(400);
+    await expect(invalidCall.json()).resolves.toMatchObject({ error: { code: -32602 } });
   });
 });

--- a/apps/web/hono/routes/mcp.test.ts
+++ b/apps/web/hono/routes/mcp.test.ts
@@ -1,0 +1,74 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { hashMcpToken } from '../lib/mcp-auth.js';
+import { MCP_TOOLS } from '../lib/mcp-tools.js';
+import type { Env } from '../types.js';
+import { mcpRoutes } from './mcp.js';
+
+const token = 'a-long-random-mcp-bearer-token-with-enough-entropy-12345';
+const env = {
+  MCP_PRINCIPALS_JSON: JSON.stringify([
+    {
+      tokenHash: hashMcpToken(token),
+      tenantId: 'tenant-a',
+      actorId: 'actor-a',
+      scopes: ['CASE_READ'],
+    },
+  ]),
+};
+
+function app() {
+  const server = new Hono<Env>();
+  server.route('/mcp', mcpRoutes);
+  return server;
+}
+
+function rpc(method: string) {
+  return {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method }),
+  };
+}
+
+describe('MCP discovery transport', () => {
+  it('requires a configured static bearer principal', async () => {
+    const response = await app().request(
+      '/mcp',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      },
+      env
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it('initializes and lists exactly the approved tool contract', async () => {
+    const server = app();
+    const initialized = await server.request('/mcp', rpc('initialize'), env);
+    expect(initialized.status).toBe(200);
+    await expect(initialized.json()).resolves.toMatchObject({
+      result: { capabilities: { tools: {} } },
+    });
+    const listed = await server.request('/mcp', rpc('tools/list'), env);
+    await expect(listed.json()).resolves.toMatchObject({ result: { tools: MCP_TOOLS } });
+  });
+
+  it('rejects malformed and unimplemented transport methods without leaking exceptions', async () => {
+    const invalid = await app().request(
+      '/mcp',
+      {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: '{}',
+      },
+      env
+    );
+    expect(invalid.status).toBe(400);
+    const missing = await app().request('/mcp', rpc('tools/call'), env);
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toMatchObject({ error: { code: -32601 } });
+  });
+});

--- a/apps/web/hono/routes/mcp.test.ts
+++ b/apps/web/hono/routes/mcp.test.ts
@@ -12,7 +12,7 @@ const env = {
       tokenHash: hashMcpToken(token),
       tenantId: 'tenant-a',
       actorId: 'actor-a',
-      scopes: ['CASE_READ'],
+      scopes: ['DOMAIN_READ', 'SIGNAL_READ', 'CASE_READ', 'CASE_WRITE', 'SCAN_REQUEST'],
     },
   ]),
 };
@@ -54,6 +54,23 @@ describe('MCP discovery transport', () => {
     });
     const listed = await server.request('/mcp', rpc('tools/list'), env);
     await expect(listed.json()).resolves.toMatchObject({ result: { tools: MCP_TOOLS } });
+  });
+
+  it('does not disclose tools above the caller scope', async () => {
+    const limitedEnv = {
+      MCP_PRINCIPALS_JSON: JSON.stringify([
+        {
+          tokenHash: hashMcpToken(token),
+          tenantId: 'tenant-a',
+          actorId: 'actor-a',
+          scopes: ['CASE_READ'],
+        },
+      ]),
+    };
+    const response = await app().request('/mcp', rpc('tools/list'), limitedEnv);
+    await expect(response.json()).resolves.toMatchObject({
+      result: { tools: [{ name: 'case_get', requiredScope: 'CASE_READ' }] },
+    });
   });
 
   it('rejects malformed and unimplemented transport methods without leaking exceptions', async () => {

--- a/apps/web/hono/routes/mcp.test.ts
+++ b/apps/web/hono/routes/mcp.test.ts
@@ -9,10 +9,12 @@ const token = 'a-long-random-mcp-bearer-token-with-enough-entropy-12345';
 const env = {
   MCP_PRINCIPALS_JSON: JSON.stringify([
     {
-      tokenHash: hashMcpToken(token),
-      tenantId: 'tenant-a',
+      principalId: 'mcp-operator-a',
+      tokenSha256: hashMcpToken(token),
+      tenantId: '11111111-1111-4111-8111-111111111111',
       actorId: 'actor-a',
       scopes: ['DOMAIN_READ', 'SIGNAL_READ', 'CASE_READ', 'CASE_WRITE', 'SCAN_REQUEST'],
+      enabled: true,
     },
   ]),
 };
@@ -56,14 +58,30 @@ describe('MCP discovery transport', () => {
     await expect(listed.json()).resolves.toMatchObject({ result: { tools: MCP_TOOLS } });
   });
 
+  it('rejects invalid JSON-RPC request IDs', async () => {
+    const response = await app().request(
+      '/mcp',
+      {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: true, method: 'initialize' }),
+      },
+      env
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: -32600 } });
+  });
+
   it('does not disclose tools above the caller scope', async () => {
     const limitedEnv = {
       MCP_PRINCIPALS_JSON: JSON.stringify([
         {
-          tokenHash: hashMcpToken(token),
-          tenantId: 'tenant-a',
+          principalId: 'mcp-operator-a',
+          tokenSha256: hashMcpToken(token),
+          tenantId: '11111111-1111-4111-8111-111111111111',
           actorId: 'actor-a',
           scopes: ['CASE_READ'],
+          enabled: true,
         },
       ]),
     };

--- a/apps/web/hono/routes/mcp.ts
+++ b/apps/web/hono/routes/mcp.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { authenticateMcpBearer, type McpPrincipal, parseMcpPrincipals } from '../lib/mcp-auth.js';
+import { dispatchMcpTool, toMcpDispatchError } from '../lib/mcp-dispatch.js';
 import { MCP_TOOLS } from '../lib/mcp-tools.js';
 import type { Env } from '../types.js';
 
@@ -54,6 +55,35 @@ mcpRoutes.post('/', async (c) => {
       id: request.id ?? null,
       result: { tools: MCP_TOOLS.filter((tool) => principal.scopes.has(tool.requiredScope)) },
     });
+  }
+  if (request.method === 'tools/call') {
+    const params = request.params;
+    if (!params || typeof params !== 'object' || Array.isArray(params)) {
+      return c.json(rpcError(request.id, -32602, 'Invalid tool call parameters'), 400);
+    }
+    const call = params as { name?: unknown; arguments?: unknown };
+    if (typeof call.name !== 'string') {
+      return c.json(rpcError(request.id, -32602, 'Tool name is required'), 400);
+    }
+    // Collector proxy headers must remain principal-derived rather than model arguments.
+    c.set('tenantId', principal.tenantId);
+    c.set('actorId', principal.actorId);
+    try {
+      const result = await dispatchMcpTool(
+        c,
+        c.get('db'),
+        principal,
+        call.name,
+        call.arguments ?? {}
+      );
+      return c.json({ jsonrpc: '2.0', id: request.id ?? null, result });
+    } catch (error) {
+      const mapped = toMcpDispatchError(error);
+      return c.json(
+        rpcError(request.id, mapped.code, mapped.message),
+        mapped.code === -32601 ? 404 : 400
+      );
+    }
   }
   return c.json(rpcError(request.id, -32601, 'Method not found'), 404);
 });

--- a/apps/web/hono/routes/mcp.ts
+++ b/apps/web/hono/routes/mcp.ts
@@ -8,6 +8,8 @@ export const mcpRoutes = new Hono<Env>();
 
 type JsonRpcRequest = { jsonrpc?: unknown; id?: unknown; method?: unknown; params?: unknown };
 
+const MCP_PRINCIPALS_SECRET_KEY = 'MCP_PRINCIPALS_JSON';
+
 function rpcError(id: unknown, code: number, message: string) {
   return {
     jsonrpc: '2.0',
@@ -17,7 +19,9 @@ function rpcError(id: unknown, code: number, message: string) {
 }
 
 function principalSecret(c: { env: Env['Bindings'] }): string | undefined {
-  return c.env.MCP_PRINCIPALS_JSON ?? process.env.MCP_PRINCIPALS_JSON;
+  // Bracket access keeps Nitro's Node runtime environment dynamic rather than
+  // replacing an undeclared secret with undefined at build time.
+  return c.env.MCP_PRINCIPALS_JSON ?? process.env[MCP_PRINCIPALS_SECRET_KEY];
 }
 
 /**

--- a/apps/web/hono/routes/mcp.ts
+++ b/apps/web/hono/routes/mcp.ts
@@ -49,7 +49,11 @@ mcpRoutes.post('/', async (c) => {
     });
   }
   if (request.method === 'tools/list') {
-    return c.json({ jsonrpc: '2.0', id: request.id ?? null, result: { tools: MCP_TOOLS } });
+    return c.json({
+      jsonrpc: '2.0',
+      id: request.id ?? null,
+      result: { tools: MCP_TOOLS.filter((tool) => principal.scopes.has(tool.requiredScope)) },
+    });
   }
   return c.json(rpcError(request.id, -32601, 'Method not found'), 404);
 });

--- a/apps/web/hono/routes/mcp.ts
+++ b/apps/web/hono/routes/mcp.ts
@@ -35,7 +35,15 @@ mcpRoutes.post('/', async (c) => {
   if (!principal) return c.json(rpcError(null, -32001, 'Unauthorized'), 401);
 
   const request = (await c.req.json().catch(() => null)) as JsonRpcRequest | null;
-  if (!request || request.jsonrpc !== '2.0' || typeof request.method !== 'string') {
+  if (
+    !request ||
+    request.jsonrpc !== '2.0' ||
+    typeof request.method !== 'string' ||
+    (typeof request.id !== 'undefined' &&
+      request.id !== null &&
+      typeof request.id !== 'string' &&
+      typeof request.id !== 'number')
+  ) {
     return c.json(rpcError(null, -32600, 'Invalid request'), 400);
   }
   if (request.method === 'initialize') {

--- a/apps/web/hono/routes/mcp.ts
+++ b/apps/web/hono/routes/mcp.ts
@@ -1,0 +1,55 @@
+import { Hono } from 'hono';
+import { authenticateMcpBearer, type McpPrincipal, parseMcpPrincipals } from '../lib/mcp-auth.js';
+import { MCP_TOOLS } from '../lib/mcp-tools.js';
+import type { Env } from '../types.js';
+
+export const mcpRoutes = new Hono<Env>();
+
+type JsonRpcRequest = { jsonrpc?: unknown; id?: unknown; method?: unknown; params?: unknown };
+
+function rpcError(id: unknown, code: number, message: string) {
+  return {
+    jsonrpc: '2.0',
+    id: typeof id === 'string' || typeof id === 'number' ? id : null,
+    error: { code, message },
+  };
+}
+
+function principalSecret(c: { env: Env['Bindings'] }): string | undefined {
+  return c.env.MCP_PRINCIPALS_JSON ?? process.env.MCP_PRINCIPALS_JSON;
+}
+
+/**
+ * MCP transport discovery is intentionally separate from session auth. Its bearer
+ * principal is static and derives tenant/actor/scope from a token hash only.
+ */
+mcpRoutes.post('/', async (c) => {
+  let principals: McpPrincipal[];
+  try {
+    principals = parseMcpPrincipals(principalSecret(c));
+  } catch {
+    return c.json(rpcError(null, -32603, 'MCP authorization configuration is invalid'), 500);
+  }
+  const principal = authenticateMcpBearer(c.req.header('authorization'), principals);
+  if (!principal) return c.json(rpcError(null, -32001, 'Unauthorized'), 401);
+
+  const request = (await c.req.json().catch(() => null)) as JsonRpcRequest | null;
+  if (!request || request.jsonrpc !== '2.0' || typeof request.method !== 'string') {
+    return c.json(rpcError(null, -32600, 'Invalid request'), 400);
+  }
+  if (request.method === 'initialize') {
+    return c.json({
+      jsonrpc: '2.0',
+      id: request.id ?? null,
+      result: {
+        protocolVersion: '2024-11-05',
+        serverInfo: { name: 'dns-ops', version: '0.1.0' },
+        capabilities: { tools: {} },
+      },
+    });
+  }
+  if (request.method === 'tools/list') {
+    return c.json({ jsonrpc: '2.0', id: request.id ?? null, result: { tools: MCP_TOOLS } });
+  }
+  return c.json(rpcError(request.id, -32601, 'Method not found'), 404);
+});

--- a/apps/web/hono/routes/portfolio.ts
+++ b/apps/web/hono/routes/portfolio.ts
@@ -5,6 +5,7 @@
  * saved filters, and template management.
  */
 
+import { evaluationCoverageOrUnknown, isEvaluationComplete } from '@dns-ops/contracts';
 import {
   AuditEventRepository,
   DomainNoteRepository,
@@ -175,12 +176,15 @@ portfolioRoutes.post('/search', async (c) => {
           ...domain,
           findings: [],
           findingsEvaluated: false,
+          evaluationCoverage: evaluationCoverageOrUnknown(undefined),
           latestSnapshot: null,
         };
       }
 
-      // Check if findings were evaluated (rulesetVersionId set on snapshot)
-      const findingsEvaluated = latestSnapshot.rulesetVersionId !== null;
+      // Only explicit complete coverage permits a zero-finding result to filter
+      // the domain out. A ruleset ID alone does not prove every check completed.
+      const evaluationCoverage = evaluationCoverageOrUnknown(latestSnapshot.metadata?.evaluation);
+      const findingsEvaluated = isEvaluationComplete(evaluationCoverage);
       const domainFindings = findingsBySnapshot.get(latestSnapshot.id) || [];
 
       // Filter out if severity filter doesn't match AND findings were evaluated
@@ -193,6 +197,7 @@ portfolioRoutes.post('/search', async (c) => {
         ...domain,
         findings: domainFindings,
         findingsEvaluated,
+        evaluationCoverage,
         latestSnapshot: {
           id: latestSnapshot.id,
           createdAt: latestSnapshot.createdAt,

--- a/apps/web/hono/routes/simulation.runtime.test.ts
+++ b/apps/web/hono/routes/simulation.runtime.test.ts
@@ -229,7 +229,7 @@ function baseState(): MockState {
 
 describe('Simulation routes', () => {
   describe('POST /api/simulate', () => {
-    it('simulates fixes for all actionable findings by snapshotId', async () => {
+    it('returns guidance without executable mutations for generic findings', async () => {
       const state = baseState();
       const app = createApp(state);
 
@@ -242,36 +242,43 @@ describe('Simulation routes', () => {
       expect(response.status).toBe(200);
       const json = (await response.json()) as {
         domain: string;
-        proposedChanges: Array<{
-          action: string;
-          name: string;
-          type: string;
-          findingType: string;
+        proposedChanges: unknown[];
+        guidanceOnlySuggestions: Array<{
+          kind: string;
+          playbookId: string;
+          executableMutation: null;
         }>;
+        mode: string;
         summary: {
           changesProposed: number;
-          findingsResolved: number;
+          guidanceProvided: number;
+          currentFindings: number;
         };
-        resolvedFindings: Array<{ type: string }>;
       };
 
+      expect(json.mode).toBe('GUIDANCE_ONLY');
       expect(json.domain).toBe('example.com');
-      expect(json.proposedChanges.length).toBeGreaterThan(0);
-
-      // Should propose SPF fix
-      const spfChange = json.proposedChanges.find((c) => c.findingType === 'mail.no-spf-record');
-      expect(spfChange).toBeDefined();
-      expect(spfChange?.action).toBe('add');
-      expect(spfChange?.type).toBe('TXT');
-
-      // Should propose DMARC fix
-      const dmarcChange = json.proposedChanges.find(
-        (c) => c.findingType === 'mail.no-dmarc-record'
+      expect(json.proposedChanges).toEqual([]);
+      expect(json.guidanceOnlySuggestions).toHaveLength(2);
+      expect(json.guidanceOnlySuggestions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'GUIDANCE_ONLY',
+            playbookId: 'mail.spf.provider-confirmation',
+            executableMutation: null,
+          }),
+          expect.objectContaining({
+            kind: 'GUIDANCE_ONLY',
+            playbookId: 'mail.dmarc.monitoring-readiness',
+            executableMutation: null,
+          }),
+        ])
       );
-      expect(dmarcChange).toBeDefined();
-
-      // Should resolve those findings
-      expect(json.summary.findingsResolved).toBeGreaterThan(0);
+      expect(json.summary).toMatchObject({
+        changesProposed: 0,
+        guidanceProvided: 2,
+        currentFindings: expect.any(Number),
+      });
     });
 
     it('simulates a single finding by findingId', async () => {
@@ -286,12 +293,14 @@ describe('Simulation routes', () => {
 
       expect(response.status).toBe(200);
       const json = (await response.json()) as {
-        proposedChanges: Array<{ findingType: string }>;
+        proposedChanges: unknown[];
+        guidanceOnlySuggestions: Array<{ playbookId: string }>;
       };
 
-      // Only SPF change should be proposed (single finding mode)
-      expect(json.proposedChanges.length).toBe(1);
-      expect(json.proposedChanges[0].findingType).toBe('mail.no-spf-record');
+      expect(json.proposedChanges).toEqual([]);
+      expect(json.guidanceOnlySuggestions).toEqual([
+        expect.objectContaining({ playbookId: 'mail.spf.provider-confirmation' }),
+      ]);
     });
 
     it('accepts specific findingTypes filter', async () => {
@@ -309,11 +318,14 @@ describe('Simulation routes', () => {
 
       expect(response.status).toBe(200);
       const json = (await response.json()) as {
-        proposedChanges: Array<{ findingType: string }>;
+        proposedChanges: unknown[];
+        guidanceOnlySuggestions: Array<{ playbookId: string }>;
       };
 
-      expect(json.proposedChanges.length).toBe(1);
-      expect(json.proposedChanges[0].findingType).toBe('mail.no-dmarc-record');
+      expect(json.proposedChanges).toEqual([]);
+      expect(json.guidanceOnlySuggestions).toEqual([
+        expect.objectContaining({ playbookId: 'mail.dmarc.monitoring-readiness' }),
+      ]);
     });
 
     it('returns 404 for missing finding', async () => {
@@ -358,7 +370,7 @@ describe('Simulation routes', () => {
       expect(response.status).toBe(400);
     });
 
-    it('includes provider detection in result', async () => {
+    it('does not present heuristic provider detection as confirmation', async () => {
       const state = baseState();
       const app = createApp(state);
 
@@ -372,10 +384,10 @@ describe('Simulation routes', () => {
       const json = (await response.json()) as {
         detectedProvider: string;
       };
-      expect(json.detectedProvider).toBeDefined();
+      expect(json.detectedProvider).toBe('unknown');
     });
 
-    it('returns diff between current and projected findings', async () => {
+    it('returns current findings without projected-resolution semantics', async () => {
       const state = baseState();
       const app = createApp(state);
 
@@ -386,24 +398,15 @@ describe('Simulation routes', () => {
       });
 
       expect(response.status).toBe(200);
-      const json = (await response.json()) as {
+      const json = (await response.json()) as Record<string, unknown> & {
         currentFindings: Array<{ type: string }>;
-        projectedFindings: Array<{ type: string }>;
-        resolvedFindings: Array<{ type: string }>;
-        remainingFindings: Array<{ type: string }>;
-        newFindings: Array<{ type: string }>;
-        summary: {
-          findingsBefore: number;
-          findingsAfter: number;
-        };
+        summary: { currentFindings: number };
       };
 
-      expect(json.currentFindings).toBeDefined();
-      expect(json.projectedFindings).toBeDefined();
-      expect(json.resolvedFindings).toBeDefined();
-      expect(json.remainingFindings).toBeDefined();
-      expect(json.newFindings).toBeDefined();
-      expect(json.summary.findingsBefore).toBeGreaterThan(0);
+      expect(json.currentFindings.length).toBeGreaterThan(0);
+      expect(json.summary.currentFindings).toBe(json.currentFindings.length);
+      expect(json.projectedFindings).toBeUndefined();
+      expect(json.resolvedFindings).toBeUndefined();
     });
   });
 
@@ -416,6 +419,12 @@ describe('Simulation routes', () => {
 
       expect(response.status).toBe(200);
       const json = (await response.json()) as {
+        mode: string;
+        guidanceSupportedTypes: Array<{
+          type: string;
+          description: string;
+          risk: string;
+        }>;
         actionableTypes: Array<{
           type: string;
           description: string;
@@ -423,6 +432,8 @@ describe('Simulation routes', () => {
         }>;
       };
 
+      expect(json.mode).toBe('GUIDANCE_ONLY');
+      expect(json.guidanceSupportedTypes).toEqual(json.actionableTypes);
       expect(json.actionableTypes.length).toBeGreaterThan(0);
       expect(json.actionableTypes.find((t) => t.type === 'mail.no-spf-record')).toBeDefined();
       expect(json.actionableTypes.find((t) => t.type === 'mail.no-dmarc-record')).toBeDefined();

--- a/apps/web/hono/routes/simulation.ts
+++ b/apps/web/hono/routes/simulation.ts
@@ -12,7 +12,11 @@ import {
   RecordSetRepository,
   SnapshotRepository,
 } from '@dns-ops/db';
-import { type RuleContext, SimulationEngine } from '@dns-ops/rules';
+import {
+  getGuidanceSupportedFindingTypes,
+  type RuleContext,
+  SimulationEngine,
+} from '@dns-ops/rules';
 import { Hono } from 'hono';
 import { requireAuth } from '../middleware/authorization.js';
 import { getWebLogger } from '../middleware/error-tracking.js';
@@ -136,51 +140,55 @@ simulationRoutes.post('/', requireAuth, async (c) => {
 /**
  * GET /api/simulate/actionable-types
  *
- * Returns the list of finding types that the simulation engine can generate fixes for.
+ * Legacy alias returning finding types with non-executable guidance playbooks.
  */
 simulationRoutes.get('/actionable-types', requireAuth, (c) => {
+  const guidanceSupportedTypes = [
+    {
+      type: 'mail.no-spf-record',
+      description: 'Missing SPF record',
+      risk: 'low',
+    },
+    {
+      type: 'mail.no-dmarc-record',
+      description: 'Missing DMARC record',
+      risk: 'low',
+    },
+    {
+      type: 'mail.no-mx-record',
+      description: 'Missing MX record',
+      risk: 'medium',
+    },
+    {
+      type: 'mail.no-mta-sts',
+      description: 'Missing MTA-STS record',
+      risk: 'low',
+    },
+    {
+      type: 'mail.no-tls-rpt',
+      description: 'Missing TLS-RPT record',
+      risk: 'low',
+    },
+    {
+      type: 'mail.no-dkim-queried',
+      description: 'No DKIM selectors discovered',
+      risk: 'low',
+    },
+    {
+      type: 'mail.spf-malformed',
+      description: 'Malformed SPF record',
+      risk: 'medium',
+    },
+    {
+      type: 'dns.cname-coexistence-conflict',
+      description: 'CNAME coexistence violation',
+      risk: 'high',
+    },
+  ];
   return c.json({
-    actionableTypes: [
-      {
-        type: 'mail.no-spf-record',
-        description: 'Missing SPF record',
-        risk: 'low',
-      },
-      {
-        type: 'mail.no-dmarc-record',
-        description: 'Missing DMARC record',
-        risk: 'low',
-      },
-      {
-        type: 'mail.no-mx-record',
-        description: 'Missing MX record',
-        risk: 'medium',
-      },
-      {
-        type: 'mail.no-mta-sts',
-        description: 'Missing MTA-STS record',
-        risk: 'low',
-      },
-      {
-        type: 'mail.no-tls-rpt',
-        description: 'Missing TLS-RPT record',
-        risk: 'low',
-      },
-      {
-        type: 'mail.no-dkim-queried',
-        description: 'No DKIM selectors discovered',
-        risk: 'low',
-      },
-      {
-        type: 'mail.spf-malformed',
-        description: 'Malformed SPF record',
-        risk: 'medium',
-      },
-      {
-        type: 'dns.cname-coexistence-conflict',
-        description: 'CNAME coexistence violation',
-        risk: 'high',
-      },
-    ],
+    mode: 'GUIDANCE_ONLY',
+    guidanceSupportedTypes,
+    actionableTypes: guidanceSupportedTypes,
+    supportedTypeIds: getGuidanceSupportedFindingTypes(),
   });
 });

--- a/apps/web/hono/routes/snapshot-history.integration.test.ts
+++ b/apps/web/hono/routes/snapshot-history.integration.test.ts
@@ -30,6 +30,7 @@ interface ClientSnapshotListItem {
   createdAt: string;
   rulesetVersionId: string | null;
   findingsEvaluated: boolean;
+  evaluationCoverage: { state: 'COMPLETE' | 'PARTIAL'; errors: unknown[] };
   queryScope: { names: string[]; types: string[]; vantages: string[] };
 }
 
@@ -199,22 +200,26 @@ const NOW = new Date();
 const YESTERDAY = new Date(NOW.getTime() - 86400000);
 
 function makeSnapshot(overrides: Record<string, unknown> = {}) {
-  return {
+  const snapshot = {
     id: 'snap-1',
     domainId: 'domain-1',
     domainName: 'example.com',
     resultState: 'complete',
-    rulesetVersionId: null,
+    rulesetVersionId: null as string | null,
     queriedNames: ['example.com'],
     queriedTypes: ['A', 'MX'],
     vantages: ['google-dns'],
-    metadata: {},
+    metadata: {} as Record<string, unknown>,
     createdAt: NOW,
     collectionDurationMs: 1200,
     triggeredBy: 'manual',
     zoneManagement: 'unmanaged',
     ...overrides,
   };
+  if (snapshot.rulesetVersionId && !('metadata' in overrides)) {
+    snapshot.metadata = { evaluation: { state: 'COMPLETE', errors: [] } };
+  }
+  return snapshot;
 }
 
 function makeRecordSet(overrides: Record<string, unknown> = {}) {
@@ -286,13 +291,14 @@ describe('Snapshot History — API ↔ Client Type Contract', () => {
       expect(snap.createdAt).toBeDefined();
       expect(snap).toHaveProperty('rulesetVersionId');
       expect(typeof snap.findingsEvaluated).toBe('boolean');
+      expect(['COMPLETE', 'PARTIAL']).toContain(snap.evaluationCoverage.state);
       expect(snap.queryScope).toBeDefined();
       expect(Array.isArray(snap.queryScope.names)).toBe(true);
       expect(Array.isArray(snap.queryScope.types)).toBe(true);
       expect(Array.isArray(snap.queryScope.vantages)).toBe(true);
     }
 
-    // Verify findingsEvaluated correctly derives from rulesetVersionId
+    // Verify findingsEvaluated derives from explicit coverage, not merely a ruleset ID.
     const withRuleset = json.snapshots.find((s) => s.id === 'snap-a');
     const withoutRuleset = json.snapshots.find((s) => s.id === 'snap-b');
     expect(withRuleset?.findingsEvaluated).toBe(true);

--- a/apps/web/hono/routes/snapshots.runtime.test.ts
+++ b/apps/web/hono/routes/snapshots.runtime.test.ts
@@ -110,19 +110,23 @@ const now = new Date();
 const yesterday = new Date(now.getTime() - 86400000);
 
 function makeSnapshot(overrides: Record<string, unknown> = {}) {
-  return {
+  const snapshot = {
     id: 'snap-1',
     domainId: 'domain-1',
     domainName: 'example.com',
     resultState: 'complete',
-    rulesetVersionId: null,
+    rulesetVersionId: null as string | null,
     queriedNames: ['example.com'],
     queriedTypes: ['A', 'MX'],
     vantages: ['google-dns'],
-    metadata: {},
+    metadata: {} as Record<string, unknown>,
     createdAt: now,
     ...overrides,
   };
+  if (snapshot.rulesetVersionId && !('metadata' in overrides)) {
+    snapshot.metadata = { evaluation: { state: 'COMPLETE', errors: [] } };
+  }
+  return snapshot;
 }
 
 describe('snapshotRoutes runtime', () => {
@@ -207,6 +211,40 @@ describe('snapshotRoutes runtime', () => {
       expect(json.id).toBe('snap-new');
       expect(json.domain).toBe('example.com');
       expect(json.findingsEvaluated).toBe(true);
+    });
+
+    it('treats a legacy ruleset ID without coverage evidence as UNKNOWN', async () => {
+      const state: MockState = {
+        domains: [
+          {
+            id: 'domain-1',
+            name: 'example.com',
+            normalizedName: 'example.com',
+            tenantId: 'tenant-1',
+          },
+        ],
+        snapshots: [
+          makeSnapshot({
+            id: 'legacy-snapshot',
+            rulesetVersionId: 'rv-legacy',
+            metadata: {},
+          }),
+        ],
+        recordSets: [],
+        findings: [],
+      };
+      const app = createApp(state);
+
+      const response = await app.request('/api/snapshots/example.com/latest');
+      const json = (await response.json()) as {
+        findingsEvaluated: boolean;
+        evaluationCoverage: { state: string; errors: Array<{ status: string }> };
+      };
+
+      expect(response.status).toBe(200);
+      expect(json.findingsEvaluated).toBe(false);
+      expect(json.evaluationCoverage.state).toBe('PARTIAL');
+      expect(json.evaluationCoverage.errors[0]?.status).toBe('UNKNOWN');
     });
 
     it('returns 404 when domain has no snapshots', async () => {

--- a/apps/web/hono/routes/snapshots.ts
+++ b/apps/web/hono/routes/snapshots.ts
@@ -7,6 +7,7 @@
  * - Diff highlighting for records, TTLs, findings, scope
  */
 
+import { evaluationCoverageOrUnknown, isEvaluationComplete } from '@dns-ops/contracts';
 import { DomainRepository, SnapshotRepository } from '@dns-ops/db';
 import { findings, recordSets } from '@dns-ops/db/schema';
 import { compareSnapshots } from '@dns-ops/parsing';
@@ -67,7 +68,8 @@ snapshotRoutes.get('/:domain', async (c) => {
         id: s.id,
         createdAt: s.createdAt,
         rulesetVersionId: s.rulesetVersionId,
-        findingsEvaluated: s.rulesetVersionId !== null,
+        findingsEvaluated: isEvaluationComplete(s.metadata?.evaluation),
+        evaluationCoverage: evaluationCoverageOrUnknown(s.metadata?.evaluation),
         queryScope: {
           names: s.queriedNames,
           types: s.queriedTypes,
@@ -131,7 +133,8 @@ snapshotRoutes.get('/:domain/latest', async (c) => {
       domain: domainName,
       createdAt: snapshot.createdAt,
       rulesetVersionId: snapshot.rulesetVersionId,
-      findingsEvaluated: snapshot.rulesetVersionId !== null,
+      findingsEvaluated: isEvaluationComplete(snapshot.metadata?.evaluation),
+      evaluationCoverage: evaluationCoverageOrUnknown(snapshot.metadata?.evaluation),
       queryScope: {
         names: snapshot.queriedNames,
         types: snapshot.queriedTypes,
@@ -198,7 +201,8 @@ snapshotRoutes.get('/:domain/:id', async (c) => {
       domainId: snapshot.domainId,
       createdAt: snapshot.createdAt,
       rulesetVersionId: snapshot.rulesetVersionId,
-      findingsEvaluated: snapshot.rulesetVersionId !== null,
+      findingsEvaluated: isEvaluationComplete(snapshot.metadata?.evaluation),
+      evaluationCoverage: evaluationCoverageOrUnknown(snapshot.metadata?.evaluation),
       queryScope: {
         names: snapshot.queriedNames,
         types: snapshot.queriedTypes,
@@ -288,9 +292,9 @@ snapshotRoutes.post('/:domain/diff', async (c) => {
       db.selectWhere(findings, eq(findings.snapshotId, snapshotB)),
     ]);
 
-    // Check if findings were evaluated for each snapshot
-    const findingsEvaluatedA = snapA.rulesetVersionId !== null;
-    const findingsEvaluatedB = snapB.rulesetVersionId !== null;
+    // Only explicit complete coverage can participate in a findings diff.
+    const findingsEvaluatedA = isEvaluationComplete(snapA.metadata?.evaluation);
+    const findingsEvaluatedB = isEvaluationComplete(snapB.metadata?.evaluation);
 
     // Generate diff
     const diff = compareSnapshots(
@@ -425,9 +429,9 @@ snapshotRoutes.post('/:domain/compare-latest', async (c) => {
       db.selectWhere(findings, eq(findings.snapshotId, snapB.id)),
     ]);
 
-    // Check if findings were evaluated for each snapshot
-    const findingsEvaluatedA = snapA.rulesetVersionId !== null;
-    const findingsEvaluatedB = snapB.rulesetVersionId !== null;
+    // Only explicit complete coverage can participate in a findings diff.
+    const findingsEvaluatedA = isEvaluationComplete(snapA.metadata?.evaluation);
+    const findingsEvaluatedB = isEvaluationComplete(snapB.metadata?.evaluation);
 
     const diff = compareSnapshots(
       {

--- a/apps/web/hono/routes/suggestions.test.ts
+++ b/apps/web/hono/routes/suggestions.test.ts
@@ -37,11 +37,22 @@ interface MockSuggestion {
 
 interface MockData {
   suggestions: MockSuggestion[];
+  findings: Array<Record<string, unknown>>;
+  snapshots: Array<Record<string, unknown>>;
+  domains: Array<Record<string, unknown>>;
 }
 
 function createMockData(): MockData {
   const now = new Date();
   return {
+    findings: [
+      { id: 'finding-1', snapshotId: 'snapshot-1', type: 'mail.no-spf-record' },
+      { id: 'finding-2', snapshotId: 'snapshot-1', type: 'mail.no-mx-record' },
+      { id: 'finding-3', snapshotId: 'snapshot-1', type: 'mail.no-dmarc-record' },
+      { id: 'finding-4', snapshotId: 'snapshot-1', type: 'mail.no-dkim-queried' },
+    ],
+    snapshots: [{ id: 'snapshot-1', domainId: 'domain-1' }],
+    domains: [{ id: 'domain-1', tenantId: 'test-tenant' }],
     suggestions: [
       {
         id: 'suggestion-regular',
@@ -111,6 +122,13 @@ function createMockData(): MockData {
   };
 }
 
+function getTableName(table: unknown): string {
+  if (!table || typeof table !== 'object') return '';
+  const record = table as Record<symbol | string, unknown>;
+  const name = record[Symbol.for('drizzle:Name')];
+  return typeof name === 'string' ? name : '';
+}
+
 // Helper to extract ID from drizzle-orm eq() condition
 function getConditionParam(condition: unknown): string | undefined {
   const sql = condition as {
@@ -123,12 +141,21 @@ function getConditionParam(condition: unknown): string | undefined {
 
 function createMockDb(data: MockData) {
   return {
-    selectOne: vi.fn(async (_table: unknown, condition: unknown) => {
+    selectOne: vi.fn(async (table: unknown, condition: unknown) => {
       const id = getConditionParam(condition);
-      if (id) {
-        return data.suggestions.find((s: MockSuggestion) => s.id === id);
+      if (!id) return undefined;
+      switch (getTableName(table)) {
+        case 'suggestions':
+          return data.suggestions.find((suggestion) => suggestion.id === id);
+        case 'findings':
+          return data.findings.find((finding) => finding.id === id);
+        case 'snapshots':
+          return data.snapshots.find((snapshot) => snapshot.id === id);
+        case 'domains':
+          return data.domains.find((domain) => domain.id === id);
+        default:
+          return undefined;
       }
-      return undefined;
     }),
     update: vi.fn(async (_table: unknown, updates: Partial<MockSuggestion>, condition: unknown) => {
       const id = getConditionParam(condition);
@@ -181,54 +208,26 @@ describe('Suggestions Routes', () => {
   // ===========================================================================
 
   describe('PATCH /suggestions/:suggestionId/apply', () => {
-    it('should apply a regular (non-review-only) suggestion', async () => {
-      const res = await app.request('/suggestions/suggestion-regular/apply', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { success: boolean; suggestion: { id: string } };
-      expect(body.success).toBe(true);
-      expect(body.suggestion.id).toBe('suggestion-regular');
-    });
-
-    it('should reject review-only suggestion without confirmApply', async () => {
-      const res = await app.request('/suggestions/suggestion-review-only/apply', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-
-      expect(res.status).toBe(403);
-      const body = (await res.json()) as {
-        error: string;
-        code: string;
-        reviewOnly: boolean;
-        hint: string;
-      };
-      expect(body.code).toBe('REQUIRES_CONFIRMATION');
-      expect(body.reviewOnly).toBe(true);
-      expect(body.hint).toContain('confirmApply');
-    });
-
-    it('should apply review-only suggestion with confirmApply: true', async () => {
-      const res = await app.request('/suggestions/suggestion-review-only/apply', {
+    it.each([
+      'suggestion-regular',
+      'suggestion-review-only',
+    ])('refuses to apply guidance-only suggestion %s', async (suggestionId) => {
+      const res = await app.request(`/suggestions/${suggestionId}/apply`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ confirmApply: true }),
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(409);
       const body = (await res.json()) as {
-        success: boolean;
-        suggestion: { id: string };
-        confirmed: boolean;
+        code: string;
+        guidance: { kind: string; executableMutation: null };
       };
-      expect(body.success).toBe(true);
-      expect(body.suggestion.id).toBe('suggestion-review-only');
-      expect(body.confirmed).toBe(true);
+      expect(body.code).toBe('GUIDANCE_ONLY');
+      expect(body.guidance).toMatchObject({
+        kind: 'GUIDANCE_ONLY',
+        executableMutation: null,
+      });
     });
 
     it('should return 404 for non-existent suggestion', async () => {
@@ -252,7 +251,8 @@ describe('Suggestions Routes', () => {
 
       expect(res.status).toBe(409);
       const body = (await res.json()) as { error: string; code: string };
-      expect(body.code).toBe('ALREADY_APPLIED');
+      expect(body.code).toBe('GUIDANCE_ONLY');
+      expect(body.error).toContain('historically acknowledged');
     });
 
     it('should return 409 for dismissed suggestion', async () => {
@@ -283,6 +283,26 @@ describe('Suggestions Routes', () => {
       });
 
       expect(res.status).toBe(401);
+    });
+  });
+
+  describe('tenant isolation', () => {
+    it.each([
+      'GET',
+      'PATCH',
+      'DELETE',
+    ] as const)('hides cross-tenant suggestions for %s-style access', async (method) => {
+      mockData.domains[0].tenantId = 'other-tenant';
+      const before = structuredClone(mockData.suggestions[0]);
+      const suffix = method === 'GET' ? '' : method === 'PATCH' ? '/apply' : '/dismiss';
+      const response = await app.request(`/suggestions/suggestion-regular${suffix}`, {
+        method: method === 'GET' ? 'GET' : 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: method === 'GET' ? undefined : JSON.stringify({ reason: 'cross-tenant' }),
+      });
+
+      expect(response.status).toBe(404);
+      expect(mockData.suggestions[0]).toEqual(before);
     });
   });
 
@@ -327,7 +347,7 @@ describe('Suggestions Routes', () => {
       expect(body.code).toBe('ALREADY_DISMISSED');
     });
 
-    it('should return 409 for already applied suggestion on dismiss', async () => {
+    it('describes historical applied state as acknowledgement on dismiss', async () => {
       const res = await app.request('/suggestions/suggestion-already-applied/dismiss', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -336,7 +356,8 @@ describe('Suggestions Routes', () => {
 
       expect(res.status).toBe(409);
       const body = (await res.json()) as { error: string; code: string };
-      expect(body.code).toBe('ALREADY_APPLIED');
+      expect(body.code).toBe('GUIDANCE_ONLY');
+      expect(body.error).toContain('historically acknowledged');
     });
   });
 
@@ -349,9 +370,15 @@ describe('Suggestions Routes', () => {
       const res = await app.request('/suggestions/suggestion-regular');
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { suggestion: { id: string; title: string } };
-      expect(body.suggestion.id).toBe('suggestion-regular');
-      expect(body.suggestion.title).toBe('Add SPF record');
+      const body = (await res.json()) as {
+        suggestion: { id: string; title: string; description: string; action: string };
+      };
+      expect(body.suggestion).toMatchObject({
+        id: 'suggestion-regular',
+        title: 'Confirm authorized senders with the mail provider',
+        action: 'Playbook: mail.spf.provider-confirmation',
+      });
+      expect(body.suggestion.description).not.toContain('Add SPF record');
     });
 
     it('should return 404 for non-existent suggestion', async () => {
@@ -360,59 +387,6 @@ describe('Suggestions Routes', () => {
       expect(res.status).toBe(404);
       const body = (await res.json()) as { error: string; code: string };
       expect(body.code).toBe('NOT_FOUND');
-    });
-  });
-
-  // ===========================================================================
-  // REVIEW-ONLY SAFEGUARD TESTS (PR-02.6.1)
-  // ===========================================================================
-
-  describe('PR-02.6.1: Review-Only Safeguard', () => {
-    it('should return REQUIRES_CONFIRMATION code for review-only without confirmApply', async () => {
-      const res = await app.request('/suggestions/suggestion-review-only/apply', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ confirmApply: false }),
-      });
-
-      expect(res.status).toBe(403);
-      const body = (await res.json()) as { code: string };
-      expect(body.code).toBe('REQUIRES_CONFIRMATION');
-    });
-
-    it('should include helpful hint in REQUIRES_CONFIRMATION response', async () => {
-      const res = await app.request('/suggestions/suggestion-review-only/apply', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-
-      const body = (await res.json()) as { hint: string };
-      expect(body.hint).toContain('confirmApply');
-      expect(body.hint).toContain('true');
-    });
-
-    it('should include reviewOnly flag in response for clarity', async () => {
-      const res = await app.request('/suggestions/suggestion-review-only/apply', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-
-      const body = (await res.json()) as { reviewOnly: boolean };
-      expect(body.reviewOnly).toBe(true);
-    });
-
-    it('should proceed with confirmApply: true for review-only', async () => {
-      const res = await app.request('/suggestions/suggestion-review-only/apply', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ confirmApply: true }),
-      });
-
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { confirmed: boolean };
-      expect(body.confirmed).toBe(true);
     });
   });
 });

--- a/apps/web/hono/routes/suggestions.ts
+++ b/apps/web/hono/routes/suggestions.ts
@@ -1,94 +1,69 @@
 /**
- * Suggestions Routes
+ * Guidance-only suggestion routes.
  *
- * API endpoints for managing remediation suggestions.
- * Includes safeguard for review-only suggestions (PR-02.6.1).
+ * Persisted rows may predate the guidance-only contract, so every response is
+ * normalized from the finding type and never returns legacy executable text.
  */
 
-import { SuggestionRepository } from '@dns-ops/db';
+import type { IDatabaseAdapter, Suggestion } from '@dns-ops/db';
+import {
+  DomainRepository,
+  FindingRepository,
+  SnapshotRepository,
+  SuggestionRepository,
+} from '@dns-ops/db';
 import { Hono } from 'hono';
+import { guidanceForPersistedFinding, sanitizePersistedSuggestion } from '../lib/guidance.js';
 import { requireAuth, requireWritePermission } from '../middleware/authorization.js';
-import { boolean, validateBody } from '../middleware/validation.js';
 import type { Env } from '../types.js';
 
 export const suggestionsRoutes = new Hono<Env>();
-
-// Apply auth middleware to all routes
 suggestionsRoutes.use('*', requireAuth);
 
-// =============================================================================
-// SCHEMAS
-// =============================================================================
-
-interface ApplySuggestionBody {
-  confirmApply?: boolean;
-  [key: string]: unknown;
+async function findTenantSuggestion(
+  db: IDatabaseAdapter,
+  tenantId: string,
+  suggestionId: string
+): Promise<{ suggestion: Suggestion; findingType: string } | null> {
+  const suggestion = await new SuggestionRepository(db).findById(suggestionId);
+  if (!suggestion) return null;
+  const finding = await new FindingRepository(db).findById(suggestion.findingId);
+  if (!finding) return null;
+  const snapshot = await new SnapshotRepository(db).findById(finding.snapshotId);
+  if (!snapshot) return null;
+  const domain = await new DomainRepository(db).findById(snapshot.domainId);
+  if (!domain || domain.tenantId !== tenantId) return null;
+  return { suggestion, findingType: finding.type };
 }
 
-const ApplySuggestionSchema = {
-  confirmApply: boolean('confirmApply', false),
-};
-
-// =============================================================================
-// PATCH /api/suggestions/:suggestionId/apply
-// =============================================================================
-
-/**
- * Apply a suggestion
- *
- * For review-only suggestions, requires confirmApply: true in request body.
- * This safeguard prevents accidental application of risky changes.
- *
- * Request: { confirmApply?: boolean }
- * Response: { success: true, suggestion: Suggestion }
- * Error: { error: string, code: 'REQUIRES_CONFIRMATION' | 'NOT_FOUND' | 'ALREADY_APPLIED' }
- */
 suggestionsRoutes.patch('/:suggestionId/apply', requireWritePermission, async (c) => {
   const db = c.get('db');
-  if (!db) {
-    return c.json({ error: 'Database not available' }, 503);
-  }
+  const tenantId = c.get('tenantId');
+  if (!db) return c.json({ error: 'Database not available' }, 503);
+  if (!tenantId) return c.json({ error: 'Unauthorized' }, 401);
 
   const suggestionId = c.req.param('suggestionId');
-  const actorId = c.get('actorId');
-  if (!actorId) {
-    return c.json({ error: 'Unauthorized' }, 401);
+  const loaded = await findTenantSuggestion(db, tenantId, suggestionId);
+  if (!loaded) {
+    return c.json({ error: 'Suggestion not found', code: 'NOT_FOUND', suggestionId }, 404);
   }
 
-  // Parse request body with optional confirmApply
-  const bodyResult = await validateBody<ApplySuggestionBody>(c, ApplySuggestionSchema);
-  const confirmApply = bodyResult.success ? bodyResult.data.confirmApply : undefined;
-
-  const suggestionRepo = new SuggestionRepository(db);
-
-  // Find the suggestion
-  const suggestion = await suggestionRepo.findById(suggestionId);
-  if (!suggestion) {
-    return c.json(
-      {
-        error: 'Suggestion not found',
-        code: 'NOT_FOUND',
-        suggestionId,
-      },
-      404
-    );
-  }
-
-  // Check if already applied
+  const { findingType, suggestion } = loaded;
   if (suggestion.appliedAt) {
     return c.json(
       {
-        error: 'Suggestion already applied',
-        code: 'ALREADY_APPLIED',
+        error: 'This guidance was historically acknowledged; no provider mutation was executed',
+        code: 'GUIDANCE_ONLY',
         suggestionId,
-        appliedAt: suggestion.appliedAt,
-        appliedBy: suggestion.appliedBy,
+        historicalAcknowledgement: {
+          acknowledgedAt: suggestion.appliedAt,
+          acknowledgedBy: suggestion.appliedBy,
+        },
+        guidance: guidanceForPersistedFinding(findingType),
       },
       409
     );
   }
-
-  // Check if dismissed
   if (suggestion.dismissedAt) {
     return c.json(
       {
@@ -101,155 +76,83 @@ suggestionsRoutes.patch('/:suggestionId/apply', requireWritePermission, async (c
     );
   }
 
-  // PR-02.6.1: Safeguard for review-only suggestions
-  if (suggestion.reviewOnly && !confirmApply) {
-    return c.json(
-      {
-        error: 'This suggestion is marked as review-only and requires explicit confirmation',
-        code: 'REQUIRES_CONFIRMATION',
-        suggestionId,
-        reviewOnly: true,
-        hint: 'Include { "confirmApply": true } in the request body to apply this suggestion',
-      },
-      403
-    );
-  }
-
-  // Apply the suggestion
-  const applied = await suggestionRepo.markApplied(suggestionId, actorId);
-
-  if (!applied) {
-    return c.json(
-      {
-        error: 'Failed to apply suggestion',
-        suggestionId,
-      },
-      500
-    );
-  }
-
-  return c.json({
-    success: true,
-    suggestion: applied,
-    confirmed: suggestion.reviewOnly && confirmApply,
-  });
+  return c.json(
+    {
+      error: 'Generic suggestions are guidance-only and cannot be applied by DNS Ops',
+      code: 'GUIDANCE_ONLY',
+      suggestionId,
+      guidance: guidanceForPersistedFinding(findingType),
+    },
+    409
+  );
 });
 
-// =============================================================================
-// PATCH /api/suggestions/:suggestionId/dismiss
-// =============================================================================
-
-/**
- * Dismiss a suggestion
- *
- * Request: { reason?: string }
- * Response: { success: true, suggestion: Suggestion }
- */
 suggestionsRoutes.patch('/:suggestionId/dismiss', requireWritePermission, async (c) => {
   const db = c.get('db');
-  if (!db) {
-    return c.json({ error: 'Database not available' }, 503);
-  }
+  const tenantId = c.get('tenantId');
+  const actorId = c.get('actorId');
+  if (!db) return c.json({ error: 'Database not available' }, 503);
+  if (!tenantId || !actorId) return c.json({ error: 'Unauthorized' }, 401);
 
   const suggestionId = c.req.param('suggestionId');
-  const actorId = c.get('actorId');
-  if (!actorId) {
-    return c.json({ error: 'Unauthorized' }, 401);
+  const loaded = await findTenantSuggestion(db, tenantId, suggestionId);
+  if (!loaded) {
+    return c.json({ error: 'Suggestion not found', code: 'NOT_FOUND', suggestionId }, 404);
+  }
+
+  const { findingType, suggestion } = loaded;
+  if (suggestion.dismissedAt) {
+    return c.json(
+      { error: 'Suggestion already dismissed', code: 'ALREADY_DISMISSED', suggestionId },
+      409
+    );
+  }
+  if (suggestion.appliedAt) {
+    return c.json(
+      {
+        error: 'This guidance was historically acknowledged; no provider mutation was executed',
+        code: 'GUIDANCE_ONLY',
+        suggestionId,
+        historicalAcknowledgement: {
+          acknowledgedAt: suggestion.appliedAt,
+          acknowledgedBy: suggestion.appliedBy,
+        },
+        guidance: guidanceForPersistedFinding(findingType),
+      },
+      409
+    );
   }
 
   let reason: string | undefined;
   try {
-    const body = await c.req.json();
+    const body = await c.req.json<{ reason?: string }>();
     reason = body.reason;
   } catch {
-    // No body is fine
+    // An omitted body is valid for dismissal.
   }
 
-  const suggestionRepo = new SuggestionRepository(db);
-
-  // Find the suggestion
-  const suggestion = await suggestionRepo.findById(suggestionId);
-  if (!suggestion) {
-    return c.json(
-      {
-        error: 'Suggestion not found',
-        code: 'NOT_FOUND',
-        suggestionId,
-      },
-      404
-    );
-  }
-
-  // Check if already dismissed
-  if (suggestion.dismissedAt) {
-    return c.json(
-      {
-        error: 'Suggestion already dismissed',
-        code: 'ALREADY_DISMISSED',
-        suggestionId,
-      },
-      409
-    );
-  }
-
-  // Check if already applied
-  if (suggestion.appliedAt) {
-    return c.json(
-      {
-        error: 'Suggestion was already applied',
-        code: 'ALREADY_APPLIED',
-        suggestionId,
-      },
-      409
-    );
-  }
-
-  // Dismiss the suggestion
-  const dismissed = await suggestionRepo.markDismissed(suggestionId, actorId, reason);
-
-  if (!dismissed) {
-    return c.json(
-      {
-        error: 'Failed to dismiss suggestion',
-        suggestionId,
-      },
-      500
-    );
-  }
+  const dismissed = await new SuggestionRepository(db).markDismissed(suggestionId, actorId, reason);
+  if (!dismissed) return c.json({ error: 'Failed to dismiss suggestion', suggestionId }, 500);
 
   return c.json({
     success: true,
-    suggestion: dismissed,
+    suggestion: sanitizePersistedSuggestion(dismissed, findingType),
   });
 });
 
-// =============================================================================
-// GET /api/suggestions/:suggestionId
-// =============================================================================
-
-/**
- * Get a single suggestion by ID
- */
 suggestionsRoutes.get('/:suggestionId', async (c) => {
   const db = c.get('db');
-  if (!db) {
-    return c.json({ error: 'Database not available' }, 503);
-  }
+  const tenantId = c.get('tenantId');
+  if (!db) return c.json({ error: 'Database not available' }, 503);
+  if (!tenantId) return c.json({ error: 'Unauthorized' }, 401);
 
   const suggestionId = c.req.param('suggestionId');
-  const suggestionRepo = new SuggestionRepository(db);
-
-  const suggestion = await suggestionRepo.findById(suggestionId);
-  if (!suggestion) {
-    return c.json(
-      {
-        error: 'Suggestion not found',
-        code: 'NOT_FOUND',
-        suggestionId,
-      },
-      404
-    );
+  const loaded = await findTenantSuggestion(db, tenantId, suggestionId);
+  if (!loaded) {
+    return c.json({ error: 'Suggestion not found', code: 'NOT_FOUND', suggestionId }, 404);
   }
 
-  return c.json({ suggestion });
+  return c.json({
+    suggestion: sanitizePersistedSuggestion(loaded.suggestion, loaded.findingType),
+  });
 });

--- a/apps/web/hono/types.ts
+++ b/apps/web/hono/types.ts
@@ -8,6 +8,8 @@ export type Env = {
     INTERNAL_SECRET?: string;
     API_KEY_SECRET?: string;
     ADMIN_EMAILS?: string;
+    /** JSON array of static MCP principals containing only SHA-256 token hashes. */
+    MCP_PRINCIPALS_JSON?: string;
     /** Cloudflare Workers environment */
     NODE_ENV?: string;
     /** Cloudflare Workers ASSETS binding */

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
     timeout: 120 * 1000, // 2 minutes to start
     env: {
       NODE_ENV: 'development',
+      PORT: process.env.PORT || new URL(BASE_URL).port || '3000',
       DATABASE_URL:
         process.env.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/dns_ops',
       COLLECTOR_URL: process.env.COLLECTOR_URL || 'http://localhost:3001',

--- a/docs/domain-operations/amendments/2026-07-28-autonomous-completion-override.md
+++ b/docs/domain-operations/amendments/2026-07-28-autonomous-completion-override.md
@@ -1,0 +1,64 @@
+# DNS Ops Phase 0–1 — Autonomous Completion Override
+
+**Date:** 2026-07-28  
+**Authority:** Antonio  
+**Applies to:** DNS Ops Phase 0–1 V4.1  
+**Repository:** `computindev/dns-ops`  
+**Implementation PR:** #3
+
+## Override
+
+- Token count, context-window size, session duration, fifteen engineering days, three calendar weeks, and twenty-four founder hours are not automatic stop conditions.
+- Continue until the approved outcome is genuinely complete or a real external approval, credential, asset, or authority boundary prevents progress.
+- Original time and attention budgets remain tracking metrics and escalation thresholds.
+- Report overruns, but do not stop solely because a budget threshold was crossed.
+- Durable checkpoints, repository state, tests, and exact SHAs—not chat memory—must make the work restartable.
+
+## Not overridden
+
+- Product scope.
+- Explicit exclusions.
+- Tenant isolation.
+- Security boundaries.
+- No production or client mutation.
+- No merge or deployment.
+- No external provider write from DNS Ops or MCP.
+- No RUA ingestion.
+- No recursive SPF evaluator.
+- No formal hypothesis graph.
+- No built-in reasoning agent.
+- No Buzz integration.
+- No OAuth product.
+- No commercial features.
+- No weakening evaluators.
+- No fabrication of founder declarations, credentials, evidence, or test results.
+
+## Revised sequencing authority
+
+Incomplete founder worksheet fields do not block work that is independent of external assets or founder declarations. The implementation owner is authorized to continue with:
+
+- Gate 2 deterministic correctness work;
+- local, non-destructive migrations;
+- deterministic fixtures and the stubbed RFC 9989 resolver;
+- rule-failure handling and actionable UNKNOWN propagation;
+- first-level SPF scope corrections;
+- generic-remediation downgrade;
+- application-service contracts and local MCP schemas/tests;
+- local signal and case lifecycle tests;
+- non-live portions of Gate 3;
+- a provider harness that contains no secret and cannot operate outside an explicit allowlist.
+
+The incomplete worksheet continues to block:
+
+- mutation of a real DNS provider;
+- use of any provider credential;
+- LIVE-01, LIVE-02, and LIVE-03;
+- claims about measured manual-time savings;
+- final Gate 3 PASS;
+- final Gate 4 PASS.
+
+Machine-inferred worksheet values must remain labeled `PROPOSED_NOT_FOUNDER_VERIFIED`. They are not founder declarations.
+
+## Authority boundary
+
+This amendment supersedes only token-, session-, and time-based stopping behavior and the sequencing effect of incomplete Day 0 inputs. It does not expand Phase 0–1 product scope or authorize unsafe actions, production/client mutation, provider writes outside the future isolated allowlisted test harness, merge, or deployment.

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "a26e542228ffaa266f0bf532533da0709dbc8aca",
+  "currentSha": "8800a40bdbf8f89d725bc3366c49b83daab4c1d0",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -37,6 +37,7 @@
     "Synchronous and queued collection now run the canonical finalizer after persistence; accepted SPF regression baselines use only the canonical signal alert path",
     "TLS baseline freshness and missing-baseline state are exposed as setup/evidence in Domain 360",
     "MCP has a tested static tokenSha256 principal map with enabled principals, UUID tenant binding, least-privilege scopes, durable idempotency, and dispatch for all ten approved tools through shared services",
+    "The only external MCP transport is POST /mcp, mounted in TanStack's server-only SSR entrypoint; it was smoke-tested from the built Node server with a static hashed principal",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
   ],
   "passingChecks": [
@@ -108,10 +109,9 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Provide the required external /mcp deployment path without putting server-only dependencies in the client bundle",
     "Build the deterministic MCP harness for all ten tool outcomes, scope/tenant negatives, parity, idempotency, and rate-limit evidence",
     "Add the remaining case UI and deterministic FIX-06 end-to-end lifecycle fixture",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T17:50:00Z"
+  "updatedAt": "2026-07-29T18:02:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "61f2c85fcff2b44e0dc57b7a0ce0f85e395d2b75",
+  "currentSha": "c0f4a6e6ed0a993db6f41d5dd7a2b5b6b0332f68",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -52,7 +52,7 @@
     "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
     "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability",
     "A tested fault-run artifact contract validates the runbook evidence shape and rejects malformed/redaction-unsafe artifacts without a provider client, secret, or network operation",
-    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, safe non-executable provider-operation references, and chronological restoration evidence with an application timestamp rather than unstructured recovery prose",
+    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, safe non-executable provider-operation references, and chronological restoration evidence with an application timestamp; completed PASS artifacts require both application and restoration timestamps",
     "The contract-to-evidence audit is reconciled with the completed fail-closed policy and latest exact-SHA independent review; only founder-controlled live/manual inputs remain blocked"
   ],
   "passingChecks": [
@@ -137,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-30T01:35:00Z"
+  "updatedAt": "2026-07-30T01:40:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "7772962224eb15d471205889a9fdc8159465d819",
+  "currentSha": "f207428a19eb364a9a281b0e080c4cc57a5017ba",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -87,6 +87,7 @@
       "blocking": false
     }
   ],
+  "trackingIssue": "https://github.com/computindev/dns-ops/issues/4",
   "pendingExternalInputs": [
     "Measured manual-check baseline",
     "Founder-verified portfolio selection, purpose, criticality, and observation-only classifications",

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -43,7 +43,7 @@
     "Stale MCP case disposition commands return and durably persist only CASE_VERSION_STALE, with no database conflict detail in the command result",
     "The deterministic scan-command harness proves cross-tenant domain denial occurs before claim/proxy, completed scan requests replay without a second collector call, and rate-limited commands persist a failed result without proxying",
     "Independent MCP review identified and the implementation corrected a scan-quota mismatch: MCP now uses the collector's ten-token incremental-refill algorithm",
-    "A fresh independent Gate 4 review at 603a7ff is BLOCKED only on documented external live/manual-baseline prerequisites; a separate detached clean checkout was attested at 47e6c4a with no code-level blocker",
+    "A fresh independent Gate 4 review at 06ecb55 is BLOCKED only on documented external live/manual-baseline prerequisites; it found no code-level blocker for the fail-closed policy and ran from a clean detached checkout",
     "The deterministic MCP harness matrix consolidates ten-tool typed transport, invalid input/ID, disabled/scope, tenant, stale evidence, duplicate/stale command, scan idempotency/rate, audit, parity, and exception-leakage evidence",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records",
@@ -134,5 +134,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T19:30:00Z"
+  "updatedAt": "2026-07-29T19:33:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "11f8083ea5fae5c7d047e4c70340f35e35d657d4",
+  "currentSha": "1e9de63dc5c7accbae928a3af57b0a907bd14011",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -51,6 +51,7 @@
     "A provider-harness readiness audit confirms no provider mutation harness can be truthfully implemented before the provider and test-host mutation manifest are authorized; no stub or provider-write capability was added",
     "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
     "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability",
+    "A tested fault-run artifact contract validates the runbook evidence shape and rejects malformed/redaction-unsafe artifacts without a provider client, secret, or network operation",
     "The contract-to-evidence audit is reconciled with the completed fail-closed policy and latest exact-SHA independent review; only founder-controlled live/manual inputs remain blocked"
   ],
   "passingChecks": [
@@ -64,7 +65,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2728 tests passed and 41 skipped after fail-closed controlled-live policy coverage"
+      "result": "2730 tests passed and 41 skipped after controlled-live policy and fault-run artifact coverage"
     },
     {
       "command": "bun run build",
@@ -135,5 +136,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T19:35:00Z"
+  "updatedAt": "2026-07-29T19:52:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "dd3edc14d70a864de5e3df3ee879de77f265e389",
+  "currentSha": "dc9eae4cc72764f9a8c1b73262b3631a2bc20b15",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2",
   "whatIsTrue": [
@@ -16,6 +16,7 @@
     "FIX-02 preserves wire DNS flags, disables recursion for authoritative targets, and requires AA proof for managed completeness",
     "Unavailable authoritative evidence is actionable UNKNOWN rather than authoritative absence",
     "FIX-03 exposes SPF as FIRST_LEVEL_ONLY with unresolved dependencies and no recursive budget claim",
+    "FIX-04 performs RFC 9989 DMARC policy discovery with an eight-query maximum and effective p/sp/np/t policy evidence",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
@@ -29,7 +30,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2546 tests passed and 41 skipped after FIX-03; evidence: docs/domain-operations/evidence/gate-2/fix-03-spf-first-level.json"
+      "result": "2566 tests passed and 41 skipped after FIX-04; evidence: docs/domain-operations/evidence/gate-2/fix-04-rfc9989-dmarc-discovery.json"
     },
     {
       "command": "bun run build",
@@ -87,8 +88,7 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Implement RFC 9989 DMARC discovery with stubbed fixtures",
     "Downgrade generic remediation to guidance-only"
   ],
-  "updatedAt": "2026-07-28T23:08:38Z"
+  "updatedAt": "2026-07-28T23:42:19Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "7334505ffa453341d8aeae5b87c00add2b5c4757",
+  "currentSha": "9ff7388c5e85fe5cb1704d2dcf4c43b27dac7d6f",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -42,6 +42,7 @@
     "A claimed case-open command that encounters an operational-service failure is completed as a durable generic COMMAND_FAILED response rather than being stranded PENDING",
     "Stale MCP case disposition commands return and durably persist only CASE_VERSION_STALE, with no database conflict detail in the command result",
     "The deterministic scan-command harness proves cross-tenant domain denial occurs before claim/proxy, completed scan requests replay without a second collector call, and rate-limited commands persist a failed result without proxying",
+    "Independent MCP review identified and the implementation corrected a scan-quota mismatch: MCP now uses the collector's ten-token incremental-refill algorithm",
     "A deterministic MCP transport harness calls all ten tools with schema-valid arguments and asserts typed JSON-RPC results plus malformed-schema rejection; service-level tenant, idempotency, audit, and stale-version proofs remain to be consolidated",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
@@ -57,7 +58,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2718 tests passed and 41 skipped after expanded MCP scan and stale-disposition command harness work"
+      "result": "2719 tests passed and 41 skipped after collector-aligned MCP quota remediation"
     },
     {
       "command": "bun run build",
@@ -119,5 +120,5 @@
     "Add the remaining case UI and consolidate service-level MCP tenant, idempotency, audit, stale-version, and rate-limit proofs into its deterministic harness",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:19:00Z"
+  "updatedAt": "2026-07-29T18:22:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -47,7 +47,8 @@
     "The deterministic MCP harness matrix consolidates ten-tool typed transport, invalid input/ID, disabled/scope, tenant, stale evidence, duplicate/stale command, scan idempotency/rate, audit, parity, and exception-leakage evidence",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records",
-    "Isolated browser smoke now passes nine Playwright checks against a migrated disposable PostgreSQL database; development migration discovery works when the app cwd is apps/web"
+    "Isolated browser smoke now passes nine Playwright checks against a migrated disposable PostgreSQL database; development migration discovery works when the app cwd is apps/web",
+    "A provider-harness readiness audit confirms no provider mutation harness can be truthfully implemented before the provider and test-host mutation manifest are authorized; no stub or provider-write capability was added"
   ],
   "passingChecks": [
     {
@@ -88,6 +89,11 @@
       "command": "bun run --filter @dns-ops/db build in clean standalone order",
       "failure": "Contracts declarations were not built first",
       "blocking": false
+    },
+    {
+      "command": "controlled provider fault-injection harness",
+      "failure": "No authorized provider kind, test-zone/test-host mutation manifest, scoped-secret fingerprint, allowlist, TTL history, or rollback owner has been supplied; a generic adapter would be a prohibited stub",
+      "blocking": true
     }
   ],
   "trackingIssue": "https://github.com/computindev/dns-ops/issues/4",
@@ -98,7 +104,8 @@
     "Scoped provider-token secret name and fingerprint confirmation",
     "Mutable-record allowlist",
     "Previous TTL values",
-    "Baseline, rollback, and token revocation owner"
+    "Baseline, rollback, and token revocation owner",
+    "Test-host deployment mutation mechanism for LIVE-01 and LIVE-02 where provider DNS changes are insufficient"
   ],
   "materialDecisions": [
     "SPF remains first-level only",
@@ -121,8 +128,8 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Obtain issue #4 external prerequisites for live Gate 3 fixtures and manual baseline, then repeat Gate 4 review after controlled-live evidence is recorded",
+    "Obtain issue #4 provider/test-host manifest, live-fixture authority, and manual baseline; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T18:55:00Z"
+  "updatedAt": "2026-07-29T19:02:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "f1edcdf34b559358f5b3a132f771caa10c2d61d6",
+  "currentSha": "14299a7be02f949c6978180e4209c5efba4c5794",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2",
   "whatIsTrue": [
@@ -10,7 +10,9 @@
     "Day 0 founder declarations and controlled test assets remain incomplete",
     "The autonomous completion amendment authorizes deterministic Gate 2 and non-live Gate 3 work",
     "PR #3 remains open and draft",
-    "No product behavior had changed at the recorded currentSha",
+    "FIX-01 proves a throwing rule becomes persisted partial UNKNOWN coverage rather than a clean result",
+    "Historical snapshots without coverage are actionable UNKNOWN",
+    "API and UI surfaces no longer treat zero findings as healthy unless coverage is explicitly complete",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
@@ -24,7 +26,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2539 tests passed and 41 skipped at the Gate 1 baseline"
+      "result": "2548 tests passed and 41 skipped after FIX-01; evidence: docs/domain-operations/evidence/gate-2/fix-01-rule-failure.json"
     },
     {
       "command": "bun run build",
@@ -82,13 +84,10 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Commit the founder override and checkpoint update",
-    "Add a deterministic throwing-rule false-green fixture",
-    "Implement typed rule-evaluation errors and actionable UNKNOWN propagation",
     "Correct authoritative DNS evidence handling",
     "Implement the explicit first-level SPF contract",
     "Implement RFC 9989 DMARC discovery with stubbed fixtures",
     "Downgrade generic remediation to guidance-only"
   ],
-  "updatedAt": "2026-07-28T22:39:44Z"
+  "updatedAt": "2026-07-28T22:53:59Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "29dee9b93f72f14989790c12ed9a0e36b33481d5",
+  "currentSha": "2a3b0b2d758e9b72148dbe85c9bbadc03fcaf2ad",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -44,7 +44,7 @@
     "The deterministic scan-command harness proves cross-tenant domain denial occurs before claim/proxy, completed scan requests replay without a second collector call, and rate-limited commands persist a failed result without proxying",
     "Independent MCP review identified and the implementation corrected a scan-quota mismatch: MCP now uses the collector's ten-token incremental-refill algorithm",
     "A fresh independent Gate 4 review at 29dee9b is BLOCKED only on documented external live, isolated-PostgreSQL, manual-baseline, and clean-checkout prerequisites; it found no remaining code-level blocker",
-    "A deterministic MCP transport harness calls all ten tools with schema-valid arguments and asserts typed JSON-RPC results plus malformed-schema rejection; service-level tenant, idempotency, audit, and stale-version proofs remain to be consolidated",
+    "The deterministic MCP harness matrix consolidates ten-tool typed transport, invalid input/ID, disabled/scope, tenant, stale evidence, duplicate/stale command, scan idempotency/rate, audit, parity, and exception-leakage evidence",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
   ],
@@ -59,7 +59,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2720 tests passed and 41 skipped after rejected-proxy command completion remediation"
+      "result": "2721 tests passed and 41 skipped after duplicate case-open replay coverage and MCP harness matrix consolidation"
     },
     {
       "command": "bun run build",
@@ -119,8 +119,8 @@
   ],
   "nextActions": [
     "Build the deterministic MCP harness for all ten tool outcomes, scope/tenant negatives, parity, idempotency, and rate-limit evidence",
-    "Add the remaining case UI and consolidate service-level MCP tenant, idempotency, audit, stale-version, and rate-limit proofs into its deterministic harness",
+    "Obtain issue #4 external prerequisites for live Gate 3 fixtures, manual baseline, and isolated PostgreSQL verification",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:29:00Z"
+  "updatedAt": "2026-07-29T18:33:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,13 +2,14 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "1a6509a6964246e5fc308b438fc303c31ed7604d",
+  "currentSha": "745f685fa8a714a14827d25b288596213885e82e",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
   "whatIsTrue": [
     "Gate 1 repository truth was accepted by Antonio",
-    "Day 0 founder declarations and controlled test assets remain incomplete",
+    "Day 0 manual baseline, portfolio classification, playbook approvals, and controlled test assets remain incomplete",
+    "Antonio authorized creation and delegation of dnsops-test.computin.dev as an isolated child zone; the computin.dev apex and existing MX, SPF, DKIM, and DMARC records remain excluded",
     "The autonomous completion amendment authorizes deterministic Gate 2 and non-live Gate 3 work",
     "PR #3 is open and ready for review; no merge or deployment is authorized",
     "FIX-01 proves a throwing rule becomes persisted partial UNKNOWN coverage rather than a clean result",
@@ -105,7 +106,7 @@
   "pendingExternalInputs": [
     "Measured manual-check baseline",
     "Founder-verified portfolio selection, purpose, criticality, and observation-only classifications",
-    "Authorized non-production test domain, web host, mail subdomain, zone, and provider",
+    "Provisioned dnsops-test.computin.dev child zone, test web host, test mail subdomain, and Cloudflare execution environment",
     "Scoped provider-token secret name and fingerprint confirmation",
     "Mutable-record allowlist",
     "Previous TTL values",
@@ -137,5 +138,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-08-04T15:47:43Z"
+  "updatedAt": "2026-08-04T15:52:46Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "ea43d32adbaeffa641ccffc32b85c08deeee748d",
+  "currentSha": "ef38151b670d64d97024dac618c6361c16a36da7",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -29,24 +29,25 @@
     "Bounded TLS evidence pins a validated public address while preserving SNI and independently records certificate chain and hostname authorization",
     "Bounded HTTP evidence covers the HTTP/HTTPS apex/www matrix, manual redirect topology, and HTML-only homepage indexability with safe-stop handling for unsafe redirects",
     "Tenant-scoped profile and latest external-evidence routes provide actionable setup state; profile mutation and audit history are atomic",
+    "Synchronous and scheduled collection paths now persist profile-gated RDAP/TLS/HTTP evidence with tenant, snapshot, hostname, feature-gate, timeout, and semaphore controls",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after tenant-scoped setup/evidence routes"
+      "result": "8 of 8 workspace tasks passed after profile-gated evidence collection"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after tenant-scoped setup/evidence routes"
+      "result": "14 of 14 workspace tasks passed after profile-gated evidence collection"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2646 tests passed and 41 skipped after tenant-scoped setup/evidence routes"
+      "result": "2651 tests passed and 41 skipped after profile-gated evidence collection"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after tenant-scoped setup/evidence routes"
+      "result": "8 of 8 workspace tasks passed after profile-gated evidence collection"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
@@ -100,11 +101,11 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Wire profile-gated RDAP/TLS/HTTP evidence collection and persistence into synchronous and scheduled snapshots",
     "Render setup/evidence and profile state in the Domain 360 UI without treating UNKNOWN as healthy",
+    "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Converge migrated alert creation on the canonical signal path and prove FIX-06",
     "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
   ],
-  "updatedAt": "2026-07-29T15:15:06Z"
+  "updatedAt": "2026-07-29T15:37:52Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "9ff7388c5e85fe5cb1704d2dcf4c43b27dac7d6f",
+  "currentSha": "29dee9b93f72f14989790c12ed9a0e36b33481d5",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -43,6 +43,7 @@
     "Stale MCP case disposition commands return and durably persist only CASE_VERSION_STALE, with no database conflict detail in the command result",
     "The deterministic scan-command harness proves cross-tenant domain denial occurs before claim/proxy, completed scan requests replay without a second collector call, and rate-limited commands persist a failed result without proxying",
     "Independent MCP review identified and the implementation corrected a scan-quota mismatch: MCP now uses the collector's ten-token incremental-refill algorithm",
+    "A fresh independent Gate 4 review at 29dee9b is BLOCKED only on documented external live, isolated-PostgreSQL, manual-baseline, and clean-checkout prerequisites; it found no remaining code-level blocker",
     "A deterministic MCP transport harness calls all ten tools with schema-valid arguments and asserts typed JSON-RPC results plus malformed-schema rejection; service-level tenant, idempotency, audit, and stale-version proofs remain to be consolidated",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
@@ -58,7 +59,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2719 tests passed and 41 skipped after collector-aligned MCP quota remediation"
+      "result": "2720 tests passed and 41 skipped after rejected-proxy command completion remediation"
     },
     {
       "command": "bun run build",
@@ -120,5 +121,5 @@
     "Add the remaining case UI and consolidate service-level MCP tenant, idempotency, audit, stale-version, and rate-limit proofs into its deterministic harness",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:22:00Z"
+  "updatedAt": "2026-07-29T18:29:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "eea9ca46f5cb713af18dcb03629d6ce002fff4a2",
+  "currentSha": "eea9ca4a00b6a1599cbfed35916920fd6bcaf206",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "5369aa4b8683e55b47016aa151f76b9e0f9db906",
+  "currentSha": "dd3edc14d70a864de5e3df3ee879de77f265e389",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2",
   "whatIsTrue": [
@@ -15,6 +15,7 @@
     "API and UI surfaces no longer treat zero findings as healthy unless coverage is explicitly complete",
     "FIX-02 preserves wire DNS flags, disables recursion for authoritative targets, and requires AA proof for managed completeness",
     "Unavailable authoritative evidence is actionable UNKNOWN rather than authoritative absence",
+    "FIX-03 exposes SPF as FIRST_LEVEL_ONLY with unresolved dependencies and no recursive budget claim",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
@@ -28,7 +29,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2543 tests passed and 41 skipped after FIX-02; evidence: docs/domain-operations/evidence/gate-2/fix-02-authoritative-evidence.json"
+      "result": "2546 tests passed and 41 skipped after FIX-03; evidence: docs/domain-operations/evidence/gate-2/fix-03-spf-first-level.json"
     },
     {
       "command": "bun run build",
@@ -86,9 +87,8 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Implement the explicit first-level SPF contract",
     "Implement RFC 9989 DMARC discovery with stubbed fixtures",
     "Downgrade generic remediation to guidance-only"
   ],
-  "updatedAt": "2026-07-28T23:01:23Z"
+  "updatedAt": "2026-07-28T23:08:38Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "cdd29aca7c98e139e88a45e98ad0b8a85304a1be",
+  "currentSha": "1a6509a6964246e5fc308b438fc303c31ed7604d",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -10,7 +10,7 @@
     "Gate 1 repository truth was accepted by Antonio",
     "Day 0 founder declarations and controlled test assets remain incomplete",
     "The autonomous completion amendment authorizes deterministic Gate 2 and non-live Gate 3 work",
-    "PR #3 remains open and draft",
+    "PR #3 is open and ready for review; no merge or deployment is authorized",
     "FIX-01 proves a throwing rule becomes persisted partial UNKNOWN coverage rather than a clean result",
     "Historical snapshots without coverage are actionable UNKNOWN",
     "API and UI surfaces no longer treat zero findings as healthy unless coverage is explicitly complete",
@@ -137,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-30T01:41:00Z"
+  "updatedAt": "2026-08-04T15:47:43Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "eea9ca4a00b6a1599cbfed35916920fd6bcaf206",
+  "currentSha": "4b611bc1296c186a3c6a452c21d331a71a941acd",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -33,24 +33,27 @@
     "Domain 360 exposes a tenant-safe Needs setup/evidence lane; UNKNOWN cannot render as healthy and authentication cache transitions clear active observers",
     "Production and client mutation remain prohibited",
     "Accepted TLS and SPF operational baselines are append-only, tenant/domain/snapshot scoped, audited, and cannot be inferred from scans",
-    "A pure evaluator classifies stale, failed, UNKNOWN, missing, or incomplete TLS evidence as setup/evidence and emits canonical observations only for an accepted fresh TLS policy violation or accepted SPF baseline regression"
+    "A pure evaluator classifies stale, failed, UNKNOWN, missing, or incomplete TLS evidence as setup/evidence and emits canonical observations only for an accepted fresh TLS policy violation or accepted SPF baseline regression",
+    "Synchronous and queued collection now run the canonical finalizer after persistence; accepted SPF regression baselines use only the canonical signal alert path",
+    "TLS baseline freshness and missing-baseline state are exposed as setup/evidence in Domain 360",
+    "MCP Phase 1 has a tested static token-hash principal parser and an exact closed ten-tool contract; endpoint dispatch and deterministic harness remain pending"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after actionable setup/evidence UI"
+      "result": "8 of 8 workspace tasks passed after baseline-aware canonical and MCP foundation work"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after actionable setup/evidence UI"
+      "result": "14 of 14 workspace tasks passed after baseline-aware canonical and MCP foundation work"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2659 tests passed and 41 skipped after actionable setup/evidence UI"
+      "result": "2679 tests passed and 41 skipped after baseline-aware canonical and MCP foundation work"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after actionable setup/evidence UI"
+      "result": "8 of 8 workspace tasks passed after baseline-aware canonical and MCP foundation work"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
@@ -104,10 +107,10 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Wire persisted baseline-aware evaluation to the canonical signal/case service",
-    "Expose tenant-scoped baseline acceptance and freshness in the profile/evidence API and Domain 360",
-    "Converge migrated SPF notifications on the canonical signal path and prove FIX-06",
-    "Add deterministic finalizer/deduplication fixtures and complete isolated migration verification"
+    "Add fully tenant-scoped canonical case operating API/UI and deterministic FIX-06 lifecycle fixture",
+    "Implement MCP endpoint dispatch for the exact ten-tool contract and its deterministic harness",
+    "Add non-live collector finalizer coverage for every collection entry point",
+    "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T16:27:00Z"
+  "updatedAt": "2026-07-29T16:41:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "14299a7be02f949c6978180e4209c5efba4c5794",
+  "currentSha": "5369aa4b8683e55b47016aa151f76b9e0f9db906",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2",
   "whatIsTrue": [
@@ -13,6 +13,8 @@
     "FIX-01 proves a throwing rule becomes persisted partial UNKNOWN coverage rather than a clean result",
     "Historical snapshots without coverage are actionable UNKNOWN",
     "API and UI surfaces no longer treat zero findings as healthy unless coverage is explicitly complete",
+    "FIX-02 preserves wire DNS flags, disables recursion for authoritative targets, and requires AA proof for managed completeness",
+    "Unavailable authoritative evidence is actionable UNKNOWN rather than authoritative absence",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
@@ -26,7 +28,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2548 tests passed and 41 skipped after FIX-01; evidence: docs/domain-operations/evidence/gate-2/fix-01-rule-failure.json"
+      "result": "2543 tests passed and 41 skipped after FIX-02; evidence: docs/domain-operations/evidence/gate-2/fix-02-authoritative-evidence.json"
     },
     {
       "command": "bun run build",
@@ -84,10 +86,9 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Correct authoritative DNS evidence handling",
     "Implement the explicit first-level SPF contract",
     "Implement RFC 9989 DMARC discovery with stubbed fixtures",
     "Downgrade generic remediation to guidance-only"
   ],
-  "updatedAt": "2026-07-28T22:53:59Z"
+  "updatedAt": "2026-07-28T23:01:23Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "46549363576da7b84fad86641d1aac19aa4842c6",
+  "currentSha": "cd7c2d62d4c03d660c472e87a29e24cc5c8870cf",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
   "whatIsTrue": [
@@ -21,6 +21,7 @@
     "Suggestion reads and writes are tenant-isolated through finding, snapshot, and domain ownership",
     "The six canonical signal kinds, deduplicated signal/case/alert persistence, lifecycle audit, fresh-evidence resolution, and reopen foundation are implemented",
     "Mail findings remain explicitly LEGACY_ONLY until production regression evaluation is wired; no silent notification cutover occurred",
+    "Six non-executable operating playbooks document evidence, applicability, verification, and escalation boundaries",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
@@ -96,7 +97,7 @@
     "Implement setup/evidence lane without automatic signal promotion",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Converge migrated alert creation on the canonical signal path and prove FIX-06",
-    "Add required operating playbooks and deterministic FIX-05/FIX-06 fixtures"
+    "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
   ],
-  "updatedAt": "2026-07-29T04:29:21Z"
+  "updatedAt": "2026-07-29T04:34:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "d268f18c6905a2f9f520fd844a0647d48990e292",
+  "currentSha": "ff5373eced4e96579f4d39747d2920c3a5e192f4",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -52,7 +52,7 @@
     "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
     "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability",
     "A tested fault-run artifact contract validates the runbook evidence shape and rejects malformed/redaction-unsafe artifacts without a provider client, secret, or network operation",
-    "RECOVERY_REQUIRED artifacts now require structured provider, zone, record/desired-value, and safe operator-command details rather than unstructured recovery prose",
+    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, and safe operator-command details rather than unstructured recovery prose",
     "The contract-to-evidence audit is reconciled with the completed fail-closed policy and latest exact-SHA independent review; only founder-controlled live/manual inputs remain blocked"
   ],
   "passingChecks": [
@@ -137,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-30T01:07:00Z"
+  "updatedAt": "2026-07-30T01:13:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -1,0 +1,94 @@
+{
+  "outcomeId": "dns-ops-phase-0-1",
+  "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
+  "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
+  "currentSha": "f1edcdf34b559358f5b3a132f771caa10c2d61d6",
+  "branch": "agent/domain-operations-phase-0-1-implementation",
+  "currentGate": "GATE_2",
+  "whatIsTrue": [
+    "Gate 1 repository truth was accepted by Antonio",
+    "Day 0 founder declarations and controlled test assets remain incomplete",
+    "The autonomous completion amendment authorizes deterministic Gate 2 and non-live Gate 3 work",
+    "PR #3 remains open and draft",
+    "No product behavior had changed at the recorded currentSha",
+    "Production and client mutation remain prohibited"
+  ],
+  "passingChecks": [
+    {
+      "command": "bun run lint",
+      "result": "8 of 8 workspace tasks passed at the Gate 1 baseline"
+    },
+    {
+      "command": "bun run typecheck",
+      "result": "14 of 14 workspace tasks passed at the Gate 1 baseline"
+    },
+    {
+      "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+      "result": "2539 tests passed and 41 skipped at the Gate 1 baseline"
+    },
+    {
+      "command": "bun run build",
+      "result": "8 of 8 workspace tasks passed at the Gate 1 baseline"
+    },
+    {
+      "command": "bun run --filter @dns-ops/db check-drift",
+      "result": "No schema drift at the Gate 1 baseline"
+    }
+  ],
+  "failingChecks": [
+    {
+      "command": "bun run --filter @dns-ops/db build in clean standalone order",
+      "failure": "Contracts declarations were not built first",
+      "blocking": false
+    },
+    {
+      "command": "bun run --filter @dns-ops/db verify-migrations",
+      "failure": "An isolated DATABASE_URL was unavailable",
+      "blocking": false
+    },
+    {
+      "command": "smoke and Playwright E2E",
+      "failure": "Required isolated database and running services were unavailable",
+      "blocking": false
+    }
+  ],
+  "pendingExternalInputs": [
+    "Measured manual-check baseline",
+    "Founder-verified portfolio selection, purpose, criticality, and observation-only classifications",
+    "Authorized non-production test domain, web host, mail subdomain, zone, and provider",
+    "Scoped provider-token secret name and fingerprint confirmation",
+    "Mutable-record allowlist",
+    "Previous TTL values",
+    "Baseline, rollback, and token revocation owner"
+  ],
+  "materialDecisions": [
+    "SPF remains first-level only",
+    "RFC 9989 DMARC discovery with an eight-query maximum is required",
+    "Coverage gaps never automatically create signals, alerts, or cases",
+    "Migrated conditions use one canonical signal path",
+    "Generic remediation is guidance-only without complete provider context",
+    "MCP uses a static token-hash principal map and exactly ten tools",
+    "The founder override removes time and context limits as automatic stop conditions",
+    "Incomplete Day 0 fields block live tests and final acceptance, not deterministic implementation"
+  ],
+  "deferredScope": [
+    "Recursive SPF evaluation",
+    "DMARC RUA and RUF ingestion",
+    "Formal hypothesis graph",
+    "Built-in reasoning agent",
+    "Buzz integration",
+    "OAuth and principal-management UI",
+    "Provider-write product capability",
+    "Client portal, billing, and commercial features"
+  ],
+  "nextActions": [
+    "Commit the founder override and checkpoint update",
+    "Add a deterministic throwing-rule false-green fixture",
+    "Implement typed rule-evaluation errors and actionable UNKNOWN propagation",
+    "Correct authoritative DNS evidence handling",
+    "Implement the explicit first-level SPF contract",
+    "Implement RFC 9989 DMARC discovery with stubbed fixtures",
+    "Downgrade generic remediation to guidance-only"
+  ],
+  "updatedAt": "2026-07-28T22:39:44Z"
+}

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "444b16054a4e1b3abeff250b463d9dd4d6691c01",
+  "currentSha": "6f17098984c279270567447ffa0abb8f272a1ea3",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -26,24 +26,25 @@
     "Minimal operator-declared domain profiles and typed RDAP/TLS/HTTP/redirect/indexability evidence contracts are implemented with database-enforced tenant ownership",
     "Coverage/setup evidence remains separate from signals, cases, findings, and alerts",
     "Bounded RDAP expiration collection uses IANA bootstrap, cumulative deadlines, streamed byte limits, exact-domain validation, strict event dates, and actionable UNKNOWN results",
+    "Bounded TLS evidence pins a validated public address while preserving SNI and independently records certificate chain and hostname authorization",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after bounded RDAP evidence"
+      "result": "8 of 8 workspace tasks passed after bounded TLS evidence"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after bounded RDAP evidence"
+      "result": "14 of 14 workspace tasks passed after bounded TLS evidence"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2618 tests passed and 41 skipped after bounded RDAP evidence"
+      "result": "2627 tests passed and 41 skipped after bounded TLS evidence"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after bounded RDAP evidence"
+      "result": "8 of 8 workspace tasks passed after bounded TLS evidence"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
@@ -97,11 +98,11 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Implement bounded TLS/HTTP/redirect/indexability collectors against registered tenant domain targets",
+    "Implement bounded HTTP/redirect/indexability collectors against registered tenant domain targets",
     "Persist probe failure and stale evidence as actionable setup/evidence without automatic signal promotion",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Converge migrated alert creation on the canonical signal path and prove FIX-06",
     "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
   ],
-  "updatedAt": "2026-07-29T12:38:18Z"
+  "updatedAt": "2026-07-29T13:03:26Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "2757583d8654a8e70a881c9ec615a2fb4f56de4b",
+  "currentSha": "7772962224eb15d471205889a9fdc8159465d819",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -11,7 +11,7 @@
     "Day 0 manual baseline, portfolio classification, playbook approvals, and controlled test assets remain incomplete",
     "The prior dnsops-test.computin.dev delegation proposal is superseded without provider mutation; Antonio authorized asorin.ai as the complete isolated controlled-test zone with no production, client, or real-mail dependency",
     "Cloudflare read-only preflight verified an active asorin.ai zone with zero DNS records observed and a protected local credential that can read that zone without recording its value",
-    "A dedicated Railway project dnsops-live-fixtures and controlled-live-web service were provisioned with no deployment, database, domain, or application secrets; deployment awaits a locally generated fixture-control secret",
+    "A dedicated Railway project dnsops-live-fixtures and controlled-live-web service are deployed with an isolated runtime control secret; Railway custom-domain setup has returned exact Cloudflare records but no Cloudflare DNS mutation has been made",
     "Wrangler OAuth was stopped before authentication because it requested broad unrelated write scopes; child-zone provisioning requires a human Cloudflare-dashboard action and a subsequently scoped child-zone token",
     "The autonomous completion amendment authorizes deterministic Gate 2 and non-live Gate 3 work",
     "PR #3 is open and ready for review; no merge or deployment is authorized",
@@ -141,5 +141,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-08-04T16:41:00Z"
+  "updatedAt": "2026-08-04T20:10:30Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,8 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "cd7c2d62d4c03d660c472e87a29e24cc5c8870cf",
+  "currentSha": "38e5442fa70faeb59a2def56a0f8caad68ce0d23",
+  "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
   "whatIsTrue": [
@@ -22,28 +23,30 @@
     "The six canonical signal kinds, deduplicated signal/case/alert persistence, lifecycle audit, fresh-evidence resolution, and reopen foundation are implemented",
     "Mail findings remain explicitly LEGACY_ONLY until production regression evaluation is wired; no silent notification cutover occurred",
     "Six non-executable operating playbooks document evidence, applicability, verification, and escalation boundaries",
+    "Minimal operator-declared domain profiles and typed RDAP/TLS/HTTP/redirect/indexability evidence contracts are implemented with database-enforced tenant ownership",
+    "Coverage/setup evidence remains separate from signals, cases, findings, and alerts",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after Gate 2 remediation completion"
+      "result": "8 of 8 workspace tasks passed after domain-profile and external-evidence contracts"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after Gate 2 remediation completion"
+      "result": "14 of 14 workspace tasks passed after domain-profile and external-evidence contracts"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2571 tests passed and 41 skipped after Gate 2 remediation completion; evidence: docs/domain-operations/evidence/gate-2/guidance-only-remediation.json"
+      "result": "2594 tests passed and 41 skipped after domain-profile and external-evidence contracts"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after Gate 2 remediation completion"
+      "result": "8 of 8 workspace tasks passed after domain-profile and external-evidence contracts"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
-      "result": "No schema drift after Gate 2 remediation completion"
+      "result": "No schema drift after migration 0013 domain profiles and external evidence"
     }
   ],
   "failingChecks": [
@@ -93,11 +96,11 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Implement minimal domain purpose/profile and bounded RDAP/TLS/HTTP evidence",
-    "Implement setup/evidence lane without automatic signal promotion",
+    "Implement bounded RDAP/TLS/HTTP/redirect/indexability collectors against registered tenant domain targets",
+    "Persist probe failure and stale evidence as actionable setup/evidence without automatic signal promotion",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Converge migrated alert creation on the canonical signal path and prove FIX-06",
     "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
   ],
-  "updatedAt": "2026-07-29T04:34:00Z"
+  "updatedAt": "2026-07-29T12:03:28Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "c0f4a6e6ed0a993db6f41d5dd7a2b5b6b0332f68",
+  "currentSha": "cdd29aca7c98e139e88a45e98ad0b8a85304a1be",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -137,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-30T01:40:00Z"
+  "updatedAt": "2026-07-30T01:41:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "4f1117f7f7a070390043cbba376bb3c31a7d2da5",
+  "currentSha": "61f2c85fcff2b44e0dc57b7a0ce0f85e395d2b75",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -52,7 +52,7 @@
     "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
     "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability",
     "A tested fault-run artifact contract validates the runbook evidence shape and rejects malformed/redaction-unsafe artifacts without a provider client, secret, or network operation",
-    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, safe non-executable provider-operation references, and chronological restoration evidence rather than unstructured recovery prose",
+    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, safe non-executable provider-operation references, and chronological restoration evidence with an application timestamp rather than unstructured recovery prose",
     "The contract-to-evidence audit is reconciled with the completed fail-closed policy and latest exact-SHA independent review; only founder-controlled live/manual inputs remain blocked"
   ],
   "passingChecks": [
@@ -137,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-30T01:30:00Z"
+  "updatedAt": "2026-07-30T01:35:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "1e9de63dc5c7accbae928a3af57b0a907bd14011",
+  "currentSha": "0d673b45b046b9f6d6e1b09601acf42a84b881ea",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -136,5 +136,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T19:52:00Z"
+  "updatedAt": "2026-07-29T20:00:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -40,6 +40,7 @@
     "The only external MCP transport is POST /mcp, mounted in TanStack's server-only SSR entrypoint; it was smoke-tested from the built Node server with a static hashed principal",
     "New MCP scan commands have a tenant-scoped 10-per-minute limiter before proxying; completed idempotent replays bypass the quota and the collector remains the downstream rate-limit boundary",
     "A deterministic MCP transport harness calls all ten tools with schema-valid arguments and asserts typed JSON-RPC results plus malformed-schema rejection; service-level tenant, idempotency, audit, and stale-version proofs remain to be consolidated",
+    "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
   ],
   "passingChecks": [
@@ -112,8 +113,8 @@
   ],
   "nextActions": [
     "Build the deterministic MCP harness for all ten tool outcomes, scope/tenant negatives, parity, idempotency, and rate-limit evidence",
-    "Add the remaining case UI and deterministic FIX-06 end-to-end lifecycle fixture",
+    "Add the remaining case UI and consolidate service-level MCP tenant, idempotency, audit, stale-version, and rate-limit proofs into its deterministic harness",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:08:00Z"
+  "updatedAt": "2026-07-29T18:10:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "708013e28290799d425937474fd130e15a0db9a6",
+  "currentSha": "90ae608ec71f7a0d6b506e4e38f7662a6ccaa5ba",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -39,6 +39,7 @@
     "MCP has a tested static tokenSha256 principal map with enabled principals, UUID tenant binding, least-privilege scopes, durable idempotency, and dispatch for all ten approved tools through shared services",
     "The only external MCP transport is POST /mcp, mounted in TanStack's server-only SSR entrypoint; it was smoke-tested from the built Node server with a static hashed principal",
     "New MCP scan commands have a tenant-scoped 10-per-minute limiter before proxying; completed idempotent replays bypass the quota and the collector remains the downstream rate-limit boundary",
+    "A deterministic MCP transport harness calls all ten tools with schema-valid arguments and asserts typed JSON-RPC results plus malformed-schema rejection; service-level tenant, idempotency, audit, and stale-version proofs remain to be consolidated",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
   ],
   "passingChecks": [
@@ -52,7 +53,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2702 tests passed and 41 skipped after direct MCP transport and scan quota enforcement"
+      "result": "2713 tests passed and 41 skipped after direct MCP transport, quota enforcement, and ten-tool schema harness work"
     },
     {
       "command": "bun run build",
@@ -114,5 +115,5 @@
     "Add the remaining case UI and deterministic FIX-06 end-to-end lifecycle fixture",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:05:00Z"
+  "updatedAt": "2026-07-29T18:08:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,14 +2,15 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "797d8a2d365d49fb61bd4c02b2dcb5a8b0a006f4",
+  "currentSha": "066db569b3e8a31004df33891556f86bb48cf8d2",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
   "whatIsTrue": [
     "Gate 1 repository truth was accepted by Antonio",
     "Day 0 manual baseline, portfolio classification, playbook approvals, and controlled test assets remain incomplete",
-    "Antonio authorized creation and delegation of dnsops-test.computin.dev as an isolated child zone; the computin.dev apex and existing MX, SPF, DKIM, and DMARC records remain excluded",
+    "The prior dnsops-test.computin.dev delegation proposal is superseded without provider mutation; Antonio authorized asorin.ai as the complete isolated controlled-test zone with no production, client, or real-mail dependency",
+    "Cloudflare read-only preflight verified an active asorin.ai zone with zero DNS records observed and a protected local credential that can read that zone without recording its value",
     "Wrangler OAuth was stopped before authentication because it requested broad unrelated write scopes; child-zone provisioning requires a human Cloudflare-dashboard action and a subsequently scoped child-zone token",
     "The autonomous completion amendment authorizes deterministic Gate 2 and non-live Gate 3 work",
     "PR #3 is open and ready for review; no merge or deployment is authorized",
@@ -107,7 +108,7 @@
   "pendingExternalInputs": [
     "Measured manual-check baseline",
     "Founder-verified portfolio selection, purpose, criticality, and observation-only classifications",
-    "Provisioned dnsops-test.computin.dev child zone, test web host, test mail subdomain, and Cloudflare execution environment",
+    "A non-production asorin.ai web-host deployment mechanism, test hostnames, exact DNS allowlist, initial values, and previous TTLs",
     "Scoped provider-token secret name and fingerprint confirmation",
     "Mutable-record allowlist",
     "Previous TTL values",
@@ -139,5 +140,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-08-04T15:55:00Z"
+  "updatedAt": "2026-08-04T16:36:46Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "093301ed9eedd4d369b41bb4ae75cf9379baae68",
+  "currentSha": "11f8083ea5fae5c7d047e4c70340f35e35d657d4",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -49,24 +49,25 @@
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records",
     "Isolated browser smoke now passes nine Playwright checks against a migrated disposable PostgreSQL database; development migration discovery works when the app cwd is apps/web",
     "A provider-harness readiness audit confirms no provider mutation harness can be truthfully implemented before the provider and test-host mutation manifest are authorized; no stub or provider-write capability was added",
-    "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval"
+    "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
+    "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after canonical operating-loop and MCP dispatch work"
+      "result": "8 of 8 workspace tasks passed after the fail-closed controlled-live policy addition"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after canonical operating-loop and MCP dispatch work"
+      "result": "14 of 14 workspace tasks passed after the fail-closed controlled-live policy addition"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2721 tests passed and 41 skipped after duplicate case-open replay coverage and MCP harness matrix consolidation"
+      "result": "2728 tests passed and 41 skipped after fail-closed controlled-live policy coverage"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after canonical operating-loop and MCP dispatch work"
+      "result": "8 of 8 workspace tasks passed after the fail-closed controlled-live policy addition"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
@@ -133,5 +134,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T19:05:00Z"
+  "updatedAt": "2026-07-29T19:30:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -50,7 +50,8 @@
     "Isolated browser smoke now passes nine Playwright checks against a migrated disposable PostgreSQL database; development migration discovery works when the app cwd is apps/web",
     "A provider-harness readiness audit confirms no provider mutation harness can be truthfully implemented before the provider and test-host mutation manifest are authorized; no stub or provider-write capability was added",
     "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
-    "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability"
+    "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability",
+    "The contract-to-evidence audit is reconciled with the completed fail-closed policy and latest exact-SHA independent review; only founder-controlled live/manual inputs remain blocked"
   ],
   "passingChecks": [
     {
@@ -134,5 +135,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T19:33:00Z"
+  "updatedAt": "2026-07-29T19:35:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "0d673b45b046b9f6d6e1b09601acf42a84b881ea",
+  "currentSha": "d268f18c6905a2f9f520fd844a0647d48990e292",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -52,6 +52,7 @@
     "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
     "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability",
     "A tested fault-run artifact contract validates the runbook evidence shape and rejects malformed/redaction-unsafe artifacts without a provider client, secret, or network operation",
+    "RECOVERY_REQUIRED artifacts now require structured provider, zone, record/desired-value, and safe operator-command details rather than unstructured recovery prose",
     "The contract-to-evidence audit is reconciled with the completed fail-closed policy and latest exact-SHA independent review; only founder-controlled live/manual inputs remain blocked"
   ],
   "passingChecks": [
@@ -136,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T20:00:00Z"
+  "updatedAt": "2026-07-30T01:07:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "d7c64ef1802387fff9ced79284006f19f814c362",
+  "currentSha": "ea43d32adbaeffa641ccffc32b85c08deeee748d",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -28,28 +28,29 @@
     "Bounded RDAP expiration collection uses IANA bootstrap, cumulative deadlines, streamed byte limits, exact-domain validation, strict event dates, and actionable UNKNOWN results",
     "Bounded TLS evidence pins a validated public address while preserving SNI and independently records certificate chain and hostname authorization",
     "Bounded HTTP evidence covers the HTTP/HTTPS apex/www matrix, manual redirect topology, and HTML-only homepage indexability with safe-stop handling for unsafe redirects",
+    "Tenant-scoped profile and latest external-evidence routes provide actionable setup state; profile mutation and audit history are atomic",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after bounded HTTP web evidence"
+      "result": "8 of 8 workspace tasks passed after tenant-scoped setup/evidence routes"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after bounded HTTP web evidence"
+      "result": "14 of 14 workspace tasks passed after tenant-scoped setup/evidence routes"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2636 tests passed and 41 skipped after bounded HTTP web evidence"
+      "result": "2646 tests passed and 41 skipped after tenant-scoped setup/evidence routes"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after bounded HTTP web evidence"
+      "result": "8 of 8 workspace tasks passed after tenant-scoped setup/evidence routes"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
-      "result": "No schema drift after migration 0013 domain profiles and external evidence"
+      "result": "No schema drift after migration 0014 domain profile audit"
     }
   ],
   "failingChecks": [
@@ -99,11 +100,11 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Persist RDAP/TLS/HTTP evidence and probe failure as actionable setup/evidence without automatic signal promotion",
-    "Expose tenant-scoped domain profile and evidence setup/read surfaces",
+    "Wire profile-gated RDAP/TLS/HTTP evidence collection and persistence into synchronous and scheduled snapshots",
+    "Render setup/evidence and profile state in the Domain 360 UI without treating UNKNOWN as healthy",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Converge migrated alert creation on the canonical signal path and prove FIX-06",
     "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
   ],
-  "updatedAt": "2026-07-29T14:42:36Z"
+  "updatedAt": "2026-07-29T15:15:06Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "fee9043aab457b9322801479e11af850dddd30c7",
+  "currentSha": "a23c627810fe033d8690cabb058031dda1738eb3",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -40,6 +40,7 @@
     "The only external MCP transport is POST /mcp, mounted in TanStack's server-only SSR entrypoint; it was smoke-tested from the built Node server with a static hashed principal",
     "New MCP scan commands have a tenant-scoped 10-per-minute limiter before proxying; completed idempotent replays bypass the quota and the collector remains the downstream rate-limit boundary",
     "A claimed case-open command that encounters an operational-service failure is completed as a durable generic COMMAND_FAILED response rather than being stranded PENDING",
+    "The deterministic scan-command harness proves cross-tenant domain denial occurs before claim/proxy, completed scan requests replay without a second collector call, and rate-limited commands persist a failed result without proxying",
     "A deterministic MCP transport harness calls all ten tools with schema-valid arguments and asserts typed JSON-RPC results plus malformed-schema rejection; service-level tenant, idempotency, audit, and stale-version proofs remain to be consolidated",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
@@ -55,7 +56,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2714 tests passed and 41 skipped after direct MCP transport, quota enforcement, ten-tool schema harness, and durable case-open failure work"
+      "result": "2717 tests passed and 41 skipped after expanded MCP scan ownership, replay, and rate-limit command harness work"
     },
     {
       "command": "bun run build",
@@ -117,5 +118,5 @@
     "Add the remaining case UI and consolidate service-level MCP tenant, idempotency, audit, stale-version, and rate-limit proofs into its deterministic harness",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:15:00Z"
+  "updatedAt": "2026-07-29T18:18:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,9 +2,9 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "dc9eae4cc72764f9a8c1b73262b3631a2bc20b15",
+  "currentSha": "021753fa35138bfc2ada3be99f435e17917ca40d",
   "branch": "agent/domain-operations-phase-0-1-implementation",
-  "currentGate": "GATE_2",
+  "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
   "whatIsTrue": [
     "Gate 1 repository truth was accepted by Antonio",
     "Day 0 founder declarations and controlled test assets remain incomplete",
@@ -17,28 +17,30 @@
     "Unavailable authoritative evidence is actionable UNKNOWN rather than authoritative absence",
     "FIX-03 exposes SPF as FIRST_LEVEL_ONLY with unresolved dependencies and no recursive budget claim",
     "FIX-04 performs RFC 9989 DMARC policy discovery with an eight-query maximum and effective p/sp/np/t policy evidence",
+    "Gate 2 passed: generic remediation is guidance-only, legacy executable text is sanitized, and closure requires lifecycle-fresh evidence",
+    "Suggestion reads and writes are tenant-isolated through finding, snapshot, and domain ownership",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed at the Gate 1 baseline"
+      "result": "8 of 8 workspace tasks passed after Gate 2 remediation completion"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed at the Gate 1 baseline"
+      "result": "14 of 14 workspace tasks passed after Gate 2 remediation completion"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2566 tests passed and 41 skipped after FIX-04; evidence: docs/domain-operations/evidence/gate-2/fix-04-rfc9989-dmarc-discovery.json"
+      "result": "2571 tests passed and 41 skipped after Gate 2 remediation completion; evidence: docs/domain-operations/evidence/gate-2/guidance-only-remediation.json"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed at the Gate 1 baseline"
+      "result": "8 of 8 workspace tasks passed after Gate 2 remediation completion"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
-      "result": "No schema drift at the Gate 1 baseline"
+      "result": "No schema drift after Gate 2 remediation completion"
     }
   ],
   "failingChecks": [
@@ -88,7 +90,11 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Downgrade generic remediation to guidance-only"
+    "Implement minimal domain purpose/profile and bounded RDAP/TLS/HTTP evidence",
+    "Implement setup/evidence lane without automatic signal promotion",
+    "Implement six canonical signal kinds and one deduplicated case lifecycle",
+    "Converge migrated alert creation on the canonical signal path",
+    "Add required operating playbooks and deterministic FIX-05/FIX-06 fixtures"
   ],
-  "updatedAt": "2026-07-28T23:42:19Z"
+  "updatedAt": "2026-07-29T03:56:46Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "af4d9f606221908a715ba054dede33ba764e6a5b",
+  "currentSha": "eea9ca46f5cb713af18dcb03629d6ce002fff4a2",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -31,7 +31,9 @@
     "Tenant-scoped profile and latest external-evidence routes provide actionable setup state; profile mutation and audit history are atomic",
     "Synchronous and scheduled collection paths now persist profile-gated RDAP/TLS/HTTP evidence with tenant, snapshot, hostname, feature-gate, timeout, and semaphore controls",
     "Domain 360 exposes a tenant-safe Needs setup/evidence lane; UNKNOWN cannot render as healthy and authentication cache transitions clear active observers",
-    "Production and client mutation remain prohibited"
+    "Production and client mutation remain prohibited",
+    "Accepted TLS and SPF operational baselines are append-only, tenant/domain/snapshot scoped, audited, and cannot be inferred from scans",
+    "A pure evaluator classifies stale, failed, UNKNOWN, missing, or incomplete TLS evidence as setup/evidence and emits canonical observations only for an accepted fresh TLS policy violation or accepted SPF baseline regression"
   ],
   "passingChecks": [
     {
@@ -52,7 +54,7 @@
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
-      "result": "No schema drift after migration 0014 domain profile audit"
+      "result": "No schema drift after migration 0015 operational condition baselines"
     }
   ],
   "failingChecks": [
@@ -102,11 +104,10 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Wire baseline-aware condition evaluation to the canonical signal/case service",
-    "Converge migrated notifications on the canonical signal path and prove FIX-06",
-    "Wire baseline-aware condition evaluation to the canonical signal/case service",
-    "Converge migrated alert creation on the canonical signal path and prove FIX-06",
-    "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
+    "Wire persisted baseline-aware evaluation to the canonical signal/case service",
+    "Expose tenant-scoped baseline acceptance and freshness in the profile/evidence API and Domain 360",
+    "Converge migrated SPF notifications on the canonical signal path and prove FIX-06",
+    "Add deterministic finalizer/deduplication fixtures and complete isolated migration verification"
   ],
-  "updatedAt": "2026-07-29T16:07:51Z"
+  "updatedAt": "2026-07-29T16:27:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "066db569b3e8a31004df33891556f86bb48cf8d2",
+  "currentSha": "2757583d8654a8e70a881c9ec615a2fb4f56de4b",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -11,6 +11,7 @@
     "Day 0 manual baseline, portfolio classification, playbook approvals, and controlled test assets remain incomplete",
     "The prior dnsops-test.computin.dev delegation proposal is superseded without provider mutation; Antonio authorized asorin.ai as the complete isolated controlled-test zone with no production, client, or real-mail dependency",
     "Cloudflare read-only preflight verified an active asorin.ai zone with zero DNS records observed and a protected local credential that can read that zone without recording its value",
+    "A dedicated Railway project dnsops-live-fixtures and controlled-live-web service were provisioned with no deployment, database, domain, or application secrets; deployment awaits a locally generated fixture-control secret",
     "Wrangler OAuth was stopped before authentication because it requested broad unrelated write scopes; child-zone provisioning requires a human Cloudflare-dashboard action and a subsequently scoped child-zone token",
     "The autonomous completion amendment authorizes deterministic Gate 2 and non-live Gate 3 work",
     "PR #3 is open and ready for review; no merge or deployment is authorized",
@@ -108,7 +109,7 @@
   "pendingExternalInputs": [
     "Measured manual-check baseline",
     "Founder-verified portfolio selection, purpose, criticality, and observation-only classifications",
-    "A non-production asorin.ai web-host deployment mechanism, test hostnames, exact DNS allowlist, initial values, and previous TTLs",
+    "A locally stored fixture-control secret, non-production asorin.ai deployment, exact DNS allowlist, initial values, and previous TTLs",
     "Scoped provider-token secret name and fingerprint confirmation",
     "Mutable-record allowlist",
     "Previous TTL values",
@@ -140,5 +141,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-08-04T16:36:46Z"
+  "updatedAt": "2026-08-04T16:41:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -48,7 +48,8 @@
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records",
     "Isolated browser smoke now passes nine Playwright checks against a migrated disposable PostgreSQL database; development migration discovery works when the app cwd is apps/web",
-    "A provider-harness readiness audit confirms no provider mutation harness can be truthfully implemented before the provider and test-host mutation manifest are authorized; no stub or provider-write capability was added"
+    "A provider-harness readiness audit confirms no provider mutation harness can be truthfully implemented before the provider and test-host mutation manifest are authorized; no stub or provider-write capability was added",
+    "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval"
   ],
   "passingChecks": [
     {
@@ -105,7 +106,8 @@
     "Mutable-record allowlist",
     "Previous TTL values",
     "Baseline, rollback, and token revocation owner",
-    "Test-host deployment mutation mechanism for LIVE-01 and LIVE-02 where provider DNS changes are insufficient"
+    "Test-host deployment mutation mechanism for LIVE-01 and LIVE-02 where provider DNS changes are insufficient",
+    "Founder calibration and approval of the six required operational playbooks"
   ],
   "materialDecisions": [
     "SPF remains first-level only",
@@ -128,8 +130,8 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Obtain issue #4 provider/test-host manifest, live-fixture authority, and manual baseline; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
+    "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T19:02:00Z"
+  "updatedAt": "2026-07-29T19:05:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "4b611bc1296c186a3c6a452c21d331a71a941acd",
+  "currentSha": "a26e542228ffaa266f0bf532533da0709dbc8aca",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -21,7 +21,7 @@
     "Gate 2 passed: generic remediation is guidance-only, legacy executable text is sanitized, and closure requires lifecycle-fresh evidence",
     "Suggestion reads and writes are tenant-isolated through finding, snapshot, and domain ownership",
     "The six canonical signal kinds, deduplicated signal/case/alert persistence, lifecycle audit, fresh-evidence resolution, and reopen foundation are implemented",
-    "Mail findings remain explicitly LEGACY_ONLY until production regression evaluation is wired; no silent notification cutover occurred",
+    "SPF absence is MIGRATED exclusively to the baseline-gated canonical signal path; all other mail findings remain explicitly LEGACY_ONLY",
     "Six non-executable operating playbooks document evidence, applicability, verification, and escalation boundaries",
     "Minimal operator-declared domain profiles and typed RDAP/TLS/HTTP/redirect/indexability evidence contracts are implemented with database-enforced tenant ownership",
     "Coverage/setup evidence remains separate from signals, cases, findings, and alerts",
@@ -36,28 +36,29 @@
     "A pure evaluator classifies stale, failed, UNKNOWN, missing, or incomplete TLS evidence as setup/evidence and emits canonical observations only for an accepted fresh TLS policy violation or accepted SPF baseline regression",
     "Synchronous and queued collection now run the canonical finalizer after persistence; accepted SPF regression baselines use only the canonical signal alert path",
     "TLS baseline freshness and missing-baseline state are exposed as setup/evidence in Domain 360",
-    "MCP Phase 1 has a tested static token-hash principal parser and an exact closed ten-tool contract; endpoint dispatch and deterministic harness remain pending"
+    "MCP has a tested static tokenSha256 principal map with enabled principals, UUID tenant binding, least-privilege scopes, durable idempotency, and dispatch for all ten approved tools through shared services",
+    "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after baseline-aware canonical and MCP foundation work"
+      "result": "8 of 8 workspace tasks passed after canonical operating-loop and MCP dispatch work"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after baseline-aware canonical and MCP foundation work"
+      "result": "14 of 14 workspace tasks passed after canonical operating-loop and MCP dispatch work"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2679 tests passed and 41 skipped after baseline-aware canonical and MCP foundation work"
+      "result": "2700 tests passed and 41 skipped after canonical operating-loop and MCP dispatch work"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after baseline-aware canonical and MCP foundation work"
+      "result": "8 of 8 workspace tasks passed after canonical operating-loop and MCP dispatch work"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
-      "result": "No schema drift after migration 0015 operational condition baselines"
+      "result": "No schema drift after migrations 0015–0019 operational baselines, case versioning, and MCP command idempotency"
     }
   ],
   "failingChecks": [
@@ -107,10 +108,10 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Add fully tenant-scoped canonical case operating API/UI and deterministic FIX-06 lifecycle fixture",
-    "Implement MCP endpoint dispatch for the exact ten-tool contract and its deterministic harness",
-    "Add non-live collector finalizer coverage for every collection entry point",
+    "Provide the required external /mcp deployment path without putting server-only dependencies in the client bundle",
+    "Build the deterministic MCP harness for all ten tool outcomes, scope/tenant negatives, parity, idempotency, and rate-limit evidence",
+    "Add the remaining case UI and deterministic FIX-06 end-to-end lifecycle fixture",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T16:41:00Z"
+  "updatedAt": "2026-07-29T17:50:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "745f685fa8a714a14827d25b288596213885e82e",
+  "currentSha": "797d8a2d365d49fb61bd4c02b2dcb5a8b0a006f4",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -10,6 +10,7 @@
     "Gate 1 repository truth was accepted by Antonio",
     "Day 0 manual baseline, portfolio classification, playbook approvals, and controlled test assets remain incomplete",
     "Antonio authorized creation and delegation of dnsops-test.computin.dev as an isolated child zone; the computin.dev apex and existing MX, SPF, DKIM, and DMARC records remain excluded",
+    "Wrangler OAuth was stopped before authentication because it requested broad unrelated write scopes; child-zone provisioning requires a human Cloudflare-dashboard action and a subsequently scoped child-zone token",
     "The autonomous completion amendment authorizes deterministic Gate 2 and non-live Gate 3 work",
     "PR #3 is open and ready for review; no merge or deployment is authorized",
     "FIX-01 proves a throwing rule becomes persisted partial UNKNOWN coverage rather than a clean result",
@@ -138,5 +139,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-08-04T15:52:46Z"
+  "updatedAt": "2026-08-04T15:55:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "69328b12e80f98b44baa0e28297127600c22e4ca",
+  "currentSha": "fc1d4cb6f6ec62131224d5a7b8d5fcc02b5f5401",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -52,7 +52,7 @@
     "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
     "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability",
     "A tested fault-run artifact contract validates the runbook evidence shape and rejects malformed/redaction-unsafe artifacts without a provider client, secret, or network operation",
-    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, and safe operator-command details rather than unstructured recovery prose",
+    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, and safe non-executable provider-operation references rather than unstructured recovery prose",
     "The contract-to-evidence audit is reconciled with the completed fail-closed policy and latest exact-SHA independent review; only founder-controlled live/manual inputs remain blocked"
   ],
   "passingChecks": [
@@ -137,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-30T01:17:00Z"
+  "updatedAt": "2026-07-30T01:25:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "021753fa35138bfc2ada3be99f435e17917ca40d",
+  "currentSha": "46549363576da7b84fad86641d1aac19aa4842c6",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
   "whatIsTrue": [
@@ -19,6 +19,8 @@
     "FIX-04 performs RFC 9989 DMARC policy discovery with an eight-query maximum and effective p/sp/np/t policy evidence",
     "Gate 2 passed: generic remediation is guidance-only, legacy executable text is sanitized, and closure requires lifecycle-fresh evidence",
     "Suggestion reads and writes are tenant-isolated through finding, snapshot, and domain ownership",
+    "The six canonical signal kinds, deduplicated signal/case/alert persistence, lifecycle audit, fresh-evidence resolution, and reopen foundation are implemented",
+    "Mail findings remain explicitly LEGACY_ONLY until production regression evaluation is wired; no silent notification cutover occurred",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
@@ -92,9 +94,9 @@
   "nextActions": [
     "Implement minimal domain purpose/profile and bounded RDAP/TLS/HTTP evidence",
     "Implement setup/evidence lane without automatic signal promotion",
-    "Implement six canonical signal kinds and one deduplicated case lifecycle",
-    "Converge migrated alert creation on the canonical signal path",
+    "Wire baseline-aware condition evaluation to the canonical signal/case service",
+    "Converge migrated alert creation on the canonical signal path and prove FIX-06",
     "Add required operating playbooks and deterministic FIX-05/FIX-06 fixtures"
   ],
-  "updatedAt": "2026-07-29T03:56:46Z"
+  "updatedAt": "2026-07-29T04:29:21Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "8800a40e0bcd4c83b35b91136d38f310c1e4f45f",
+  "currentSha": "708013e0f8b866ff99c5f534cf218af4e9a10773",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -38,6 +38,7 @@
     "TLS baseline freshness and missing-baseline state are exposed as setup/evidence in Domain 360",
     "MCP has a tested static tokenSha256 principal map with enabled principals, UUID tenant binding, least-privilege scopes, durable idempotency, and dispatch for all ten approved tools through shared services",
     "The only external MCP transport is POST /mcp, mounted in TanStack's server-only SSR entrypoint; it was smoke-tested from the built Node server with a static hashed principal",
+    "New MCP scan commands have a tenant-scoped 10-per-minute limiter before proxying; completed idempotent replays bypass the quota and the collector remains the downstream rate-limit boundary",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
   ],
   "passingChecks": [
@@ -51,7 +52,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2700 tests passed and 41 skipped after canonical operating-loop and MCP dispatch work"
+      "result": "2702 tests passed and 41 skipped after direct MCP transport and scan quota enforcement"
     },
     {
       "command": "bun run build",
@@ -113,5 +114,5 @@
     "Add the remaining case UI and deterministic FIX-06 end-to-end lifecycle fixture",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:02:00Z"
+  "updatedAt": "2026-07-29T18:05:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "a23c627810fe033d8690cabb058031dda1738eb3",
+  "currentSha": "7334505ffa453341d8aeae5b87c00add2b5c4757",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -40,6 +40,7 @@
     "The only external MCP transport is POST /mcp, mounted in TanStack's server-only SSR entrypoint; it was smoke-tested from the built Node server with a static hashed principal",
     "New MCP scan commands have a tenant-scoped 10-per-minute limiter before proxying; completed idempotent replays bypass the quota and the collector remains the downstream rate-limit boundary",
     "A claimed case-open command that encounters an operational-service failure is completed as a durable generic COMMAND_FAILED response rather than being stranded PENDING",
+    "Stale MCP case disposition commands return and durably persist only CASE_VERSION_STALE, with no database conflict detail in the command result",
     "The deterministic scan-command harness proves cross-tenant domain denial occurs before claim/proxy, completed scan requests replay without a second collector call, and rate-limited commands persist a failed result without proxying",
     "A deterministic MCP transport harness calls all ten tools with schema-valid arguments and asserts typed JSON-RPC results plus malformed-schema rejection; service-level tenant, idempotency, audit, and stale-version proofs remain to be consolidated",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
@@ -56,7 +57,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2717 tests passed and 41 skipped after expanded MCP scan ownership, replay, and rate-limit command harness work"
+      "result": "2718 tests passed and 41 skipped after expanded MCP scan and stale-disposition command harness work"
     },
     {
       "command": "bun run build",
@@ -118,5 +119,5 @@
     "Add the remaining case UI and consolidate service-level MCP tenant, idempotency, audit, stale-version, and rate-limit proofs into its deterministic harness",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:18:00Z"
+  "updatedAt": "2026-07-29T18:19:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "fc1d4cb6f6ec62131224d5a7b8d5fcc02b5f5401",
+  "currentSha": "4f1117f7f7a070390043cbba376bb3c31a7d2da5",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -52,7 +52,7 @@
     "A contract-to-evidence audit confirms all remaining requirements are founder-controlled: controlled live assets/authority, manual-work baseline, portfolio classification, and six-playbook calibration/approval",
     "A tested secret-free controlled-live policy validates the test-domain boundary, SHA-256 credential fingerprint, and exact allowlisted zone/name/type/LIVE tuples; it has no network or provider-write capability",
     "A tested fault-run artifact contract validates the runbook evidence shape and rejects malformed/redaction-unsafe artifacts without a provider client, secret, or network operation",
-    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, and safe non-executable provider-operation references rather than unstructured recovery prose",
+    "RECOVERY_REQUIRED artifacts now require structured provider, artifact-bound zone, artifact-target record/desired-value, safe non-executable provider-operation references, and chronological restoration evidence rather than unstructured recovery prose",
     "The contract-to-evidence audit is reconciled with the completed fail-closed policy and latest exact-SHA independent review; only founder-controlled live/manual inputs remain blocked"
   ],
   "passingChecks": [
@@ -137,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-30T01:25:00Z"
+  "updatedAt": "2026-07-30T01:30:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "0c8167fe162f96f3fca8b76ccb0314cc8b6ec323",
+  "currentSha": "093301ed9eedd4d369b41bb4ae75cf9379baae68",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -46,7 +46,8 @@
     "A fresh independent Gate 4 review at 29dee9b is BLOCKED only on documented external live, isolated-PostgreSQL, manual-baseline, and clean-checkout prerequisites; it found no remaining code-level blocker",
     "The deterministic MCP harness matrix consolidates ten-tool typed transport, invalid input/ID, disabled/scope, tenant, stale evidence, duplicate/stale command, scan idempotency/rate, audit, parity, and exception-leakage evidence",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
-    "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
+    "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records",
+    "Isolated browser smoke now passes nine Playwright checks against a migrated disposable PostgreSQL database; development migration discovery works when the app cwd is apps/web"
   ],
   "passingChecks": [
     {
@@ -76,17 +77,16 @@
     {
       "command": "DATABASE_URL=<isolated> bun run --filter @dns-ops/db verify-operations-concurrency",
       "result": "Fresh isolated PostgreSQL verification passed for canonical-signal unique insert and internal-case version CAS concurrency"
+    },
+    {
+      "command": "PORT=3100 BASE_URL=http://localhost:3100 DATABASE_URL=<isolated> bun run e2e -- e2e/smoke.spec.ts",
+      "result": "9 Playwright browser smoke tests passed against an isolated migrated database"
     }
   ],
   "failingChecks": [
     {
       "command": "bun run --filter @dns-ops/db build in clean standalone order",
       "failure": "Contracts declarations were not built first",
-      "blocking": false
-    },
-    {
-      "command": "smoke and Playwright E2E",
-      "failure": "Required isolated database and running services were unavailable",
       "blocking": false
     }
   ],
@@ -124,5 +124,5 @@
     "Obtain issue #4 external prerequisites for live Gate 3 fixtures, manual baseline, and final clean-checkout Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T18:41:00Z"
+  "updatedAt": "2026-07-29T18:51:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "2a3b0b2d758e9b72148dbe85c9bbadc03fcaf2ad",
+  "currentSha": "0c8167fe162f96f3fca8b76ccb0314cc8b6ec323",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -67,18 +67,21 @@
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
-      "result": "No schema drift after migrations 0015–0019 operational baselines, case versioning, and MCP command idempotency"
+      "result": "No schema drift after migrations 0015–0020 operational baselines, case versioning, MCP command idempotency, and schema-exported session tables"
+    },
+    {
+      "command": "DATABASE_URL=<isolated> bun run --filter @dns-ops/db verify-migrations",
+      "result": "Fresh isolated PostgreSQL migration verification passed: 32/32 tables and 32/32 enums"
+    },
+    {
+      "command": "DATABASE_URL=<isolated> bun run --filter @dns-ops/db verify-operations-concurrency",
+      "result": "Fresh isolated PostgreSQL verification passed for canonical-signal unique insert and internal-case version CAS concurrency"
     }
   ],
   "failingChecks": [
     {
       "command": "bun run --filter @dns-ops/db build in clean standalone order",
       "failure": "Contracts declarations were not built first",
-      "blocking": false
-    },
-    {
-      "command": "bun run --filter @dns-ops/db verify-migrations",
-      "failure": "An isolated DATABASE_URL was unavailable",
       "blocking": false
     },
     {
@@ -118,9 +121,8 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Build the deterministic MCP harness for all ten tool outcomes, scope/tenant negatives, parity, idempotency, and rate-limit evidence",
-    "Obtain issue #4 external prerequisites for live Gate 3 fixtures, manual baseline, and isolated PostgreSQL verification",
-    "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
+    "Obtain issue #4 external prerequisites for live Gate 3 fixtures, manual baseline, and final clean-checkout Gate 4 review",
+    "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T18:33:00Z"
+  "updatedAt": "2026-07-29T18:41:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "38e5442fa70faeb59a2def56a0f8caad68ce0d23",
+  "currentSha": "444b16054a4e1b3abeff250b463d9dd4d6691c01",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -25,24 +25,25 @@
     "Six non-executable operating playbooks document evidence, applicability, verification, and escalation boundaries",
     "Minimal operator-declared domain profiles and typed RDAP/TLS/HTTP/redirect/indexability evidence contracts are implemented with database-enforced tenant ownership",
     "Coverage/setup evidence remains separate from signals, cases, findings, and alerts",
+    "Bounded RDAP expiration collection uses IANA bootstrap, cumulative deadlines, streamed byte limits, exact-domain validation, strict event dates, and actionable UNKNOWN results",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after domain-profile and external-evidence contracts"
+      "result": "8 of 8 workspace tasks passed after bounded RDAP evidence"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after domain-profile and external-evidence contracts"
+      "result": "14 of 14 workspace tasks passed after bounded RDAP evidence"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2594 tests passed and 41 skipped after domain-profile and external-evidence contracts"
+      "result": "2618 tests passed and 41 skipped after bounded RDAP evidence"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after domain-profile and external-evidence contracts"
+      "result": "8 of 8 workspace tasks passed after bounded RDAP evidence"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
@@ -96,11 +97,11 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Implement bounded RDAP/TLS/HTTP/redirect/indexability collectors against registered tenant domain targets",
+    "Implement bounded TLS/HTTP/redirect/indexability collectors against registered tenant domain targets",
     "Persist probe failure and stale evidence as actionable setup/evidence without automatic signal promotion",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Converge migrated alert creation on the canonical signal path and prove FIX-06",
     "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
   ],
-  "updatedAt": "2026-07-29T12:03:28Z"
+  "updatedAt": "2026-07-29T12:38:18Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "8800a40bdbf8f89d725bc3366c49b83daab4c1d0",
+  "currentSha": "8800a40e0bcd4c83b35b91136d38f310c1e4f45f",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -43,7 +43,7 @@
     "Stale MCP case disposition commands return and durably persist only CASE_VERSION_STALE, with no database conflict detail in the command result",
     "The deterministic scan-command harness proves cross-tenant domain denial occurs before claim/proxy, completed scan requests replay without a second collector call, and rate-limited commands persist a failed result without proxying",
     "Independent MCP review identified and the implementation corrected a scan-quota mismatch: MCP now uses the collector's ten-token incremental-refill algorithm",
-    "A fresh independent Gate 4 review at 29dee9b is BLOCKED only on documented external live, isolated-PostgreSQL, manual-baseline, and clean-checkout prerequisites; it found no remaining code-level blocker",
+    "A fresh independent Gate 4 review at 603a7ff is BLOCKED only on documented external live/manual-baseline prerequisites and final clean-checkout review; it found no remaining code-level blocker",
     "The deterministic MCP harness matrix consolidates ten-tool typed transport, invalid input/ID, disabled/scope, tenant, stale evidence, duplicate/stale command, scan idempotency/rate, audit, parity, and exception-leakage evidence",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records",
@@ -124,5 +124,5 @@
     "Obtain issue #4 external prerequisites for live Gate 3 fixtures, manual baseline, and final clean-checkout Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T18:51:00Z"
+  "updatedAt": "2026-07-29T18:53:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "708013e0f8b866ff99c5f534cf218af4e9a10773",
+  "currentSha": "708013e28290799d425937474fd130e15a0db9a6",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "ef38151b670d64d97024dac618c6361c16a36da7",
+  "currentSha": "af4d9f606221908a715ba054dede33ba764e6a5b",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -30,24 +30,25 @@
     "Bounded HTTP evidence covers the HTTP/HTTPS apex/www matrix, manual redirect topology, and HTML-only homepage indexability with safe-stop handling for unsafe redirects",
     "Tenant-scoped profile and latest external-evidence routes provide actionable setup state; profile mutation and audit history are atomic",
     "Synchronous and scheduled collection paths now persist profile-gated RDAP/TLS/HTTP evidence with tenant, snapshot, hostname, feature-gate, timeout, and semaphore controls",
+    "Domain 360 exposes a tenant-safe Needs setup/evidence lane; UNKNOWN cannot render as healthy and authentication cache transitions clear active observers",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after profile-gated evidence collection"
+      "result": "8 of 8 workspace tasks passed after actionable setup/evidence UI"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after profile-gated evidence collection"
+      "result": "14 of 14 workspace tasks passed after actionable setup/evidence UI"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2651 tests passed and 41 skipped after profile-gated evidence collection"
+      "result": "2659 tests passed and 41 skipped after actionable setup/evidence UI"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after profile-gated evidence collection"
+      "result": "8 of 8 workspace tasks passed after actionable setup/evidence UI"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
@@ -101,11 +102,11 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Render setup/evidence and profile state in the Domain 360 UI without treating UNKNOWN as healthy",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
+    "Converge migrated notifications on the canonical signal path and prove FIX-06",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Converge migrated alert creation on the canonical signal path and prove FIX-06",
     "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
   ],
-  "updatedAt": "2026-07-29T15:37:52Z"
+  "updatedAt": "2026-07-29T16:07:51Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "90ae608ec71f7a0d6b506e4e38f7662a6ccaa5ba",
+  "currentSha": "fee9043aab457b9322801479e11af850dddd30c7",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -39,6 +39,7 @@
     "MCP has a tested static tokenSha256 principal map with enabled principals, UUID tenant binding, least-privilege scopes, durable idempotency, and dispatch for all ten approved tools through shared services",
     "The only external MCP transport is POST /mcp, mounted in TanStack's server-only SSR entrypoint; it was smoke-tested from the built Node server with a static hashed principal",
     "New MCP scan commands have a tenant-scoped 10-per-minute limiter before proxying; completed idempotent replays bypass the quota and the collector remains the downstream rate-limit boundary",
+    "A claimed case-open command that encounters an operational-service failure is completed as a durable generic COMMAND_FAILED response rather than being stranded PENDING",
     "A deterministic MCP transport harness calls all ten tools with schema-valid arguments and asserts typed JSON-RPC results plus malformed-schema rejection; service-level tenant, idempotency, audit, and stale-version proofs remain to be consolidated",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records"
@@ -54,7 +55,7 @@
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2713 tests passed and 41 skipped after direct MCP transport, quota enforcement, and ten-tool schema harness work"
+      "result": "2714 tests passed and 41 skipped after direct MCP transport, quota enforcement, ten-tool schema harness, and durable case-open failure work"
     },
     {
       "command": "bun run build",
@@ -116,5 +117,5 @@
     "Add the remaining case UI and consolidate service-level MCP tenant, idempotency, audit, stale-version, and rate-limit proofs into its deterministic harness",
     "Complete isolated PostgreSQL migration/concurrency verification and retain live Gate 3/4 blocks"
   ],
-  "updatedAt": "2026-07-29T18:10:00Z"
+  "updatedAt": "2026-07-29T18:15:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -43,7 +43,7 @@
     "Stale MCP case disposition commands return and durably persist only CASE_VERSION_STALE, with no database conflict detail in the command result",
     "The deterministic scan-command harness proves cross-tenant domain denial occurs before claim/proxy, completed scan requests replay without a second collector call, and rate-limited commands persist a failed result without proxying",
     "Independent MCP review identified and the implementation corrected a scan-quota mismatch: MCP now uses the collector's ten-token incremental-refill algorithm",
-    "A fresh independent Gate 4 review at 603a7ff is BLOCKED only on documented external live/manual-baseline prerequisites and final clean-checkout review; it found no remaining code-level blocker",
+    "A fresh independent Gate 4 review at 603a7ff is BLOCKED only on documented external live/manual-baseline prerequisites; a separate detached clean checkout was attested at 47e6c4a with no code-level blocker",
     "The deterministic MCP harness matrix consolidates ten-tool typed transport, invalid input/ID, disabled/scope, tenant, stale evidence, duplicate/stale command, scan idempotency/rate, audit, parity, and exception-leakage evidence",
     "FIX-05 proves stale TLS evidence remains setup/evidence with no canonical observation or delivery; FIX-06 proves duplicate canonical observations create one signal/case/alert and delivery occurs only on create and reopen",
     "Tenant-scoped case listing/detail/history and optimistic disposition updates are available with lifecycle and general audit records",
@@ -121,8 +121,8 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Obtain issue #4 external prerequisites for live Gate 3 fixtures, manual baseline, and final clean-checkout Gate 4 review",
+    "Obtain issue #4 external prerequisites for live Gate 3 fixtures and manual baseline, then repeat Gate 4 review after controlled-live evidence is recorded",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-29T18:53:00Z"
+  "updatedAt": "2026-07-29T18:55:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "ff5373eced4e96579f4d39747d2920c3a5e192f4",
+  "currentSha": "69328b12e80f98b44baa0e28297127600c22e4ca",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -137,5 +137,5 @@
     "Obtain issue #4 provider/test-host manifest, live-fixture authority, manual baseline, portfolio classification, and playbook approval; implement the concrete isolated fault harness, run LIVE-01 through LIVE-03, then repeat Gate 4 review",
     "Retain all Gate 3/4 live-operation blocks until the tracked authority, assets, allowlist, secret, and rollback prerequisites are supplied"
   ],
-  "updatedAt": "2026-07-30T01:13:00Z"
+  "updatedAt": "2026-07-30T01:17:00Z"
 }

--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -2,7 +2,7 @@
   "outcomeId": "dns-ops-phase-0-1",
   "authoritySha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
   "baseSha": "32dc8268ee8f38ce11513c3c9d2106bedf18f17a",
-  "currentSha": "6f17098984c279270567447ffa0abb8f272a1ea3",
+  "currentSha": "d7c64ef1802387fff9ced79284006f19f814c362",
   "currentShaMeaning": "latest committed implementation or operating-content SHA verified by this checkpoint; the checkpoint commit itself is expected to be newer",
   "branch": "agent/domain-operations-phase-0-1-implementation",
   "currentGate": "GATE_2_PASS / GATE_3_NON_LIVE",
@@ -27,24 +27,25 @@
     "Coverage/setup evidence remains separate from signals, cases, findings, and alerts",
     "Bounded RDAP expiration collection uses IANA bootstrap, cumulative deadlines, streamed byte limits, exact-domain validation, strict event dates, and actionable UNKNOWN results",
     "Bounded TLS evidence pins a validated public address while preserving SNI and independently records certificate chain and hostname authorization",
+    "Bounded HTTP evidence covers the HTTP/HTTPS apex/www matrix, manual redirect topology, and HTML-only homepage indexability with safe-stop handling for unsafe redirects",
     "Production and client mutation remain prohibited"
   ],
   "passingChecks": [
     {
       "command": "bun run lint",
-      "result": "8 of 8 workspace tasks passed after bounded TLS evidence"
+      "result": "8 of 8 workspace tasks passed after bounded HTTP web evidence"
     },
     {
       "command": "bun run typecheck",
-      "result": "14 of 14 workspace tasks passed after bounded TLS evidence"
+      "result": "14 of 14 workspace tasks passed after bounded HTTP web evidence"
     },
     {
       "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
-      "result": "2627 tests passed and 41 skipped after bounded TLS evidence"
+      "result": "2636 tests passed and 41 skipped after bounded HTTP web evidence"
     },
     {
       "command": "bun run build",
-      "result": "8 of 8 workspace tasks passed after bounded TLS evidence"
+      "result": "8 of 8 workspace tasks passed after bounded HTTP web evidence"
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
@@ -98,11 +99,11 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Implement bounded HTTP/redirect/indexability collectors against registered tenant domain targets",
-    "Persist probe failure and stale evidence as actionable setup/evidence without automatic signal promotion",
+    "Persist RDAP/TLS/HTTP evidence and probe failure as actionable setup/evidence without automatic signal promotion",
+    "Expose tenant-scoped domain profile and evidence setup/read surfaces",
     "Wire baseline-aware condition evaluation to the canonical signal/case service",
     "Converge migrated alert creation on the canonical signal path and prove FIX-06",
     "Add deterministic FIX-05 stale-evidence and FIX-06 canonical deduplication fixtures"
   ],
-  "updatedAt": "2026-07-29T13:03:26Z"
+  "updatedAt": "2026-07-29T14:42:36Z"
 }

--- a/docs/domain-operations/checkpoints/day-0-gate-1.md
+++ b/docs/domain-operations/checkpoints/day-0-gate-1.md
@@ -1,9 +1,9 @@
 # DNS Ops Phase 0–1 — Day 0 / Gate 1 Repository Truth
 
 **Recorded:** 2026-07-28  
-**Checkpoint status:** `GATE_1_PASS` / `DAY_0_INPUT_REQUIRED` — product implementation has not started
+**Checkpoint status:** `GATE_1_PASS` / `DAY_0_INPUT_REQUIRED` / `GATE_2_AUTHORIZED`
 
-Gate 1 was accepted by the founder on 2026-07-28. PR #3 remains open and draft; merge and implementation remain unauthorized until Day 0 passes.
+Gate 1 was accepted by the founder on 2026-07-28. PR #3 remains open and draft; merge and deployment remain unauthorized. The sequencing override in [`../amendments/2026-07-28-autonomous-completion-override.md`](../amendments/2026-07-28-autonomous-completion-override.md) authorizes independent Gate 2 and non-live Gate 3 work while preserving the external-input block on live mutations and final acceptance.
 
 ## Git authority
 
@@ -32,8 +32,9 @@ Read in required order:
 6. `docs/domain-operations/phase-0-1/04-review-gates-and-agent-prompt.md`
 7. `docs/domain-operations/controlled-test-assets-runbook-v4.1.md`
 8. `docs/domain-operations/day-0-worksheet.md`
+9. `docs/domain-operations/amendments/2026-07-28-autonomous-completion-override.md`
 
-The product brief was not used to expand scope.
+The product brief was not used to expand scope. The amendment changes stop/sequencing behavior only; all V4.1 scope and safety boundaries remain authoritative.
 
 ## Repository-native commands
 
@@ -227,5 +228,5 @@ Scope expansion is not available. If correctness or the canonical operating loop
 - Founder time consumed: **0 hours**.
 - Remaining engineering budget: **14.5 days total**, with **12 days reserved after Gate 1**.
 - Remaining founder budget: **24 hours**.
-- Real blocker: human-only Day 0 fields and unavailable test-asset authorization/secret presence.
-- Next automatic action after founder inputs: validate the completed worksheet without reading secret values, record Day 0 PASS, then begin Gate 2 correctness work with rule-error and DNS uncertainty tests first.
+- Real external blocker: human-only Day 0 fields and unavailable test-asset authorization/secret presence block live mutations and final Gate 3/4 acceptance, but not deterministic Gate 2 work.
+- Next automatic action: begin Gate 2 with the throwing-rule false-green fixture, then typed UNKNOWN propagation and DNS evidence honesty; continue independent work while preserving the bundled founder-input request.

--- a/docs/domain-operations/checkpoints/day-0-gate-1.md
+++ b/docs/domain-operations/checkpoints/day-0-gate-1.md
@@ -84,6 +84,7 @@ Raw command logs for this workstation run are under `/tmp/dns-ops-gate1-baseline
 - Only `zoneManagement === "managed"` triggers per-nameserver collection in `apps/collector/src/dns/collector.ts`; unmanaged and unknown zones use public recursive evidence only.
 - Nameservers are discovered through the configured recursive resolver, then used as target vantages.
 - `queryWithDnsPacket` decodes AA/TC/RD/RA/AD/CD, but `DNSResolver.queryViaDnsPacket` discards those decoded flags and substitutes constants with `aa: false` (`apps/collector/src/dns/dnssec-resolver.ts`, `apps/collector/src/dns/resolver.ts`).
+- Raw packet queries always set `RECURSION_DESIRED`, including when targeting an authoritative vantage.
 - A/AAAA use Node `Resolver.setServers`; the discovered nameserver values are hostnames, while `setServers` expects address literals. This can turn intended authoritative A/AAAA checks into errors.
 - Direct nameserver targeting is useful evidence, but current persisted observations cannot prove the AA bit and must not be presented as verified authoritative answers.
 - `calculateResultState` can still return `complete` for a managed plan when all returned query results succeed; it does not require AA proof.
@@ -114,7 +115,7 @@ Therefore a throwing rule can produce no finding while the snapshot remains comp
 
 1. `apps/collector/src/jobs/worker.ts` runs `generateAndSendFindingAlerts` after queued `collect-domain` jobs.
 2. `apps/collector/src/jobs/alert-from-findings.ts` converts every high/critical, non-review-only finding into a new alert and may deliver a webhook.
-3. Finding-derived alerts have no stable condition deduplication key; repeated scans can create repeated alerts.
+3. Finding-derived alerts have no stable condition deduplication key; repeated scans can create repeated alerts. This path also bypasses the monitoring route's suppression window and daily cap.
 4. `apps/collector/src/jobs/monitoring.ts` separately creates a `Collection Failed` legacy alert and webhook when its collector HTTP request fails.
 5. Synchronous ad-hoc collection and the monitoring-refresh worker do not share one canonical alert path.
 6. No signal path exists yet, so nothing is currently `MAPPED_TO_SIGNAL`.
@@ -149,7 +150,7 @@ Before a mail condition becomes `MAPPED_TO_SIGNAL`, its direct finding-alert eli
 
 - Implemented probes are SMTP STARTTLS and MTA-STS. Web TLS and generic HTTP probe enum values are schema-only.
 - SSRF checks block private, loopback, link-local, multicast, reserved, and mapped-private addresses; MTA-STS rejects redirects.
-- In-memory allowlists are tenant-keyed, but probe routes can build allowlist entries from caller-supplied `domain`, `hostname`, `mxRecords`, and `dnsResults`; these inputs are not proven to be registered-domain evidence.
+- In-memory allowlists are tenant-keyed, but probe routes can build allowlist entries from caller-supplied `domain`, `hostname`, `mxRecords`, and `dnsResults`; the SMTP route fabricates a successful `vantageIdentifier: "mock"` DNS result from request data, and MTA-STS directly adds a custom entry. These inputs are not proven registered-domain evidence, so the allowlist does not establish target provenance on these routes.
 - Collector `/api/*` service auth is a boundary, but Phase 1 `scan_request` must additionally accept only a registered domain ID and derive tenant/actor from the MCP principal.
 - Web authorization derives tenant/actor from request context and repositories often recheck tenant ownership. Some legacy repositories fetch broadly then filter in memory; MCP services must use explicit tenant predicates.
 - Audit events exist for portfolio, remediation, monitoring, and alert lifecycle changes. Rule failures, scan requests, suggestion apply/dismiss, and probe persistence do not yet provide the Phase 1 audit contract.
@@ -160,6 +161,7 @@ Before a mail condition becomes `MAPPED_TO_SIGNAL`, its direct finding-alert eli
 - `docs/architecture/runtime-topology.md` says raw DNS flag parsing is future work; raw parsing now exists, but `DNSResolver` discards the decoded flags. The limitation remains, for a different implementation reason.
 - `docs/rules/query-scope.md` describes conditional shallow SPF include queries and stronger managed authoritative completeness that current query planning does not implement.
 - `docs/rules/trust-boundary.md` says targets are derived from DNS only, while probe routes accept caller-supplied DNS-shaped values.
+- The repository has no typed `InternalSignalKind`, `InternalCaseStatus`, per-check UNKNOWN model, condition registry, or `/mcp` endpoint. The existing `partial` state is snapshot-level only.
 - `README.md` reports 2,212 tests/114 files; the verified baseline is 2,539 passing tests/136 passing files plus skips.
 - `README.md` links `STATUS_REPORT.md` and `REPO_STRUCTURE.md`, but neither file exists. `docs/rules/trust-boundary.md` also links missing `docs/security/probe-incident-response.md` and `docs/architecture/network-isolation.md`.
 - `README.md` advertises concrete provider-aware fixes; Phase 0–1 requires generic remediations to become non-executable guidance.

--- a/docs/domain-operations/checkpoints/day-0-gate-1.md
+++ b/docs/domain-operations/checkpoints/day-0-gate-1.md
@@ -1,0 +1,227 @@
+# DNS Ops Phase 0–1 — Day 0 / Gate 1 Repository Truth
+
+**Recorded:** 2026-07-28  
+**Checkpoint status:** `DAY_0_INPUT_REQUIRED` — product implementation has not started
+
+## Git authority
+
+| Item | Verified value |
+|---|---|
+| Repository | `computindev/dns-ops` |
+| Documentation authority ref | `origin/agent/domain-operations-phase-0-1` |
+| Documentation authority SHA | `32dc8268ee8f38ce11513c3c9d2106bedf18f17a` |
+| Implementation base SHA | `32dc8268ee8f38ce11513c3c9d2106bedf18f17a` |
+| Audited source SHA | `32dc8268ee8f38ce11513c3c9d2106bedf18f17a` |
+| Implementation branch | `agent/domain-operations-phase-0-1-implementation` |
+| Authority ancestry | authority is the implementation branch ancestor; divergence at audit time was `0 0` |
+| Worktree state at audit start | dirty only because tracked nested path `.pi/self-learning-memory` was already modified; no product file was dirty |
+
+`origin/master` contains the authority tree through merge commit `212afab`, but it is not an implementation authority and was not merged into this branch.
+
+## Authoritative documents read
+
+Read in required order:
+
+1. `docs/domain-operations/README.md`
+2. `docs/domain-operations/phase-0-1-execution-contract-v4.1.md`
+3. `docs/domain-operations/phase-0-1/01-outcome-budget-scope.md`
+4. `docs/domain-operations/phase-0-1/02-correctness-remediation-operations.md`
+5. `docs/domain-operations/phase-0-1/03-seeded-tests-and-mcp.md`
+6. `docs/domain-operations/phase-0-1/04-review-gates-and-agent-prompt.md`
+7. `docs/domain-operations/controlled-test-assets-runbook-v4.1.md`
+8. `docs/domain-operations/day-0-worksheet.md`
+
+The product brief was not used to expand scope.
+
+## Repository-native commands
+
+Root `package.json` and `.github/workflows/ci.yml` establish these commands:
+
+- `bun install --frozen-lockfile`
+- `bun run --filter @dns-ops/db build`
+- `bun run --filter @dns-ops/db check-drift`
+- `DATABASE_URL=... bun run --filter @dns-ops/db verify-migrations`
+- `bun run lint`
+- `bun run typecheck`
+- `RUN_LIVE_DNS_TESTS=0 bun run test`
+- `bun run build`
+- `bun run smoke-test`
+- `bun run --filter @dns-ops/web e2e`
+- optional only: `bun run test:live-dns`
+
+CI additionally provisions PostgreSQL 15 and Redis 7, pushes the schema to the isolated CI database, starts the collector, and runs Playwright.
+
+## Validation baseline
+
+Environment: Bun `1.3.14`, Node `v22.23.1`; the repository declares Bun `1.3.11` and Node `>=20`.
+
+| Command | Result | Evidence |
+|---|---|---|
+| `bun install --frozen-lockfile` | PASS | 1,313 packages installed without tracked lockfile change |
+| standalone DB build before dependency builds | FAIL | `@dns-ops/contracts` declarations unavailable; this ordering is not a valid clean-worktree baseline |
+| `bun run --filter @dns-ops/db check-drift` | PASS | `NO DRIFT` |
+| `bun run --filter @dns-ops/db verify-migrations` | BLOCKED | `DATABASE_URL` is unset; no local PostgreSQL readiness tool is available |
+| `bun run lint` | PASS | 8/8 workspace tasks |
+| `bun run typecheck` | PASS | 14/14 workspace tasks |
+| `RUN_LIVE_DNS_TESTS=0 bun run test` | PASS | 136 files passed, 3 skipped; 2,539 tests passed, 41 skipped |
+| `bun run build` | PASS | 8/8 workspace tasks |
+| smoke test | NOT RUN | requires running services |
+| Playwright E2E | NOT RUN | requires isolated PostgreSQL, collector, and web runtime |
+| live DNS tests | NOT RUN | optional network test; not a deterministic baseline requirement |
+
+Raw command logs for this workstation run are under `/tmp/dns-ops-gate1-baseline/` and are intentionally not committed.
+
+## Runtime topology proven by code
+
+- PostgreSQL/Drizzle is the product datastore (`packages/db/src/schema/index.ts`).
+- `apps/collector` is a Node/Hono process with synchronous collection and optional BullMQ/Redis workers (`apps/collector/src/index.ts`, `apps/collector/src/jobs/worker.ts`).
+- `apps/web` builds a TanStack Start/Vinxi Node server and both services have Railway Docker configuration (`apps/web/package.json`, `apps/web/railway.toml`, `apps/collector/railway.toml`).
+- Web calls collector APIs; collector persists snapshots, observations, record sets, findings, suggestions, alerts, and probe observations.
+- There are no signal, internal-case, domain-purpose, RDAP, web TLS, generic HTTP-health, redirect-matrix, or indexability application contracts in current source.
+
+## Current authoritative-DNS truth
+
+- Only `zoneManagement === "managed"` triggers per-nameserver collection in `apps/collector/src/dns/collector.ts`; unmanaged and unknown zones use public recursive evidence only.
+- Nameservers are discovered through the configured recursive resolver, then used as target vantages.
+- `queryWithDnsPacket` decodes AA/TC/RD/RA/AD/CD, but `DNSResolver.queryViaDnsPacket` discards those decoded flags and substitutes constants with `aa: false` (`apps/collector/src/dns/dnssec-resolver.ts`, `apps/collector/src/dns/resolver.ts`).
+- A/AAAA use Node `Resolver.setServers`; the discovered nameserver values are hostnames, while `setServers` expects address literals. This can turn intended authoritative A/AAAA checks into errors.
+- Direct nameserver targeting is useful evidence, but current persisted observations cannot prove the AA bit and must not be presented as verified authoritative answers.
+- `calculateResultState` can still return `complete` for a managed plan when all returned query results succeed; it does not require AA proof.
+
+## Current SPF truth
+
+- `parseSPF` performs first-record token parsing only (`packages/parsing/src/mail/index.ts`).
+- `countSPFLookups` is misnamed for the approved scope, is not used by the active SPF rule, and cannot count a `redirect=` modifier because it inspects mechanisms only.
+- The active rule does not recurse includes or redirect, which is consistent with the closed scope, but it does not emit the required `FIRST_LEVEL_ONLY` assessment or unresolved-dependency limitation.
+- The active rule can call a record “valid,” “certain,” “safe,” or “Configuration looks good” without evaluating nested includes. It does not currently claim the recursive ten-term budget, but its green language overstates completeness.
+
+## Current DMARC truth
+
+- The parser models `p`, `sp`, `pct`, `rua`, `ruf`, `fo`, `adkim`, `aspf`, `rf`, and `ri`.
+- It does not model current `np`, `psd`, or `t` behavior.
+- `pct`, `rf`, and `ri` remain active data, and `pct` drives rule output.
+- Discovery is one direct `_dmarc.<domain>` lookup. There is no RFC 9989 tree walk, organizational-domain primitive, eight-query bound, or typed resolver trace.
+- Multiple records are not rejected; the first matching answer is used.
+- Failed DMARC queries are filtered out before analysis and become a certain “No DMARC record,” conflating DNS failure with absence.
+
+## Current rule-error behavior
+
+`RulesEngine.evaluate` catches each rule exception, writes `console.error`, and continues without returning an error (`packages/rules/src/engine/index.ts`). `DNSCollector.evaluateAndPersistFindings` also catches its whole evaluation/persistence path and returns zero findings/suggestions (`apps/collector/src/dns/collector.ts`). Snapshot completeness was decided before rules evaluation.
+
+Therefore a throwing rule can produce no finding while the snapshot remains complete. `MailFindingsPanel` renders zero findings as green “No mail configuration issues detected.” This is a verified false-green path and Gate 2 blocker.
+
+## Current alert-generation paths
+
+1. `apps/collector/src/jobs/worker.ts` runs `generateAndSendFindingAlerts` after queued `collect-domain` jobs.
+2. `apps/collector/src/jobs/alert-from-findings.ts` converts every high/critical, non-review-only finding into a new alert and may deliver a webhook.
+3. Finding-derived alerts have no stable condition deduplication key; repeated scans can create repeated alerts.
+4. `apps/collector/src/jobs/monitoring.ts` separately creates a `Collection Failed` legacy alert and webhook when its collector HTTP request fails.
+5. Synchronous ad-hoc collection and the monitoring-refresh worker do not share one canonical alert path.
+6. No signal path exists yet, so nothing is currently `MAPPED_TO_SIGNAL`.
+
+## Legacy condition map
+
+| Condition ID | Disposition | Replacement signal | Notification path | Evidence |
+|---|---|---|---|---|
+| `domain.expiring-soon` | `DISABLED` | `DOMAIN_EXPIRING_SOON` | `NONE` | no RDAP/expiration collector or rule |
+| `web.tls-certificate-regression` | `DISABLED` | `TLS_CERTIFICATE_REGRESSION` | `NONE` | schema enum exists; no web TLS probe/evaluator |
+| `web.http-endpoint-unavailable` | `DISABLED` | `HTTP_ENDPOINT_UNAVAILABLE` | `NONE` | schema enum exists; no HTTP-health probe/evaluator |
+| `web.redirect-topology-regression` | `DISABLED` | `REDIRECT_TOPOLOGY_REGRESSION` | `NONE` | no redirect-matrix evaluator |
+| `web.homepage-indexability-regression` | `DISABLED` | `HOMEPAGE_INDEXABILITY_REGRESSION` | `NONE` | no robots/canonical/indexability evaluator |
+| `mail.no-spf-record` | `LEGACY_ONLY` | `MAIL_DNS_CONFIGURATION_REGRESSION` candidate | `LEGACY_ALERT` | high, non-review-only finding reaches finding-alert job |
+| `mail.no-dmarc-record` | `LEGACY_ONLY` | `MAIL_DNS_CONFIGURATION_REGRESSION` candidate | `LEGACY_ALERT` | high, non-review-only finding reaches finding-alert job |
+| `mail.dkim-no-valid-keys` | `LEGACY_ONLY` | `MAIL_DNS_CONFIGURATION_REGRESSION` candidate | `LEGACY_ALERT` | high, non-review-only finding reaches finding-alert job |
+| `collector.collection-failed` | `LEGACY_ONLY` | none in the six-signal set | `LEGACY_ALERT` | direct alert in monitoring route |
+| all other current DNS/mail finding types | `DISABLED` | none yet | `NONE` | current severity/review-only filter does not notify |
+| `dns.partial-coverage-unmanaged` | `DISABLED` | prohibited | `NONE` | currently a safe/info finding; must move to setup/evidence and never signal |
+
+Before a mail condition becomes `MAPPED_TO_SIGNAL`, its direct finding-alert eligibility must be removed in the same change and duplicate-path tests must pass.
+
+## Suggestion and remediation truth
+
+- Active rules emit provider-assuming, executable-looking record text for SPF, DMARC, DKIM, MTA-STS, TLS-RPT, MX, and CNAME changes (`packages/rules/src/mail/rules.ts`, `packages/rules/src/dns/rules.ts`).
+- The deterministic simulation engine emits concrete mutation objects, including generic reporting mailboxes, provider templates, Null MX, and `YOUR_PUBLIC_KEY` placeholders (`packages/rules/src/simulation/index.ts`).
+- The UI labels suggestion state changes “Apply” / “Applied,” although the API only marks the database suggestion row and performs no provider mutation (`apps/web/app/components/MailFindingsPanel.tsx`, `apps/web/hono/routes/suggestions.ts`).
+- Generic remediation requests are executable-looking workflow records with status transitions that can be resolved without fresh evidence (`apps/web/hono/routes/mail.ts`, `packages/db/src/schema/remediation.ts`).
+- These paths must become guidance-only or be gated by complete, provider-confirmed simulation context. DNS Ops product and MCP currently contain no provider API writer, which must remain true.
+
+## Probe, tenant, and audit boundaries
+
+- Implemented probes are SMTP STARTTLS and MTA-STS. Web TLS and generic HTTP probe enum values are schema-only.
+- SSRF checks block private, loopback, link-local, multicast, reserved, and mapped-private addresses; MTA-STS rejects redirects.
+- In-memory allowlists are tenant-keyed, but probe routes can build allowlist entries from caller-supplied `domain`, `hostname`, `mxRecords`, and `dnsResults`; these inputs are not proven to be registered-domain evidence.
+- Collector `/api/*` service auth is a boundary, but Phase 1 `scan_request` must additionally accept only a registered domain ID and derive tenant/actor from the MCP principal.
+- Web authorization derives tenant/actor from request context and repositories often recheck tenant ownership. Some legacy repositories fetch broadly then filter in memory; MCP services must use explicit tenant predicates.
+- Audit events exist for portfolio, remediation, monitoring, and alert lifecycle changes. Rule failures, scan requests, suggestion apply/dismiss, and probe persistence do not yet provide the Phase 1 audit contract.
+
+## Stale or conflicting documentation
+
+- `README.md` and `docs/architecture/runtime-topology.md` call the web runtime Cloudflare Workers/Hyperdrive; package scripts, Vinxi Node output, Dockerfiles, and Railway config prove the deployed shape is currently a Node server on Railway.
+- `docs/architecture/runtime-topology.md` says raw DNS flag parsing is future work; raw parsing now exists, but `DNSResolver` discards the decoded flags. The limitation remains, for a different implementation reason.
+- `docs/rules/query-scope.md` describes conditional shallow SPF include queries and stronger managed authoritative completeness that current query planning does not implement.
+- `docs/rules/trust-boundary.md` says targets are derived from DNS only, while probe routes accept caller-supplied DNS-shaped values.
+- `README.md` reports 2,212 tests/114 files; the verified baseline is 2,539 passing tests/136 passing files plus skips.
+- `README.md` links `STATUS_REPORT.md` and `REPO_STRUCTURE.md`, but neither file exists. `docs/rules/trust-boundary.md` also links missing `docs/security/probe-incident-response.md` and `docs/architecture/network-isolation.md`.
+- `README.md` advertises concrete provider-aware fixes; Phase 0–1 requires generic remediations to become non-executable guidance.
+- Migration `0007_tenant_domain_uniqueness.sql` calls itself a stub requiring review even though it executes DDL; this is stale and operationally misleading prose.
+
+## Falsification results
+
+Verified counterexamples or risks:
+
+- throwing rule → swallowed exception → complete snapshot may show green;
+- failed DMARC DNS lookup → certain record absence;
+- first-level SPF → green completeness language without dependency resolution;
+- legacy DMARC `pct` still drives current output;
+- no RFC 9989 fixture resolver or tree walk exists;
+- coverage gap represented as a safe finding rather than setup/evidence;
+- repeated queued findings can create repeated legacy alerts;
+- generic record values and placeholders look executable;
+- caller-supplied probe evidence can authorize a target;
+- no MCP exists yet, so principal-derived actor/tenant enforcement is unproven.
+
+## Day 0 gate
+
+Automatically completed:
+
+- authority, base, branch, ancestry, and Git state verified;
+- all authoritative documents read;
+- repository-native scripts and CI identified;
+- dependencies installed with the frozen lockfile;
+- lint, typecheck, deterministic tests, build, and schema drift baseline recorded;
+- runtime, DNS, SPF, DMARC, rules, alerts, remediation, probes, tenant, audit, and stale-doc paths inspected;
+- no Day 0 secret value was read or printed.
+
+Missing founder inputs:
+
+- at least four manual checks with real frequency, minutes/run, domains/run, evidence location, and keep/replace target;
+- selected initial portfolio;
+- purpose and criticality for every included domain;
+- observation-only marker for every included production/client asset;
+- selected non-production test domain, web host, mail subdomain, zone ID, and provider kind;
+- confirmations that the test assets have no production/customer/mail dependency;
+- scoped provider token existence, safe runtime-secret storage, secret name/fingerprint, and revocation owner;
+- exact mutable names/types allowlist plus baseline/rollback path;
+- previous TTL values for mutable records.
+
+All `DNSOPS_TEST_*` variables and `DATABASE_URL` were unset in the inspected environment. No secret values were requested or exposed.
+
+## Remaining scope within twelve engineering days
+
+After Day 0 passes, retain this bounded sequence:
+
+1. **Correctness foundation (4 days):** typed rule failures/UNKNOWN, snapshot partial state, authoritative limitation, first-level SPF contract, RFC 9989 parser/discovery and deterministic resolver fixtures, downgrade generic remediation.
+2. **Minimal operating loop (4 days):** domain purpose/profile, bounded RDAP/TLS/HTTP/redirect/indexability evidence, setup/evidence lane, six signals, one deduplicated case lifecycle, legacy convergence, audit, six playbooks.
+3. **MCP and deterministic proof (3 days):** `/mcp`, static token-hash principals/scopes, exactly ten tools including `scan_request`, idempotency/version/rate/tenant/audit negatives, application parity harness.
+4. **Gate completion (1 day):** fixture matrix, authorized live harness only when Day 0 assets are ready, final validation, fresh clean-context review, evidence and handoff.
+
+Scope expansion is not available. If correctness or the canonical operating loop exceeds these caps, lower surface breadth without weakening evaluators.
+
+## Budget and next action
+
+- Engineering consumed through this checkpoint: **0.5 focused day**.
+- Founder time consumed: **0 hours**.
+- Remaining engineering budget: **14.5 days total**, with **12 days reserved after Gate 1**.
+- Remaining founder budget: **24 hours**.
+- Real blocker: human-only Day 0 fields and unavailable test-asset authorization/secret presence.
+- Next automatic action after founder inputs: validate the completed worksheet without reading secret values, record Day 0 PASS, then begin Gate 2 correctness work with rule-error and DNS uncertainty tests first.

--- a/docs/domain-operations/checkpoints/day-0-gate-1.md
+++ b/docs/domain-operations/checkpoints/day-0-gate-1.md
@@ -1,7 +1,9 @@
 # DNS Ops Phase 0–1 — Day 0 / Gate 1 Repository Truth
 
 **Recorded:** 2026-07-28  
-**Checkpoint status:** `DAY_0_INPUT_REQUIRED` — product implementation has not started
+**Checkpoint status:** `GATE_1_PASS` / `DAY_0_INPUT_REQUIRED` — product implementation has not started
+
+Gate 1 was accepted by the founder on 2026-07-28. PR #3 remains open and draft; merge and implementation remain unauthorized until Day 0 passes.
 
 ## Git authority
 

--- a/docs/domain-operations/controlled-test-assets-runbook-v4.1.md
+++ b/docs/domain-operations/controlled-test-assets-runbook-v4.1.md
@@ -100,7 +100,16 @@ export type FaultRunArtifact = {
   caseIds: string[];
   auditEventIds: string[];
   result: "PASS" | "FAIL" | "RECOVERY_REQUIRED";
-  recoveryInstructions?: string;
+  recovery?: {
+    provider: string;
+    zoneId: string;
+    records: Array<{
+      name: string;
+      type: "A" | "AAAA" | "CNAME" | "TXT";
+      desiredValue: string;
+    }>;
+    operatorCommands: string[];
+  };
 };
 ```
 

--- a/docs/domain-operations/controlled-test-assets-runbook-v4.1.md
+++ b/docs/domain-operations/controlled-test-assets-runbook-v4.1.md
@@ -113,7 +113,9 @@ export type FaultRunArtifact = {
 };
 ```
 
-Secrets and full provider response headers must be redacted.
+Secrets and full provider response headers must be redacted. For `RECOVERY_REQUIRED`, the recovery zone must equal the artifact zone and every recovery record must be one of the artifact's declared targets.
+
+`operatorCommands` are audited, human-readable recovery instructions only. A harness must never execute them as shell text. The future `recover` command must resolve a provider-specific, allowlisted operation from the structured provider/zone/record data and reject any tuple outside its approved policy.
 
 ---
 

--- a/docs/domain-operations/controlled-test-assets-runbook-v4.1.md
+++ b/docs/domain-operations/controlled-test-assets-runbook-v4.1.md
@@ -115,7 +115,7 @@ export type FaultRunArtifact = {
 
 Secrets and full provider response headers must be redacted. For `RECOVERY_REQUIRED`, the recovery zone must equal the artifact zone and every recovery record must be one of the artifact's declared targets.
 
-`operatorCommands` are audited, human-readable recovery instructions only. A harness must never execute them as shell text. The future `recover` command must resolve a provider-specific, allowlisted operation from the structured provider/zone/record data and reject any tuple outside its approved policy.
+`operatorCommands` are audited provider-operation references in `operation: STATUS` form, not shell text or copyable credential-bearing commands. A harness must never execute them as shell text. The future `recover` command must resolve a provider-specific, allowlisted operation from the structured provider/zone/record data and reject any tuple outside its approved policy.
 
 ---
 

--- a/docs/domain-operations/day-0-worksheet.md
+++ b/docs/domain-operations/day-0-worksheet.md
@@ -9,7 +9,7 @@
 
 - Date: 2026-07-28
 - Authority SHA supplied to agent: `32dc8268ee8f38ce11513c3c9d2106bedf18f17a`
-- Founder/operator:
+- Founder/operator: Antonio
 - Maximum portfolio size: **30 domains**
 - Selected test DNS provider:
 - Selected non-production test zone:

--- a/docs/domain-operations/day-0-worksheet.md
+++ b/docs/domain-operations/day-0-worksheet.md
@@ -125,10 +125,11 @@ These must be non-production and have no client or real mail dependency.
 
 ## Authorized test-zone preflight
 
-- Founder authorization recorded 2026-08-04: create and delegate `dnsops-test.computin.dev` as an isolated child zone; Antonio owns rollback and credential revocation.
-- Explicitly excluded: the `computin.dev` apex and all existing MX, SPF, DKIM, and DMARC records.
-- Read-only preflight evidence: `docs/domain-operations/evidence/gate-3/computin-test-zone-delegation-preflight.json`.
-- The child zone and its scoped credential do not yet exist; do not run provider mutations until the remaining safety confirmations are complete.
+- The prior `dnsops-test.computin.dev` delegation proposal is superseded; no provider mutation or delegation was performed.
+- Founder authorization recorded 2026-08-04: use `asorin.ai` as the complete isolated controlled-test zone; Antonio owns rollback and credential revocation.
+- Founder declaration: `asorin.ai` has no production traffic, client dependency, or real mail dependency.
+- Cloudflare read-only preflight evidence: `docs/domain-operations/evidence/gate-3/asorin-test-zone-preflight.json`.
+- The zone is active with no DNS records observed. Do not run provider mutations until the remaining safety confirmations are complete.
 
 ## Safety confirmations
 

--- a/docs/domain-operations/day-0-worksheet.md
+++ b/docs/domain-operations/day-0-worksheet.md
@@ -123,6 +123,13 @@ These must be non-production and have no client or real mail dependency.
 | Provider token secret name |  |  | Do not paste token value |
 | Token fingerprint |  |  |  |
 
+## Authorized test-zone preflight
+
+- Founder authorization recorded 2026-08-04: create and delegate `dnsops-test.computin.dev` as an isolated child zone; Antonio owns rollback and credential revocation.
+- Explicitly excluded: the `computin.dev` apex and all existing MX, SPF, DKIM, and DMARC records.
+- Read-only preflight evidence: `docs/domain-operations/evidence/gate-3/computin-test-zone-delegation-preflight.json`.
+- The child zone and its scoped credential do not yet exist; do not run provider mutations until the remaining safety confirmations are complete.
+
 ## Safety confirmations
 
 - [ ] No production traffic.

--- a/docs/domain-operations/day-0-worksheet.md
+++ b/docs/domain-operations/day-0-worksheet.md
@@ -7,8 +7,8 @@
 
 # A. Decision record
 
-- Date:
-- Authority SHA supplied to agent:
+- Date: 2026-07-28
+- Authority SHA supplied to agent: `32dc8268ee8f38ce11513c3c9d2106bedf18f17a`
 - Founder/operator:
 - Maximum portfolio size: **30 domains**
 - Selected test DNS provider:

--- a/docs/domain-operations/evidence/gate-2/fix-01-rule-failure.json
+++ b/docs/domain-operations/evidence/gate-2/fix-01-rule-failure.json
@@ -1,0 +1,51 @@
+{
+  "fixtureId": "FIX-01",
+  "recordedAt": "2026-07-28T22:53:59Z",
+  "implementationBaseSha": "336ddb4b6934cac0849478342e1710ccad1c15b6",
+  "counterexample": {
+    "command": "bunx vitest run packages/rules/src/engine/index.test.ts",
+    "preFixResult": "FAILED as expected: RulesEngine returned no complete/errors fields and logged the thrown exception",
+    "falseGreenRisk": "A throwing rule produced zero findings without an incomplete evaluation result"
+  },
+  "postFixAssertions": [
+    "A throwing rule returns RULE_EXECUTION_FAILED with status UNKNOWN",
+    "UNKNOWN includes CHECK_EVALUATION_FAILED and RUN_FRESH_SCAN",
+    "The snapshot evaluation coverage is persisted as PARTIAL",
+    "A collection result is partial when rule evaluation is incomplete",
+    "Historical snapshots without coverage are actionable UNKNOWN",
+    "API responses expose evaluation coverage",
+    "Portfolio filtering cannot drop a zero-finding domain unless coverage is explicitly COMPLETE",
+    "Mail UI suppresses a health score and green zero-findings state while coverage is PARTIAL"
+  ],
+  "tests": {
+    "targeted": {
+      "command": "bunx vitest run packages/contracts/src/evaluation.test.ts packages/rules/src/engine/index.test.ts packages/db/src/repos/snapshot.evaluation.test.ts apps/collector/src/dns/collector.ruleset-version.test.ts apps/collector/src/dns/collector.authoritative.test.ts apps/web/hono/routes/findings.runtime.test.ts apps/web/hono/routes/snapshots.runtime.test.ts apps/web/hono/routes/snapshot-history.integration.test.ts apps/web/hono/routes/portfolio.test.ts",
+      "result": "140 passed in 9 files"
+    },
+    "lint": {
+      "command": "bun run lint",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "typecheck": {
+      "command": "bun run typecheck",
+      "result": "14 of 14 workspace tasks passed"
+    },
+    "deterministicSuite": {
+      "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+      "result": "2548 passed, 41 skipped; 139 files passed, 3 skipped"
+    },
+    "build": {
+      "command": "bun run build",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "schemaDrift": {
+      "command": "bun run --filter @dns-ops/db check-drift",
+      "result": "NO DRIFT"
+    }
+  },
+  "notRun": [
+    "Migration verification: isolated DATABASE_URL unavailable",
+    "Smoke and Playwright E2E: required services unavailable",
+    "Live DNS/provider mutations: founder-verified assets and credentials unavailable"
+  ]
+}

--- a/docs/domain-operations/evidence/gate-2/fix-02-authoritative-evidence.json
+++ b/docs/domain-operations/evidence/gate-2/fix-02-authoritative-evidence.json
@@ -1,0 +1,51 @@
+{
+  "fixtureId": "FIX-02",
+  "recordedAt": "2026-07-28T23:01:23Z",
+  "implementationBaseSha": "831269c0639030c39caa6d26983a6476bffb6484",
+  "counterexamples": [
+    "Wire-format AA/RD/RA flags were decoded and then replaced by constants",
+    "Authoritative targets received recursion-desired queries",
+    "A/AAAA authoritative queries passed nameserver hostnames to Resolver.setServers",
+    "Managed collections could report complete without any AA proof"
+  ],
+  "postFixAssertions": [
+    "Every supported record type uses one wire-format resolver path",
+    "Recursive vantages set RD and authoritative vantages clear RD",
+    "Decoded AA, TC, RD, RA, AD, and CD flags are preserved",
+    "Nameserver hostnames are valid direct raw-query targets and no longer pass through Resolver.setServers",
+    "Managed collection is partial unless every captured authoritative response succeeds with AA=true",
+    "Missing or non-authoritative evidence is persisted as actionable UNKNOWN with RETRY_PROBE",
+    "The Domain UI renders authoritative UNKNOWN and a retry action"
+  ],
+  "tests": {
+    "targeted": {
+      "command": "bunx vitest run apps/collector/src/dns/dnssec-decode.test.ts apps/collector/src/dns/resolver.test.ts apps/collector/src/dns/collector.authoritative.test.ts apps/collector/src/dns/collector.ruleset-version.test.ts",
+      "result": "30 passed in 4 files"
+    },
+    "lint": {
+      "command": "bun run lint",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "typecheck": {
+      "command": "bun run typecheck",
+      "result": "14 of 14 workspace tasks passed"
+    },
+    "deterministicSuite": {
+      "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+      "result": "2543 passed, 41 skipped; 139 files passed, 3 skipped"
+    },
+    "build": {
+      "command": "bun run build",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "schemaDrift": {
+      "command": "bun run --filter @dns-ops/db check-drift",
+      "result": "NO DRIFT"
+    }
+  },
+  "notRun": [
+    "Live authoritative/provider mutation tests: founder-verified assets and credentials unavailable",
+    "Migration verification: isolated DATABASE_URL unavailable",
+    "Smoke and Playwright E2E: required services unavailable"
+  ]
+}

--- a/docs/domain-operations/evidence/gate-2/fix-03-spf-first-level.json
+++ b/docs/domain-operations/evidence/gate-2/fix-03-spf-first-level.json
@@ -1,0 +1,48 @@
+{
+  "fixtureId": "FIX-03",
+  "recordedAt": "2026-07-28T23:08:38Z",
+  "implementationBaseSha": "e8bdf0564e0b516cf01c2fd05930494723248752",
+  "postFixAssertions": [
+    "SPF assessment scope is always FIRST_LEVEL_ONLY",
+    "Direct DNS lookup terms count only the published record and include redirect exactly once",
+    "Include domains and redirect target are returned as unresolved dependencies",
+    "completeEvaluation is always false",
+    "The limitation explicitly disclaims recursive lookup-budget, cycle, void lookup, nested validity, and sender authorization",
+    "Rule and preview output expose the limited scope",
+    "Malformed directly visible mechanisms are rejected",
+    "The stale benchmark no longer claims recursive ten-term compliance"
+  ],
+  "tests": {
+    "targeted": {
+      "command": "bunx vitest run packages/parsing/src/mail/index.test.ts packages/rules/src/mail/rules.test.ts apps/collector/src/mail/checker.test.ts",
+      "result": "55 passed in 3 files"
+    },
+    "lint": {
+      "command": "bun run lint",
+      "result": "8 of 8 workspace tasks passed; the later non-null-assertion cleanup also passes Biome"
+    },
+    "typecheck": {
+      "command": "bun run typecheck",
+      "result": "14 of 14 workspace tasks passed"
+    },
+    "deterministicSuite": {
+      "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+      "result": "2546 passed, 41 skipped; 140 files passed, 3 skipped"
+    },
+    "build": {
+      "command": "bun run build",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "schemaDrift": {
+      "command": "bun run --filter @dns-ops/db check-drift",
+      "result": "NO DRIFT"
+    }
+  },
+  "exclusionsConfirmed": [
+    "No recursive include traversal",
+    "No cycle detection",
+    "No void-lookup evaluator",
+    "No global ten-term budget claim",
+    "No sender authorization claim"
+  ]
+}

--- a/docs/domain-operations/evidence/gate-2/fix-04-rfc9989-dmarc-discovery.json
+++ b/docs/domain-operations/evidence/gate-2/fix-04-rfc9989-dmarc-discovery.json
@@ -1,0 +1,63 @@
+{
+  "fixtureId": "FIX-04",
+  "recordedAt": "2026-07-28T23:42:19Z",
+  "implementationBaseSha": "cf639df6ccc2a578d9093d9aba1885a8baf4c2d0",
+  "standard": {
+    "document": "RFC 9989",
+    "sections": ["4.7", "4.8", "4.10", "4.10.1"],
+    "source": "https://www.rfc-editor.org/rfc/rfc9989.html"
+  },
+  "postFixAssertions": [
+    "Policy discovery queries the Author Domain first and performs no more than eight DMARC TXT queries",
+    "Author Domains longer than eight labels jump to the seven-label suffix after the direct query",
+    "Only an exact case-sensitive DMARC1 first version tag is accepted, including RFC-permitted WSP",
+    "Multiple current-version records at one target are discarded",
+    "psd=n and psd=y stop the walk and organizational/PSD selection remains explicit",
+    "psd=u is accepted without falsely asserting an Organizational Domain",
+    "DNS failures yield actionable UNKNOWN while ENOTFOUND/ENODATA are handled as absence evidence",
+    "Inherited effective policy follows existing sp->p and non-existent np->sp->p precedence",
+    "Domain-existence evidence is required before inherited policy can be marked determined",
+    "Invalid or duplicate p/sp/np tags use p=none only when at least one syntactically valid reporting URI exists",
+    "t=y lowers reject to quarantine and quarantine to none",
+    "Scoring uses only the determined effective policy and never raw inherited p",
+    "SPF remains partial-credit only because Phase 0–1 does not recursively evaluate it"
+  ],
+  "tests": {
+    "targeted": {
+      "command": "bunx vitest run apps/collector/src/mail/dmarc-discovery.test.ts apps/collector/src/mail/checker.test.ts packages/parsing/src/mail/index.test.ts packages/parsing/src/mail/result.test.ts packages/parsing/src/e2e/result-integration.e2e.test.ts",
+      "result": "123 passed in 5 files"
+    },
+    "lint": {
+      "command": "bun run lint",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "typecheck": {
+      "command": "bun run typecheck",
+      "result": "14 of 14 workspace tasks passed"
+    },
+    "deterministicSuite": {
+      "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+      "result": "2566 passed, 41 skipped; 141 files passed, 3 skipped"
+    },
+    "build": {
+      "command": "bun run build",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "schemaDrift": {
+      "command": "bun run --filter @dns-ops/db check-drift",
+      "result": "NO DRIFT"
+    }
+  },
+  "review": {
+    "method": "Four fresh-context independent reviewer passes against RFC 9989",
+    "resolvedFindings": [
+      "Version-tag grammar and public parser consistency",
+      "Malformed and duplicate policy-tag handling",
+      "np/sp/p precedence and domain-existence evidence",
+      "psd=u and walk-start psd=y behavior",
+      "t=y policy reduction",
+      "RFC URI percent-escape validation",
+      "Safe score derivation"
+    ]
+  }
+}

--- a/docs/domain-operations/evidence/gate-2/fix-05-guidance-only-remediation.json
+++ b/docs/domain-operations/evidence/gate-2/fix-05-guidance-only-remediation.json
@@ -1,0 +1,60 @@
+{
+  "fixtureId": "FIX-05",
+  "recordedAt": "2026-07-29T03:56:46Z",
+  "implementationBaseSha": "4b4e1f863809e5e938905cc5ce2226524d6845a5",
+  "postFixAssertions": [
+    "Generic rule suggestions contain playbook references and non-executable prose rather than record values",
+    "Generic simulation returns mode GUIDANCE_ONLY, executable proposedChanges=[], and executableMutation=null",
+    "Heuristic provider detection is not presented as confirmed context",
+    "The legacy apply route always returns a typed GUIDANCE_ONLY refusal and never marks a suggestion applied",
+    "Historical applied state is described as acknowledgement rather than provider execution",
+    "Persisted legacy executable suggestion text is sanitized at findings, GET, dismiss, and apply response boundaries",
+    "Suggestion GET/apply/dismiss resolve finding->snapshot->domain and return 404 across tenant boundaries",
+    "Remediation resolution and closure require a same-domain, same-tenant, complete snapshot newer than the active lifecycle transition",
+    "Stale, partial, wrong-domain, cross-tenant, and replayed verification evidence cannot close remediation",
+    "Guidance UI exposes no Apply action, concrete record diff, projected result, or resolved-finding claim",
+    "SPF receives partial score credit only because recursive evaluation remains out of scope"
+  ],
+  "tests": {
+    "targeted": {
+      "command": "bunx vitest run apps/web/hono/routes/suggestions.test.ts apps/web/hono/routes/simulation.runtime.test.ts apps/web/hono/routes/mail.runtime.test.ts apps/web/hono/routes/findings.runtime.test.ts packages/rules/src/mail/rules.test.ts packages/rules/src/dns/rules.test.ts",
+      "result": "114 passed in 6 files before the final lifecycle/copy pass; all affected tests passed again afterward"
+    },
+    "lint": {
+      "command": "bun run lint",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "typecheck": {
+      "command": "bun run typecheck",
+      "result": "14 of 14 workspace tasks passed"
+    },
+    "deterministicSuite": {
+      "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+      "result": "2571 passed, 41 skipped; 141 files passed, 3 skipped"
+    },
+    "build": {
+      "command": "bun run build",
+      "result": "8 of 8 workspace tasks passed"
+    },
+    "schemaDrift": {
+      "command": "bun run --filter @dns-ops/db check-drift",
+      "result": "NO DRIFT"
+    }
+  },
+  "review": {
+    "method": "Three fresh-context independent review passes",
+    "finalResult": "CLEAN",
+    "resolvedFindings": [
+      "Legacy executable rows leaking through response boundaries",
+      "Cross-tenant suggestion read and dismiss access",
+      "Misleading apply and simulation contracts/copy",
+      "Unconfirmed provider presentation",
+      "Verification snapshot replay after remediation reopen"
+    ]
+  },
+  "safety": {
+    "providerWritesAdded": false,
+    "productionMutations": false,
+    "clientAssetMutations": false
+  }
+}

--- a/docs/domain-operations/evidence/gate-2/guidance-only-remediation.json
+++ b/docs/domain-operations/evidence/gate-2/guidance-only-remediation.json
@@ -1,5 +1,5 @@
 {
-  "fixtureId": "FIX-05",
+  "evidenceId": "GATE2-REMEDIATION-GUIDANCE",
   "recordedAt": "2026-07-29T03:56:46Z",
   "implementationBaseSha": "4b4e1f863809e5e938905cc5ce2226524d6845a5",
   "postFixAssertions": [

--- a/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
@@ -1,0 +1,33 @@
+{
+  "manifestId": "ASORIN-AI-CONTROLLED-LIVE-01-03",
+  "status": "FOUNDER_AUTHORIZED_PENDING_HARNESS_IMPLEMENTATION",
+  "zone": "asorin.ai",
+  "provider": "cloudflare",
+  "rollbackAndRevocationOwner": "Antonio",
+  "globalConstraints": [
+    "No production traffic, client dependency, or real mail dependency exists in asorin.ai.",
+    "All mutable DNS records use TTL 60 after the required previous-TTL wait.",
+    "Only the isolated harness may apply or restore mutations."
+  ],
+  "scenarios": {
+    "LIVE-01": {
+      "host": "www.asorin.ai",
+      "healthy": "HTTP/HTTPS www redirects with 308 to https://asorin.ai/.",
+      "fault": "Fixture mode redirect_fault makes www.asorin.ai return 200 without the canonical redirect.",
+      "expectedSignal": "REDIRECT_TOPOLOGY_REGRESSION"
+    },
+    "LIVE-02": {
+      "host": "asorin.ai",
+      "healthy": "Indexable HTML with canonical https://asorin.ai/.",
+      "fault": "Fixture mode noindex_fault sets X-Robots-Tag and HTML robots to noindex while preserving redirects.",
+      "expectedSignal": "HOMEPAGE_INDEXABILITY_REGRESSION"
+    },
+    "LIVE-03": {
+      "host": "mail.asorin.ai",
+      "record": {"type": "TXT", "ttl": 60, "baselineValue": "v=spf1 -all"},
+      "fault": "Delete the sole approved SPF TXT record, producing deterministic no-SPF evidence.",
+      "expectedSignal": "MAIL_DNS_CONFIGURATION_REGRESSION",
+      "mailFlow": "None"
+    }
+  }
+}

--- a/docs/domain-operations/evidence/gate-3/asorin-test-zone-preflight.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-test-zone-preflight.json
@@ -1,0 +1,37 @@
+{
+  "evidenceId": "GATE3-ASORIN-TEST-ZONE-PREFLIGHT",
+  "recordedAt": "2026-08-04T16:36:46Z",
+  "status": "READ_ONLY_PREFLIGHT_PASS_PENDING_HOST_DEPLOYMENT_AUTHORIZATION",
+  "founderAuthorization": {
+    "testDomain": "asorin.ai",
+    "declaration": "asorin.ai has no production traffic, clients, or real mail dependency and is authorized as the complete controlled-test zone.",
+    "rollbackAndRevocationOwner": "Antonio"
+  },
+  "cloudflareReadOnlyVerification": {
+    "zoneId": "7391960081e72b26c9c5066133013ab2",
+    "zoneStatus": "active",
+    "paused": false,
+    "authoritativeNameservers": [
+      "mcgrory.ns.cloudflare.com",
+      "olivia.ns.cloudflare.com"
+    ],
+    "tokenVerificationSucceeded": true,
+    "zoneReadSucceeded": true,
+    "dnsRecordReadSucceeded": true,
+    "recordCountObserved": 0,
+    "providerCredentialFingerprint": "sha256:17fe70271d1013db5ef7fffa31f6ea68e98a2a0040300a3acb3ee96e4b9bfd8f",
+    "credentialValueRecorded": false
+  },
+  "scopeCaveat": "The successful token verification and asorin.ai readback prove usable access to this zone. Cloudflare Dashboard configuration remains the authority for confirming its intended least-privilege policy; no token value is stored in this repository.",
+  "remainingInputs": [
+    "A non-production web-host deployment mechanism for LIVE-01 redirect and LIVE-02 indexability mutations",
+    "Exact test hostnames, DNS record allowlist, initial values, and previous TTLs",
+    "DNSOPS_TEST_MAIL_SUBDOMAIN and an explicit no-real-mail dependency assertion for that hostname",
+    "Manual-work baseline, portfolio classification, and playbook approval"
+  ],
+  "prohibitedActionsUntilRemainingInputsExist": [
+    "DNS record mutations",
+    "Provider harness apply/restore operations",
+    "LIVE-01 through LIVE-03 execution"
+  ]
+}

--- a/docs/domain-operations/evidence/gate-3/asorin-test-zone-preflight.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-test-zone-preflight.json
@@ -23,7 +23,16 @@
     "credentialValueRecorded": false
   },
   "scopeCaveat": "The successful token verification and asorin.ai readback prove usable access to this zone. Cloudflare Dashboard configuration remains the authority for confirming its intended least-privilege policy; no token value is stored in this repository.",
+  "railwayFixture": {
+    "projectId": "0e240f31-311a-4140-9dbf-c18c485d9820",
+    "projectName": "dnsops-live-fixtures",
+    "environmentId": "e6c3a4d7-2cce-4e2a-8d81-9b7e433dcd1d",
+    "serviceId": "4197eca1-a820-4f2f-8706-46cba7a0740d",
+    "serviceName": "controlled-live-web",
+    "status": "PROVISIONED_NOT_DEPLOYED_PENDING_LOCAL_CONTROL_SECRET"
+  },
   "remainingInputs": [
+    "A locally stored DNSOPS_FIXTURE_CONTROL_TOKEN for the Railway fixture; its value must not be sent to chat or Git",
     "A non-production web-host deployment mechanism for LIVE-01 redirect and LIVE-02 indexability mutations",
     "Exact test hostnames, DNS record allowlist, initial values, and previous TTLs",
     "DNSOPS_TEST_MAIL_SUBDOMAIN and an explicit no-real-mail dependency assertion for that hostname",

--- a/docs/domain-operations/evidence/gate-3/asorin-test-zone-preflight.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-test-zone-preflight.json
@@ -29,7 +29,23 @@
     "environmentId": "e6c3a4d7-2cce-4e2a-8d81-9b7e433dcd1d",
     "serviceId": "4197eca1-a820-4f2f-8706-46cba7a0740d",
     "serviceName": "controlled-live-web",
-    "status": "PROVISIONED_NOT_DEPLOYED_PENDING_LOCAL_CONTROL_SECRET"
+    "status": "DEPLOYED_PENDING_CLOUDFLARE_DNS_CONFIGURATION",
+    "deploymentId": "258377b9-bf88-422f-947c-a41d691cb8af",
+    "serviceDomain": "controlled-live-web-production.up.railway.app",
+    "customDomains": {
+      "asorin.ai": {
+        "railwayDomainId": "110e3e42-141b-4f3a-9328-3a6dff4b9851",
+        "requiredCnameTarget": "epgybwo0.up.railway.app",
+        "requiredVerificationHost": "_railway-verify",
+        "verificationTokenPresent": true
+      },
+      "www.asorin.ai": {
+        "railwayDomainId": "efe59266-2b4a-476b-b189-f5e660ac8da8",
+        "requiredCnameTarget": "4xbfxxr5.up.railway.app",
+        "requiredVerificationHost": "_railway-verify.www",
+        "verificationTokenPresent": true
+      }
+    }
   },
   "remainingInputs": [
     "A locally stored DNSOPS_FIXTURE_CONTROL_TOKEN for the Railway fixture; its value must not be sent to chat or Git",

--- a/docs/domain-operations/evidence/gate-3/bounded-http-web-evidence.json
+++ b/docs/domain-operations/evidence/gate-3/bounded-http-web-evidence.json
@@ -1,0 +1,30 @@
+{
+  "evidenceId": "GATE3-BOUNDED-HTTP-WEB-EVIDENCE",
+  "recordedAt": "2026-07-29T14:42:36Z",
+  "implementationBaseSha": "14c3ca3290f4db0ca65e134685779643045c277e",
+  "scope": "Deterministic bounded HTTP reachability, redirect topology, and homepage indexability collection; no live portfolio scan",
+  "assertions": [
+    "Exactly four homepage starts are collected: HTTP/HTTPS multiplied by apex/www",
+    "Redirects are manual, bounded, and every hop validates all resolved public IP addresses",
+    "Automatic redirect following, arbitrary initial paths, credentials, fragments, and IP-literal targets are rejected",
+    "Unsafe or token-bearing redirect targets stop probing and require manual review without retaining the target URL",
+    "Response bodies are released on normal, malformed redirect, bound, content-type, and parser-error paths",
+    "Indexability reads only HTML/XHTML with a bounded body and records normalized X-Robots-Tag, robots meta, and canonical evidence",
+    "A failed indexability parse does not discard already observed reachability or redirect evidence",
+    "Probe failures are actionable UNKNOWN setup/evidence states and do not create findings, signals, alerts, or cases"
+  ],
+  "validation": {
+    "focused": "9 HTTP collector tests passed; independent review CLEAN",
+    "lint": "8 of 8 workspace tasks passed",
+    "typecheck": "14 of 14 workspace tasks passed",
+    "deterministicSuite": "2636 passed, 41 skipped; 149 files passed, 3 skipped",
+    "build": "8 of 8 workspace tasks passed",
+    "schemaDrift": "NO DRIFT"
+  },
+  "residualRisk": "HTTP fetch independently resolves the hostname after safe-address preflight; DNS address pinning remains future hardening and this collector does not claim complete rebinding prevention.",
+  "safety": {
+    "liveNetworkUsedByTests": false,
+    "providerWritesAdded": false,
+    "liveMutations": false
+  }
+}

--- a/docs/domain-operations/evidence/gate-3/bounded-rdap-evidence.json
+++ b/docs/domain-operations/evidence/gate-3/bounded-rdap-evidence.json
@@ -1,0 +1,31 @@
+{
+  "evidenceId": "GATE3-BOUNDED-RDAP-EVIDENCE",
+  "recordedAt": "2026-07-29T12:38:18Z",
+  "implementationBaseSha": "7015fbae3e95bcca5458e8a523bd386b500706e3",
+  "scope": "Deterministic bounded RDAP expiration collection; no live portfolio scan",
+  "assertions": [
+    "The trust root is the fixed IANA DNS RDAP bootstrap URL",
+    "Only bootstrap-declared HTTPS services are queried and redirects are rejected",
+    "Credentials, fragments, private/reserved addresses, complete IPv6 local/multicast ranges, mapped-address variants, and zone-scoped IPv6 targets are rejected",
+    "One cumulative deadline covers bootstrap and service DNS resolution, fetch, and streamed body reads",
+    "Declared and streamed bodies are bounded before excess data is retained",
+    "The response must identify the exact requested domain",
+    "RDAP event dates require calendar-valid RFC3339 date-time syntax",
+    "Missing, malformed, mismatched, and conflicting expiration evidence remains actionable UNKNOWN",
+    "No test performs live DNS or HTTP and no condition creates a signal, alert, case, or finding"
+  ],
+  "validation": {
+    "focused": "169 tests passed across RDAP and SSRF suites",
+    "lint": "8 of 8 workspace tasks passed",
+    "typecheck": "14 of 14 workspace tasks passed",
+    "deterministicSuite": "2618 passed, 41 skipped; 147 files passed, 3 skipped",
+    "build": "8 of 8 workspace tasks passed",
+    "schemaDrift": "NO DRIFT"
+  },
+  "residualRisk": "The HTTP fetch connection independently resolves DNS after safe-address preflight; address pinning remains future hardening and is not represented as complete rebinding prevention.",
+  "safety": {
+    "liveNetworkUsedByTests": false,
+    "providerWritesAdded": false,
+    "liveMutations": false
+  }
+}

--- a/docs/domain-operations/evidence/gate-3/bounded-tls-evidence.json
+++ b/docs/domain-operations/evidence/gate-3/bounded-tls-evidence.json
@@ -1,0 +1,32 @@
+{
+  "evidenceId": "GATE3-BOUNDED-TLS-EVIDENCE",
+  "recordedAt": "2026-07-29T13:03:26Z",
+  "implementationBaseSha": "812361ae96724bdee091b53e084222cadf6cdd66",
+  "scope": "Deterministic bounded HTTPS TLS certificate evidence; no live portfolio scan",
+  "assertions": [
+    "Every resolver result must be a zone-free public IP and all results pass SSRF validation",
+    "One deterministic address is used directly while the registered hostname remains SNI",
+    "One permissive observational handshake captures the same certificate for chain and hostname evaluation",
+    "Chain authorization comes from TLSSocket.authorized with handshake hostname checking disabled",
+    "Hostname authorization is evaluated separately with tls.checkServerIdentity",
+    "Invalid certificates remain determined evidence rather than disappearing as successful or absent",
+    "Certificate identity, issuer, SANs, validity dates, protocol, cipher, and SHA-256 fingerprint are typed",
+    "SAN parsing is quote-aware and discards malformed or fabricated names",
+    "One cumulative deadline covers DNS and handshake; normal, error, and abort paths destroy the socket",
+    "Target identity is checked at the connector boundary and failures remain actionable UNKNOWN",
+    "No test performs live DNS or TLS and no signal, alert, case, or finding is created"
+  ],
+  "validation": {
+    "focused": "9 TLS collector tests passed; independent review CLEAN",
+    "lint": "8 of 8 workspace tasks passed",
+    "typecheck": "14 of 14 workspace tasks passed",
+    "deterministicSuite": "2627 passed, 41 skipped; 148 files passed, 3 skipped",
+    "build": "8 of 8 workspace tasks passed",
+    "schemaDrift": "NO DRIFT"
+  },
+  "safety": {
+    "liveNetworkUsedByTests": false,
+    "providerWritesAdded": false,
+    "liveMutations": false
+  }
+}

--- a/docs/domain-operations/evidence/gate-3/computin-test-zone-delegation-preflight.json
+++ b/docs/domain-operations/evidence/gate-3/computin-test-zone-delegation-preflight.json
@@ -1,0 +1,44 @@
+{
+  "evidenceId": "GATE3-COMPUTIN-TEST-ZONE-DELEGATION-PREFLIGHT",
+  "recordedAt": "2026-08-04T15:52:46Z",
+  "status": "AUTHORIZED_PENDING_CLOUDFLARE_AUTHENTICATION",
+  "founderAuthorization": {
+    "author": "Antonio",
+    "authorizedAction": "Create and delegate dnsops-test.computin.dev as an isolated child DNS zone.",
+    "rollbackAndRevocationOwner": "Antonio",
+    "explicitExclusions": [
+      "computin.dev apex",
+      "existing MX records",
+      "existing SPF records",
+      "existing DKIM records",
+      "existing DMARC records"
+    ]
+  },
+  "readOnlyPreflight": {
+    "parentZone": "computin.dev",
+    "parentAuthoritativeNameservers": [
+      "olivia.ns.cloudflare.com",
+      "mcgrory.ns.cloudflare.com"
+    ],
+    "parentNsObservedTtlSeconds": 2198,
+    "childZone": "dnsops-test.computin.dev",
+    "childDelegationPresent": false,
+    "negativeResponse": {
+      "soaZone": "computin.dev",
+      "soaMinimumTtlSeconds": 1800
+    }
+  },
+  "executionBoundary": {
+    "provider": "Cloudflare",
+    "wranglerAuthentication": "not authenticated; wrangler whoami instructed the operator to run wrangler login",
+    "credentialHandling": "No token value was requested, read, logged, or committed.",
+    "permittedNextMutation": "Create the child Cloudflare zone and add only its delegation NS records at dnsops-test.computin.dev after an authenticated operator session is available."
+  },
+  "remainingInputs": [
+    "Cloudflare authenticated session or an approved harness runtime-secret reference after the child zone exists",
+    "DNSOPS_TEST_WEB_HOST and a non-production deployment mechanism for redirect and indexability fixtures",
+    "DNSOPS_TEST_MAIL_SUBDOMAIN with confirmation of no real mail dependency",
+    "Exact record allowlist, baseline values, and previous TTLs",
+    "Manual-work baseline, portfolio classification, and playbook approval"
+  ]
+}

--- a/docs/domain-operations/evidence/gate-3/computin-test-zone-delegation-preflight.json
+++ b/docs/domain-operations/evidence/gate-3/computin-test-zone-delegation-preflight.json
@@ -30,9 +30,9 @@
   },
   "executionBoundary": {
     "provider": "Cloudflare",
-    "wranglerAuthentication": "not authenticated; wrangler whoami instructed the operator to run wrangler login",
+    "wranglerAuthentication": "not authenticated. A wrangler login attempt was stopped before authentication because its OAuth request included broad unrelated write scopes; it is not an approved provisioning credential.",
     "credentialHandling": "No token value was requested, read, logged, or committed.",
-    "permittedNextMutation": "Create the child Cloudflare zone and add only its delegation NS records at dnsops-test.computin.dev after an authenticated operator session is available."
+    "permittedNextMutation": "An authenticated human operator creates the child Cloudflare zone and adds only its delegation NS records at dnsops-test.computin.dev, then provisions a child-zone-only DNS token for the future harness."
   },
   "remainingInputs": [
     "Cloudflare authenticated session or an approved harness runtime-secret reference after the child zone exists",

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,13 +1,14 @@
 {
   "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
-  "recordedAt": "2026-07-30T01:35:00Z",
+  "recordedAt": "2026-07-30T01:40:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
     "The runbook FaultRunArtifact contract for LIVE-01 through LIVE-03 evidence",
     "Runtime validation of plain enumerable data, bounded arrays, SHA-256 baseline/credential fingerprints, canonical DNS target names, UTC calendar-valid timestamps, and recovery-result requirements",
     "Redacted provider-response operation/status summaries only, plus identifier checks that reject credential/header/token/API/private-key material",
-    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, safe non-executable provider-operation references, and chronological application/restoration timestamps with restoration requiring an application timestamp"
+    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, safe non-executable provider-operation references, and chronological application/restoration timestamps with restoration requiring an application timestamp",
+    "A PASS artifact requires both application and restoration timestamps"
   ],
   "verification": {
     "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
@@ -30,7 +31,7 @@
     "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
   ],
   "review": {
-    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, cookie/session, opaque credential recovery-text, restoration-before-application, and restoration-without-application boundaries. Final re-review found no remaining code-level security or correctness blocker."
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, cookie/session, opaque credential recovery-text, restoration-before-application, restoration-without-application, and completed-run-without-restoration-evidence boundaries. Final re-review found no remaining code-level security or correctness blocker."
   },
   "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
 }

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,12 +1,13 @@
 {
   "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
-  "recordedAt": "2026-07-29T20:00:00Z",
+  "recordedAt": "2026-07-30T01:06:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
     "The runbook FaultRunArtifact contract for LIVE-01 through LIVE-03 evidence",
     "Runtime validation of plain enumerable data, bounded arrays, SHA-256 baseline/credential fingerprints, canonical DNS target names, UTC calendar-valid timestamps, and recovery-result requirements",
-    "Redacted provider-response operation/status summaries only, plus identifier and recovery-instruction checks that reject credential/header/token/API/private-key material"
+    "Redacted provider-response operation/status summaries only, plus identifier checks that reject credential/header/token/API/private-key material",
+    "A structured RECOVERY_REQUIRED payload with provider, zone, exact recovery records/desired values, and safe operator commands"
   ],
   "verification": {
     "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
@@ -29,7 +30,7 @@
     "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
   ],
   "review": {
-    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, and opaque credential-shaped identifier leakage boundaries. Final re-review found no remaining code-level security or correctness blocker."
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, and incomplete recovery-payload boundaries. Final re-review found no remaining code-level security or correctness blocker."
   },
   "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
 }

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,13 +1,13 @@
 {
   "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
-  "recordedAt": "2026-07-30T01:06:00Z",
+  "recordedAt": "2026-07-30T01:12:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
     "The runbook FaultRunArtifact contract for LIVE-01 through LIVE-03 evidence",
     "Runtime validation of plain enumerable data, bounded arrays, SHA-256 baseline/credential fingerprints, canonical DNS target names, UTC calendar-valid timestamps, and recovery-result requirements",
     "Redacted provider-response operation/status summaries only, plus identifier checks that reject credential/header/token/API/private-key material",
-    "A structured RECOVERY_REQUIRED payload with provider, zone, exact recovery records/desired values, and safe operator commands"
+    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, and safe operator commands"
   ],
   "verification": {
     "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
@@ -30,7 +30,7 @@
     "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
   ],
   "review": {
-    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, and incomplete recovery-payload boundaries. Final re-review found no remaining code-level security or correctness blocker."
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, and unrelated-zone/target recovery boundaries. Final re-review found no remaining code-level security or correctness blocker."
   },
   "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
 }

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,13 +1,13 @@
 {
   "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
-  "recordedAt": "2026-07-30T01:25:00Z",
+  "recordedAt": "2026-07-30T01:30:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
     "The runbook FaultRunArtifact contract for LIVE-01 through LIVE-03 evidence",
     "Runtime validation of plain enumerable data, bounded arrays, SHA-256 baseline/credential fingerprints, canonical DNS target names, UTC calendar-valid timestamps, and recovery-result requirements",
     "Redacted provider-response operation/status summaries only, plus identifier checks that reject credential/header/token/API/private-key material",
-    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, and safe non-executable provider-operation references"
+    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, safe non-executable provider-operation references, and chronological application/restoration timestamps"
   ],
   "verification": {
     "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
@@ -30,7 +30,7 @@
     "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
   ],
   "review": {
-    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, cookie/session, and opaque credential recovery-text boundaries. Final re-review found no remaining code-level security or correctness blocker."
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, cookie/session, opaque credential recovery-text, and restoration-before-application boundaries. Final re-review found no remaining code-level security or correctness blocker."
   },
   "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
 }

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,13 +1,13 @@
 {
   "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
-  "recordedAt": "2026-07-30T01:17:00Z",
+  "recordedAt": "2026-07-30T01:25:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
     "The runbook FaultRunArtifact contract for LIVE-01 through LIVE-03 evidence",
     "Runtime validation of plain enumerable data, bounded arrays, SHA-256 baseline/credential fingerprints, canonical DNS target names, UTC calendar-valid timestamps, and recovery-result requirements",
     "Redacted provider-response operation/status summaries only, plus identifier checks that reject credential/header/token/API/private-key material",
-    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, and safe operator commands"
+    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, and safe non-executable provider-operation references"
   ],
   "verification": {
     "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
@@ -30,7 +30,7 @@
     "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
   ],
   "review": {
-    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, and cookie/session recovery-command credential boundaries. Final re-review found no remaining code-level security or correctness blocker."
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, cookie/session, and opaque credential recovery-text boundaries. Final re-review found no remaining code-level security or correctness blocker."
   },
   "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
 }

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,0 +1,35 @@
+{
+  "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
+  "recordedAt": "2026-07-29T19:51:00Z",
+  "source": "packages/contracts/src/live-fault-harness.ts",
+  "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
+  "implements": [
+    "The runbook FaultRunArtifact contract for LIVE-01 through LIVE-03 evidence",
+    "Runtime validation of plain enumerable data, bounded arrays, SHA-256 baseline/credential fingerprints, canonical DNS target names, UTC calendar-valid timestamps, and recovery-result requirements",
+    "Redacted provider-response operation/status summaries only, plus identifier and recovery-instruction checks that reject credential/header/token/API/private-key material"
+  ],
+  "verification": {
+    "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
+    "result": "9 passed",
+    "additional": [
+      "bunx biome check packages/contracts/src/live-fault-harness.ts packages/contracts/src/live-fault-harness.test.ts packages/contracts/src/index.ts passed",
+      "bun run --filter @dns-ops/contracts typecheck passed"
+    ]
+  },
+  "safety": {
+    "providerClient": false,
+    "providerToken": false,
+    "networkCalls": false,
+    "dnsOpsProviderWrites": false,
+    "mcpProviderWrites": false
+  },
+  "notClaimed": [
+    "A concrete provider adapter, runtime secret resolution, or live operator command",
+    "Provider mutation, restoration, LIVE-01/LIVE-02/LIVE-03 execution, or live artifact generation",
+    "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
+  ],
+  "review": {
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, and recovery-prose credential leakage boundaries. Final review found no remaining code-level security or correctness blocker."
+  },
+  "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
+}

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,6 +1,6 @@
 {
   "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
-  "recordedAt": "2026-07-29T19:51:00Z",
+  "recordedAt": "2026-07-29T20:00:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
@@ -29,7 +29,7 @@
     "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
   ],
   "review": {
-    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, and recovery-prose credential leakage boundaries. Final review found no remaining code-level security or correctness blocker."
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, and opaque credential-shaped identifier leakage boundaries. Final re-review found no remaining code-level security or correctness blocker."
   },
   "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
 }

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,6 +1,6 @@
 {
   "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
-  "recordedAt": "2026-07-30T01:12:00Z",
+  "recordedAt": "2026-07-30T01:17:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
@@ -30,7 +30,7 @@
     "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
   ],
   "review": {
-    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, and unrelated-zone/target recovery boundaries. Final re-review found no remaining code-level security or correctness blocker."
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, and cookie/session recovery-command credential boundaries. Final re-review found no remaining code-level security or correctness blocker."
   },
   "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
 }

--- a/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
+++ b/docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json
@@ -1,13 +1,13 @@
 {
   "evidenceId": "GATE3-FAULT-RUN-ARTIFACT-POLICY",
-  "recordedAt": "2026-07-30T01:30:00Z",
+  "recordedAt": "2026-07-30T01:35:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
     "The runbook FaultRunArtifact contract for LIVE-01 through LIVE-03 evidence",
     "Runtime validation of plain enumerable data, bounded arrays, SHA-256 baseline/credential fingerprints, canonical DNS target names, UTC calendar-valid timestamps, and recovery-result requirements",
     "Redacted provider-response operation/status summaries only, plus identifier checks that reject credential/header/token/API/private-key material",
-    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, safe non-executable provider-operation references, and chronological application/restoration timestamps"
+    "A structured RECOVERY_REQUIRED payload with provider, artifact-bound zone, exact artifact-target recovery records/desired values, safe non-executable provider-operation references, and chronological application/restoration timestamps with restoration requiring an application timestamp"
   ],
   "verification": {
     "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
@@ -30,7 +30,7 @@
     "Replacement of issue #4 authorization, assets, allowlist, TTL, and rollback prerequisites"
   ],
   "review": {
-    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, cookie/session, opaque credential recovery-text, and restoration-before-application boundaries. Final re-review found no remaining code-level security or correctness blocker."
+    "result": "Iterative independent review found and remediation covered response/header, timestamp, canonical-input, zone-identifier, target-name, recovery-prose, policy/request zone, opaque credential-shaped identifier, incomplete recovery-payload, unrelated-zone/target recovery, cookie/session, opaque credential recovery-text, restoration-before-application, and restoration-without-application boundaries. Final re-review found no remaining code-level security or correctness blocker."
   },
   "nextAction": "A selected-provider harness must emit this validated artifact only after its explicit allowlist policy passes; it remains blocked on the issue #4 manifest and authority."
 }

--- a/docs/domain-operations/evidence/gate-3/fix-05-stale-evidence.json
+++ b/docs/domain-operations/evidence/gate-3/fix-05-stale-evidence.json
@@ -1,0 +1,34 @@
+{
+  "evidenceId": "FIX-05-STALE-TLS-EVIDENCE",
+  "recordedAt": "2026-07-29T18:09:00Z",
+  "implementationSha": "708013e28290799d425937474fd130e15a0db9a6",
+  "scope": "Deterministic non-live stale TLS evidence classification",
+  "fixture": {
+    "baseline": "accepted TLS certificate baseline with maxEvidenceAgeSeconds=1",
+    "observation": "TLS_CERTIFICATE probe captured two seconds before deterministic evaluation time",
+    "violationFields": {
+      "hostnameAuthorized": false,
+      "chainAuthorized": true
+    }
+  },
+  "expected": {
+    "classification": "EVIDENCE_STALE setup/evidence",
+    "canonicalObservation": false,
+    "alertDelivery": false
+  },
+  "proof": {
+    "test": "apps/collector/src/jobs/operational-condition-finalizer.test.ts :: does not send stale TLS evidence",
+    "assertions": [
+      "evaluation.setupEvidence contains EVIDENCE_STALE",
+      "observer.observe is not called",
+      "send is not called"
+    ],
+    "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+    "result": "2713 passed, 41 skipped"
+  },
+  "safety": {
+    "liveDns": false,
+    "providerWrites": false,
+    "productionWrites": false
+  }
+}

--- a/docs/domain-operations/evidence/gate-3/fix-06-canonical-dedup.json
+++ b/docs/domain-operations/evidence/gate-3/fix-06-canonical-dedup.json
@@ -1,0 +1,37 @@
+{
+  "evidenceId": "FIX-06-CANONICAL-DEDUPE-AND-DELIVERY",
+  "recordedAt": "2026-07-29T18:09:00Z",
+  "implementationSha": "708013e28290799d425937474fd130e15a0db9a6",
+  "scope": "Deterministic non-live duplicate observation, canonical lifecycle, and notification proof",
+  "fixture": {
+    "condition": "MAIL_DNS_CONFIGURATION_REGRESSION",
+    "tenant": "tenant-1",
+    "domain": "domain-1",
+    "duplicateInput": "same complete snapshot and canonical observation submitted twice"
+  },
+  "expected": {
+    "signals": 1,
+    "activeCases": 1,
+    "activeAlerts": 1,
+    "firstDelivery": 1,
+    "duplicateDelivery": 0,
+    "reopenDelivery": 1
+  },
+  "proof": {
+    "persistenceTest": "packages/db/src/repos/operations.test.ts :: deduplicates repeated observations to one signal, case, and alert",
+    "lifecycleTest": "packages/db/src/repos/operations.test.ts :: resolves from fresh evidence and reopens the same operational objects",
+    "deliveryTest": "apps/collector/src/jobs/operational-condition-finalizer.test.ts :: sends only newly-created or reopened canonical alerts",
+    "assertions": [
+      "two repeated observations create one internal signal, one internal case, one alert, and one opening event",
+      "resolution and a newer regression reuse those same operational object IDs",
+      "delivery occurs for initial create and reopen only, never for the duplicate observation"
+    ],
+    "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+    "result": "2713 passed, 41 skipped"
+  },
+  "safety": {
+    "liveDns": false,
+    "providerWrites": false,
+    "productionWrites": false
+  }
+}

--- a/docs/domain-operations/evidence/gate-3/mcp-harness-matrix.json
+++ b/docs/domain-operations/evidence/gate-3/mcp-harness-matrix.json
@@ -1,0 +1,54 @@
+{
+  "evidenceId": "MCP-PHASE1-DETERMINISTIC-HARNESS",
+  "recordedAt": "2026-07-29T18:32:00Z",
+  "implementationSha": "2a3b0b2d758e9b72148dbe85c9bbadc03fcaf2ad",
+  "scope": "Deterministic non-live Phase 1 MCP contract and shared-service proof",
+  "requirements": [
+    {
+      "requirement": "all ten schemas and successful typed results",
+      "evidence": "apps/web/hono/routes/mcp.harness.test.ts invokes every closed-contract tool through JSON-RPC and asserts structuredContent."
+    },
+    {
+      "requirement": "invalid tool input and invalid JSON-RPC IDs",
+      "evidence": "mcp.harness.test.ts rejects malformed schema arguments; apps/web/hono/routes/mcp.test.ts rejects boolean request IDs with -32600."
+    },
+    {
+      "requirement": "disabled principal and insufficient scope",
+      "evidence": "apps/web/hono/lib/mcp-auth.test.ts rejects disabled principals and denied scopes; apps/web/hono/routes/mcp.test.ts confirms scoped discovery; read, case, and scan service tests deny persistence before an absent scope."
+    },
+    {
+      "requirement": "cross-tenant denial",
+      "evidence": "apps/web/hono/lib/mcp-scan-service.command.test.ts denies an owned-domain mismatch before command claim or collector proxy; packages/db/src/repos/operations.test.ts rejects cross-tenant canonical observation and case access."
+    },
+    {
+      "requirement": "stale evidence does not signal",
+      "evidence": "docs/domain-operations/evidence/gate-3/fix-05-stale-evidence.json and apps/collector/src/jobs/operational-condition-finalizer.test.ts prove stale TLS evidence has EVIDENCE_STALE setup state with no observer or notification."
+    },
+    {
+      "requirement": "duplicate case_open and stale expectedVersion",
+      "evidence": "apps/web/hono/lib/mcp-case-command-service.failure.test.ts proves same-key case-open replay avoids a second canonical-service call and returns only CASE_VERSION_STALE for an optimistic concurrency conflict; packages/db/src/repos/operations.test.ts proves audit-event creation."
+    },
+    {
+      "requirement": "scan idempotency and rate limiting",
+      "evidence": "apps/web/hono/lib/mcp-scan-service.command.test.ts proves replay-before-proxy, durable rate-limit failure, cross-tenant denial, and rejected-proxy completion; mcp-scan-rate-limit.test.ts proves the collector-aligned incremental token-bucket refill."
+    },
+    {
+      "requirement": "application-service parity and no exception leakage",
+      "evidence": "MCP case commands and UI case routes both use OperationalConditionService; MCP scan and UI collection both use proxyToCollector. apps/web/hono/lib/mcp-dispatch.test.ts maps unexpected exceptions to generic -32603, while command tests persist generic failures without internal messages."
+    }
+  ],
+  "validation": {
+    "command": "RUN_LIVE_DNS_TESTS=0 bun run test",
+    "result": "2721 passed, 41 skipped"
+  },
+  "safety": {
+    "liveDns": false,
+    "providerWrites": false,
+    "productionWrites": false,
+    "mcpProviderWrites": false
+  },
+  "remainingExternalBlockers": [
+    "Controlled live-loop proof and authoritative mutation evidence require issue #4 prerequisites.",
+    "Isolated PostgreSQL migration/concurrency verification requires an isolated DATABASE_URL."
+  ]
+}

--- a/docs/domain-operations/evidence/gate-3/provider-harness-policy.json
+++ b/docs/domain-operations/evidence/gate-3/provider-harness-policy.json
@@ -1,6 +1,6 @@
 {
   "evidenceId": "GATE3-PROVIDER-HARNESS-POLICY",
-  "recordedAt": "2026-07-29T19:12:00Z",
+  "recordedAt": "2026-07-29T19:52:00Z",
   "source": "packages/contracts/src/live-fault-harness.ts",
   "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
   "implements": [
@@ -11,11 +11,11 @@
   ],
   "verification": {
     "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
-    "result": "7 passed",
+    "result": "9 passed",
     "additional": [
       "bunx biome check packages/contracts/src/live-fault-harness.ts packages/contracts/src/live-fault-harness.test.ts packages/contracts/src/index.ts passed",
       "bun run --filter @dns-ops/contracts typecheck passed",
-      "bun run lint, RUN_LIVE_DNS_TESTS=0 bun run test (2728 passed, 41 skipped), bun run typecheck, bun run build, and bun run --filter @dns-ops/db check-drift all passed"
+      "bun run lint, RUN_LIVE_DNS_TESTS=0 bun run test (2730 passed, 41 skipped), bun run typecheck, bun run build, and bun run --filter @dns-ops/db check-drift all passed"
     ]
   },
   "safety": {

--- a/docs/domain-operations/evidence/gate-3/provider-harness-policy.json
+++ b/docs/domain-operations/evidence/gate-3/provider-harness-policy.json
@@ -1,0 +1,39 @@
+{
+  "evidenceId": "GATE3-PROVIDER-HARNESS-POLICY",
+  "recordedAt": "2026-07-29T19:12:00Z",
+  "source": "packages/contracts/src/live-fault-harness.ts",
+  "status": "NON_LIVE_SAFETY_INFRASTRUCTURE_COMPLETE",
+  "implements": [
+    "Secret-free controlled-fault policy with only a provider credential SHA-256 fingerprint",
+    "Validation that test web/mail assets and every allowlisted record remain inside the designated test domain",
+    "Exact zone/name/record-type/LIVE mutation authorization",
+    "Fail-closed rejection of malformed/non-plain, accessor-backed, non-enumerable, or symbol-bearing objects and unknown or credential-bearing fields at both policy and allowlist-entry levels, sparse/oversized arrays, duplicate type/mutation values, malformed fingerprints, duplicate allowlist entries, and unallowlisted tuple requests"
+  ],
+  "verification": {
+    "command": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
+    "result": "7 passed",
+    "additional": [
+      "bunx biome check packages/contracts/src/live-fault-harness.ts packages/contracts/src/live-fault-harness.test.ts packages/contracts/src/index.ts passed",
+      "bun run --filter @dns-ops/contracts typecheck passed",
+      "bun run lint, RUN_LIVE_DNS_TESTS=0 bun run test (2728 passed, 41 skipped), bun run typecheck, bun run build, and bun run --filter @dns-ops/db check-drift all passed"
+    ]
+  },
+  "safety": {
+    "providerClient": false,
+    "providerToken": false,
+    "dnsOpsProviderWrites": false,
+    "mcpProviderWrites": false,
+    "networkCalls": false
+  },
+  "review": {
+    "result": "Independent review found nested own-property, inherited-property, non-enumerable/symbol, accessor-time-of-check/time-of-use, sparse-array length denial-of-service, and unbounded dense-array boundaries. The policy now snapshots descriptor-validated enumerable data before authorization, rejects sparse arrays by descriptor count, bounds allowlist/type/mutation cardinality, and rejects duplicate values; focused regression tests cover the reported boundaries.",
+    "remainingFinding": "No concrete provider adapter exists until issue #4 supplies its provider/test-host manifest."
+  },
+  "notClaimed": [
+    "A concrete provider adapter or live operator commands",
+    "Credential resolution or provider API access",
+    "LIVE-01 through LIVE-03 execution",
+    "Replacement of the provider/test-host manifest and rollback authorization required by issue #4"
+  ],
+  "nextAction": "After the selected provider and test-host manifest are supplied, require its adapter to call authorizeControlledFaultMutation before every provider operation and implement the concrete runbook commands."
+}

--- a/docs/domain-operations/evidence/gate-3/provider-harness-readiness.json
+++ b/docs/domain-operations/evidence/gate-3/provider-harness-readiness.json
@@ -1,0 +1,30 @@
+{
+  "evidenceId": "GATE3-PROVIDER-HARNESS-READINESS",
+  "recordedAt": "2026-07-29T19:02:00Z",
+  "status": "BLOCKED_BY_TEST_ASSET",
+  "auditScope": "Controlled LIVE-01 through LIVE-03 harness readiness under V4.1 and the autonomous-completion amendment.",
+  "facts": [
+    "The repository has no provider fault-injection harness, provider SDK adapter, DNSOPS_TEST configuration, or provider API client.",
+    "The existing MCP harness is deterministic application-contract coverage and is not a provider mutation harness.",
+    "The amendment authorizes a no-secret, explicit-allowlist harness but continues to block provider credentials and controlled live mutations until founder inputs are supplied."
+  ],
+  "requiredExternalInputs": [
+    "Authorized non-production test domain, web host, mail subdomain, and zone ID",
+    "Provider kind and a scoped runtime-secret name plus non-secret fingerprint",
+    "Exact mutable hostnames, record types, and LIVE-01/02/03 mutation mapping",
+    "Previous TTLs and a baseline/rollback procedure",
+    "Test-host deployment mutation mechanism for redirect/indexability where the provider alone cannot perform it",
+    "Baseline, rollback, and token-revocation owner"
+  ],
+  "whyImplementationCannotProceed": [
+    "Provider zone/record identity, readback, TTL, restoration, and audit behavior are provider-specific.",
+    "LIVE-01 and LIVE-02 may require a test-host deployment mechanism, which is not identified.",
+    "A provider-agnostic command runner with unimplemented adapters would be a prohibited stub and could not honestly expose prepare/apply/verify/restore/recover behavior."
+  ],
+  "safeCompletedWork": [
+    "The controlled-test runbook defines the required allowlist, artifact, TTL, authoritative-evidence, restoration, and recovery contract.",
+    "No DNS Ops application or MCP provider-write capability was added.",
+    "No credential was requested, read, logged, or used."
+  ],
+  "nextAction": "After Issue #4 supplies the provider and asset manifest, implement and test the concrete isolated harness, then run LIVE-01 through LIVE-03 only through that harness."
+}

--- a/docs/domain-operations/evidence/gate-3/provider-harness-readiness.json
+++ b/docs/domain-operations/evidence/gate-3/provider-harness-readiness.json
@@ -4,7 +4,7 @@
   "status": "BLOCKED_BY_TEST_ASSET",
   "auditScope": "Controlled LIVE-01 through LIVE-03 harness readiness under V4.1 and the autonomous-completion amendment.",
   "facts": [
-    "The repository has no provider fault-injection harness, provider SDK adapter, DNSOPS_TEST configuration, or provider API client.",
+    "The repository has no provider fault-injection command runner, provider SDK adapter, DNSOPS_TEST runtime configuration, or provider API client; it now has a tested pure allowlist-policy module only.",
     "The existing MCP harness is deterministic application-contract coverage and is not a provider mutation harness.",
     "The amendment authorizes a no-secret, explicit-allowlist harness but continues to block provider credentials and controlled live mutations until founder inputs are supplied."
   ],
@@ -23,6 +23,7 @@
   ],
   "safeCompletedWork": [
     "The controlled-test runbook defines the required allowlist, artifact, TTL, authoritative-evidence, restoration, and recovery contract.",
+    "The tested packages/contracts/src/live-fault-harness.ts policy rejects secret-bearing configuration and exact tuple escapes without implementing any provider client.",
     "No DNS Ops application or MCP provider-write capability was added.",
     "No credential was requested, read, logged, or used."
   ],

--- a/docs/domain-operations/evidence/gate-3/signal-case-foundation.json
+++ b/docs/domain-operations/evidence/gate-3/signal-case-foundation.json
@@ -1,0 +1,37 @@
+{
+  "evidenceId": "GATE3-SIGNAL-CASE-FOUNDATION",
+  "recordedAt": "2026-07-29T04:29:21Z",
+  "implementationBaseSha": "78913a402bbfc03c70f4be99aa24083086c2aeec",
+  "scope": "Non-live persistence and lifecycle foundation; not FIX-06 completion",
+  "assertions": [
+    "Exactly six InternalSignalKind values and five InternalCaseStatus values are typed",
+    "Tenant plus bounded canonical condition key uniquely identifies a signal",
+    "One case and one alert are uniquely linked to each signal",
+    "Repeated sequential observation reuses one signal, case, and alert",
+    "Observation validates tenant ownership of domain, snapshot, monitored domain, and optional finding",
+    "Observation and resolution use transactions plus optimistic predicates with bounded conflict retry",
+    "Resolution requires newer complete evidence and an exact cleared condition key",
+    "Verification evidence cannot be replayed as reopening evidence",
+    "A newer concurrent scan can reopen even when captured before resolution commit",
+    "Case lifecycle transitions append audit events only after successful updates",
+    "Unclassified legacy conditions default to DISABLED/NONE",
+    "Mail findings remain explicitly LEGACY_ONLY until production regression evaluation is wired, preventing a silent notification gap"
+  ],
+  "validation": {
+    "targeted": "30 tests passed across operations contracts/repos, condition registry, and alert generation",
+    "lint": "8 of 8 workspace tasks passed",
+    "typecheck": "14 of 14 workspace tasks passed",
+    "deterministicSuite": "2582 passed, 41 skipped; 144 files passed, 3 skipped",
+    "build": "8 of 8 workspace tasks passed",
+    "schemaDrift": "NO DRIFT"
+  },
+  "blockedEvidence": [
+    "Real PostgreSQL migration execution and concurrent Promise.all attestation require an isolated DATABASE_URL",
+    "FIX-06 remains incomplete until production condition evaluation drives the canonical service and proves one notification"
+  ],
+  "safety": {
+    "providerWritesAdded": false,
+    "liveMutations": false,
+    "productionSignalCutover": false
+  }
+}

--- a/docs/domain-operations/evidence/gate-3/signal-case-foundation.json
+++ b/docs/domain-operations/evidence/gate-3/signal-case-foundation.json
@@ -1,8 +1,8 @@
 {
   "evidenceId": "GATE3-SIGNAL-CASE-FOUNDATION",
-  "recordedAt": "2026-07-29T04:29:21Z",
-  "implementationBaseSha": "78913a402bbfc03c70f4be99aa24083086c2aeec",
-  "scope": "Non-live persistence and lifecycle foundation; not FIX-06 completion",
+  "recordedAt": "2026-07-29T18:09:00Z",
+  "implementationBaseSha": "708013e28290799d425937474fd130e15a0db9a6",
+  "scope": "Non-live persistence and lifecycle foundation; superseded for deterministic FIX-06 proof by fix-06-canonical-dedup.json",
   "assertions": [
     "Exactly six InternalSignalKind values and five InternalCaseStatus values are typed",
     "Tenant plus bounded canonical condition key uniquely identifies a signal",
@@ -15,7 +15,8 @@
     "A newer concurrent scan can reopen even when captured before resolution commit",
     "Case lifecycle transitions append audit events only after successful updates",
     "Unclassified legacy conditions default to DISABLED/NONE",
-    "Mail findings remain explicitly LEGACY_ONLY until production regression evaluation is wired, preventing a silent notification gap"
+    "SPF absence is MIGRATED through the baseline-gated canonical path while remaining mail findings are explicitly LEGACY_ONLY",
+    "The canonical finalizer delivers only on initial create and reopen; its duplicate delivery path is covered in fix-06-canonical-dedup.json"
   ],
   "validation": {
     "targeted": "30 tests passed across operations contracts/repos, condition registry, and alert generation",
@@ -27,7 +28,7 @@
   },
   "blockedEvidence": [
     "Real PostgreSQL migration execution and concurrent Promise.all attestation require an isolated DATABASE_URL",
-    "FIX-06 remains incomplete until production condition evaluation drives the canonical service and proves one notification"
+    "Deterministic FIX-06 proof is retained in fix-06-canonical-dedup.json; isolated PostgreSQL concurrency attestation remains pending"
   ],
   "safety": {
     "providerWritesAdded": false,

--- a/docs/domain-operations/evidence/gate-4/clean-checkout-attestation.json
+++ b/docs/domain-operations/evidence/gate-4/clean-checkout-attestation.json
@@ -1,0 +1,21 @@
+{
+  "evidenceId": "GATE4-CLEAN-CHECKOUT-ATTESTATION",
+  "recordedAt": "2026-07-29T18:55:00Z",
+  "reviewedSha": "47e6c4a8b7c3875d6064638405a10426ce7f9a04",
+  "checkout": {
+    "type": "detached disposable git worktree",
+    "path": "/tmp/dnsops-gate4-clean",
+    "statusCommand": "git -C /tmp/dnsops-gate4-clean status --short --branch",
+    "result": "clean detached HEAD",
+    "diffCheckCommand": "git -C /tmp/dnsops-gate4-clean diff --check",
+    "diffCheckResult": "passed"
+  },
+  "notes": [
+    "A fresh reviewer initially generated an untracked .pi-subagents artifact in the disposable checkout; it was removed before this attestation.",
+    "The primary developer worktree intentionally retains excluded agent artifacts unstaged; this attestation demonstrates a separate clean checkout at the same reviewed SHA."
+  ],
+  "remainingBlockers": [
+    "Controlled LIVE-01 through LIVE-03 prerequisites in issue #4.",
+    "Manual-work baseline and founder classification evidence in issue #4."
+  ]
+}

--- a/docs/domain-operations/evidence/gate-4/contract-requirement-audit.json
+++ b/docs/domain-operations/evidence/gate-4/contract-requirement-audit.json
@@ -1,6 +1,6 @@
 {
   "auditId": "PHASE-0-1-CONTRACT-REQUIREMENT-AUDIT",
-  "recordedAt": "2026-07-29T19:35:00Z",
+  "recordedAt": "2026-07-30T01:40:00Z",
   "contract": "docs/domain-operations/phase-0-1-execution-contract-v4.1.md",
   "amendment": "docs/domain-operations/amendments/2026-07-28-autonomous-completion-override.md",
   "verdict": "BLOCKED_BY_EXTERNAL_AUTHORITY",
@@ -53,6 +53,7 @@
         "docs/domain-operations/evidence/gate-4/isolated-browser-smoke.json",
         "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-post-isolation.json",
         "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-live-policy.json",
+        "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-30-final-artifact-validation.json",
         "docs/domain-operations/evidence/gate-4/clean-checkout-attestation.json"
       ]
     }

--- a/docs/domain-operations/evidence/gate-4/contract-requirement-audit.json
+++ b/docs/domain-operations/evidence/gate-4/contract-requirement-audit.json
@@ -1,6 +1,6 @@
 {
   "auditId": "PHASE-0-1-CONTRACT-REQUIREMENT-AUDIT",
-  "recordedAt": "2026-07-29T19:05:00Z",
+  "recordedAt": "2026-07-29T19:35:00Z",
   "contract": "docs/domain-operations/phase-0-1-execution-contract-v4.1.md",
   "amendment": "docs/domain-operations/amendments/2026-07-28-autonomous-completion-override.md",
   "verdict": "BLOCKED_BY_EXTERNAL_AUTHORITY",
@@ -38,11 +38,20 @@
       ]
     },
     {
+      "requirement": "Provider-independent fail-closed allowlist safety layer authorized by the amendment",
+      "evidence": [
+        "packages/contracts/src/live-fault-harness.ts",
+        "packages/contracts/src/live-fault-harness.test.ts",
+        "docs/domain-operations/evidence/gate-3/provider-harness-policy.json"
+      ]
+    },
+    {
       "requirement": "Exact non-live validation, isolated migration/concurrency, browser smoke, and independent non-live review",
       "evidence": [
         "docs/domain-operations/evidence/gate-4/isolated-postgres-migration-concurrency.json",
         "docs/domain-operations/evidence/gate-4/isolated-browser-smoke.json",
         "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-post-isolation.json",
+        "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-live-policy.json",
         "docs/domain-operations/evidence/gate-4/clean-checkout-attestation.json"
       ]
     }
@@ -50,7 +59,7 @@
   "blocked": [
     {
       "requirement": "A concrete, isolated controlled provider/test-host fault harness and LIVE-01 through LIVE-03",
-      "reason": "Provider kind, authorized test asset manifest, exact mutation allowlist, test-host deployment mechanism, TTL history, rollback procedure, and revocation owner are absent. A generic unimplemented provider adapter would violate the no-stubs policy.",
+      "reason": "The provider-independent fail-closed policy is complete, but provider kind, authorized test asset manifest, exact mutation allowlist, test-host deployment mechanism, TTL history, rollback procedure, and revocation owner are absent. A generic unimplemented provider adapter would violate the no-stubs policy.",
       "evidence": "docs/domain-operations/evidence/gate-3/provider-harness-readiness.json"
     },
     {
@@ -66,7 +75,7 @@
     {
       "requirement": "Final Gate 4 PASS review",
       "reason": "The contract requires final live artifacts, manual baseline comparison, playbook approval, and a fresh review after those inputs. Current review is correctly BLOCKED, not PASS.",
-      "evidence": "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-post-isolation.json"
+      "evidence": "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-live-policy.json"
     }
   ],
   "scopeConfirmations": [

--- a/docs/domain-operations/evidence/gate-4/contract-requirement-audit.json
+++ b/docs/domain-operations/evidence/gate-4/contract-requirement-audit.json
@@ -42,7 +42,8 @@
       "evidence": [
         "packages/contracts/src/live-fault-harness.ts",
         "packages/contracts/src/live-fault-harness.test.ts",
-        "docs/domain-operations/evidence/gate-3/provider-harness-policy.json"
+        "docs/domain-operations/evidence/gate-3/provider-harness-policy.json",
+        "docs/domain-operations/evidence/gate-3/fault-run-artifact-policy.json"
       ]
     },
     {

--- a/docs/domain-operations/evidence/gate-4/contract-requirement-audit.json
+++ b/docs/domain-operations/evidence/gate-4/contract-requirement-audit.json
@@ -1,0 +1,78 @@
+{
+  "auditId": "PHASE-0-1-CONTRACT-REQUIREMENT-AUDIT",
+  "recordedAt": "2026-07-29T19:05:00Z",
+  "contract": "docs/domain-operations/phase-0-1-execution-contract-v4.1.md",
+  "amendment": "docs/domain-operations/amendments/2026-07-28-autonomous-completion-override.md",
+  "verdict": "BLOCKED_BY_EXTERNAL_AUTHORITY",
+  "completed": [
+    {
+      "requirement": "Gate 1 repository truth, authority, and legacy-path map",
+      "evidence": [
+        "docs/domain-operations/checkpoints/day-0-gate-1.md",
+        "docs/domain-operations/checkpoints/current-state.json"
+      ]
+    },
+    {
+      "requirement": "Gate 2 correctness: explicit rule failures, authoritative uncertainty, first-level SPF limitation, RFC 9989 discovery, and guidance-only remediation",
+      "evidence": [
+        "docs/domain-operations/evidence/gate-2/fix-01-rule-failure.json",
+        "docs/domain-operations/evidence/gate-2/fix-02-authoritative-evidence.json",
+        "docs/domain-operations/evidence/gate-2/fix-03-spf-first-level.json",
+        "docs/domain-operations/evidence/gate-2/fix-04-rfc9989-dmarc-discovery.json",
+        "docs/domain-operations/evidence/gate-2/fix-05-guidance-only-remediation.json"
+      ]
+    },
+    {
+      "requirement": "Actionable UNKNOWN/setup UX, canonical signals/cases/alerts, duplicate prevention, fresh-evidence resolution, reopen behavior, and playbook drafts",
+      "evidence": [
+        "docs/domain-operations/evidence/gate-3/signal-case-foundation.json",
+        "docs/domain-operations/evidence/gate-3/fix-05-stale-evidence.json",
+        "docs/domain-operations/evidence/gate-3/fix-06-canonical-dedup.json",
+        "docs/playbooks/"
+      ]
+    },
+    {
+      "requirement": "Exactly ten static-token-hash MCP tools with tenant/scope/negative/idempotency/parity coverage",
+      "evidence": [
+        "docs/domain-operations/evidence/gate-3/mcp-harness-matrix.json"
+      ]
+    },
+    {
+      "requirement": "Exact non-live validation, isolated migration/concurrency, browser smoke, and independent non-live review",
+      "evidence": [
+        "docs/domain-operations/evidence/gate-4/isolated-postgres-migration-concurrency.json",
+        "docs/domain-operations/evidence/gate-4/isolated-browser-smoke.json",
+        "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-post-isolation.json",
+        "docs/domain-operations/evidence/gate-4/clean-checkout-attestation.json"
+      ]
+    }
+  ],
+  "blocked": [
+    {
+      "requirement": "A concrete, isolated controlled provider/test-host fault harness and LIVE-01 through LIVE-03",
+      "reason": "Provider kind, authorized test asset manifest, exact mutation allowlist, test-host deployment mechanism, TTL history, rollback procedure, and revocation owner are absent. A generic unimplemented provider adapter would violate the no-stubs policy.",
+      "evidence": "docs/domain-operations/evidence/gate-3/provider-harness-readiness.json"
+    },
+    {
+      "requirement": "Measured manual-work baseline and comparison showing at least four named checks automated or materially shortened",
+      "reason": "Founder has not supplied observed frequency, time, domains, or current-evidence values in the Day 0 worksheet.",
+      "evidence": "docs/domain-operations/day-0-worksheet.md"
+    },
+    {
+      "requirement": "Founder selection/classification of the initial portfolio and approval/calibration of all six playbooks",
+      "reason": "The Day 0 worksheet portfolio rows and playbook approval cells are incomplete; these are founder declarations and cannot be inferred.",
+      "evidence": "docs/domain-operations/day-0-worksheet.md"
+    },
+    {
+      "requirement": "Final Gate 4 PASS review",
+      "reason": "The contract requires final live artifacts, manual baseline comparison, playbook approval, and a fresh review after those inputs. Current review is correctly BLOCKED, not PASS.",
+      "evidence": "docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-post-isolation.json"
+    }
+  ],
+  "scopeConfirmations": [
+    "No production or client mutation occurred.",
+    "DNS Ops and MCP retain no provider-write capability.",
+    "Recursive SPF, DMARC RUA/RUF ingestion, a formal graph, an agent, Buzz, OAuth, and commercial features remain excluded."
+  ],
+  "nextAction": "Obtain the founder-controlled inputs listed in issue #4, implement the concrete isolated fault harness for the selected provider/test host, execute the three controlled live scenarios with rollback artifacts, then repeat the final clean-checkout review."
+}

--- a/docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-live-policy.json
+++ b/docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-live-policy.json
@@ -1,0 +1,34 @@
+{
+  "verdict": "BLOCKED",
+  "reviewedSha": "06ecb55ed4db9cd98d2d9df7dc92bc80d435c40a",
+  "reviewedAt": "2026-07-29T19:33:00Z",
+  "reviewEnvironment": "clean detached disposable checkout",
+  "evidence": [
+    "packages/contracts/src/live-fault-harness.ts is pure validation/authorization code with no runtime imports, network calls, provider SDK/client, environment-secret access, or write capability.",
+    "The policy rejects unknown, hidden, symbol, accessor, inherited, and nested credential-bearing fields; exact zone/name/type/LIVE authorization uses canonicalized values.",
+    "The integration changes only contracts, focused tests, and evidence/checkpoint documents; no app, collector, MCP, or provider implementation changed.",
+    "Committed policy evidence parses as JSON and records seven focused tests."
+  ],
+  "falsificationAttempts": [
+    "Inspected credential-field, prototype/accessor, sparse-array, domain-escape, and tuple-broadening defenses.",
+    "Inspected the policy integration diff for provider/MCP/product writes, network APIs, process environment access, SDK imports, and secret-bearing configuration.",
+    "Verified JSON validity and diff cleanliness at the reviewed SHA."
+  ],
+  "findings": [
+    {
+      "severity": "LOW",
+      "title": "No code-level security or correctness blocker found",
+      "evidence": "The pure contract is fail-closed for malformed policy/request data and introduces no provider, product, or MCP write path."
+    },
+    {
+      "severity": "BLOCKER",
+      "title": "External live/manual-baseline prerequisites remain unavailable",
+      "evidence": "The concrete provider/test-host manifest, scoped-secret confirmation, live assets, TTL/rollback authority, manual baseline, and founder approvals remain pending in issue #4."
+    }
+  ],
+  "residualUncertainty": [
+    "The clean checkout had no installed dependencies, so the focused tests were not independently reproduced there; their successful local execution and full repository validation are recorded in the checkpoint.",
+    "LIVE-01 through LIVE-03 and rollback behavior require authorized external assets and authority."
+  ],
+  "recommendedNextAction": "Keep the policy as non-live safety infrastructure; obtain the issue #4 manifest and implement/review a concrete isolated harness before any live mutation."
+}

--- a/docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-post-isolation.json
+++ b/docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29-post-isolation.json
@@ -1,0 +1,39 @@
+{
+  "verdict": "BLOCKED",
+  "reviewedSha": "603a7ff0fae06dabb3936f9aebbe40ae80c997c0",
+  "reviewedAt": "2026-07-29T18:53:00Z",
+  "evidence": [
+    "Fresh non-live suite passed: RUN_LIVE_DNS_TESTS=0 bun run test reported 2721 passed and 41 skipped.",
+    "Focused @dns-ops/db and @dns-ops/web typechecks passed.",
+    "Migration 0020 matches exported users and sessions schema tables; isolated verification recorded 32/32 tables, 32/32 enums, canonical-signal unique-insert behavior, and internal-case version CAS.",
+    "Committed browser-smoke evidence records nine passing Playwright checks against a migrated disposable PostgreSQL database."
+  ],
+  "falsificationAttempts": [
+    "Compared migration 0020 to the users and sessions schema definitions.",
+    "Inspected independent-client duplicate signal and case-CAS verifier assertions.",
+    "Inspected apps/web migration-directory traversal and Playwright port propagation.",
+    "Reviewed deterministic MCP tenant/scope/idempotency/rate/stale/exception evidence."
+  ],
+  "findings": [
+    {
+      "severity": "LOW",
+      "title": "No code-level blocker identified",
+      "evidence": "The isolated migration, concurrency, and browser-smoke gaps identified by prior review are now covered by committed code and evidence."
+    },
+    {
+      "severity": "BLOCKER",
+      "title": "External Gate 3 prerequisites remain unavailable",
+      "evidence": "Issue #4 inputs for manual baseline, founder classification, authorized controlled assets, scoped secret confirmation, allowlist, TTLs, and rollback/revocation authority are pending."
+    },
+    {
+      "severity": "LOW",
+      "title": "Final clean-checkout condition remains pending",
+      "evidence": "Excluded .pi agent artifacts are present in this worktree; final Gate 4 must run from a clean disposable checkout."
+    }
+  ],
+  "residualUncertainty": [
+    "LIVE-01 through LIVE-03, authoritative propagation, and live resolve/reopen proof require authorized non-production assets and rollback authority.",
+    "Final Gate 4 acceptance requires a clean checkout after the controlled live evidence is available."
+  ],
+  "recommendedNextAction": "Obtain Issue #4 prerequisites, run controlled LIVE-01 through LIVE-03 with rollback evidence from a clean checkout, then repeat Gate 4 review."
+}

--- a/docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29.json
+++ b/docs/domain-operations/evidence/gate-4/fresh-review-2026-07-29.json
@@ -1,0 +1,32 @@
+{
+  "verdict": "BLOCKED",
+  "reviewedSha": "29dee9b93f72f14989790c12ed9a0e36b33481d5",
+  "reviewedAt": "2026-07-29T18:28:00Z",
+  "evidence": [
+    "The scan proxy-rejection path catches an unexpected proxy failure and completes the claimed command as FAILED with COLLECTOR_UNAVAILABLE.",
+    "apps/web/hono/lib/mcp-scan-service.command.test.ts proves rejected-proxy completion, cross-tenant denial before proxy, replay without a second proxy request, and rate-limit failure persistence.",
+    "Repository validation at the reviewed implementation: bun run lint (8/8), RUN_LIVE_DNS_TESTS=0 bun run test (2720 passed, 41 skipped), bun run typecheck (14/14), bun run build (8/8), and db drift check (clean)."
+  ],
+  "falsificationAttempts": [
+    "Rejected proxyToCollector after a command claim; the persisted result is COLLECTOR_UNAVAILABLE/FAILED rather than PENDING.",
+    "Attempted cross-tenant scan domain access, repeat scan replay, and rate-limit exhaustion through deterministic command tests.",
+    "Reviewed static token-hash principal derivation, tool scope checks, closed ten-tool contract, and canonical command persistence."
+  ],
+  "findings": [
+    {
+      "severity": "BLOCKER",
+      "title": "External Gate 3 and Gate 4 prerequisites remain unavailable",
+      "evidence": "Controlled test assets, scoped provider secret confirmation, allowlist, TTL values, baseline/rollback/revocation authority, measured manual-work baseline, and isolated PostgreSQL DATABASE_URL are still pending in the checkpoint."
+    },
+    {
+      "severity": "LOW",
+      "title": "Review workspace contains excluded agent artifacts",
+      "evidence": ".pi/self-learning-memory and .pi-subagents are deliberately excluded from product commits; a fresh clean checkout is still required for final Gate 4 acceptance."
+    }
+  ],
+  "residualUncertainty": [
+    "Controlled live mutations, authoritative DNS freshness proof, and the live resolve/reopen loop cannot be reproduced without approved non-production assets and authority.",
+    "Migration and concurrent persistence behavior cannot be independently verified without an isolated PostgreSQL database."
+  ],
+  "recommendedNextAction": "Obtain the recorded external prerequisites, run controlled LIVE-01 through LIVE-03 plus isolated PostgreSQL migration/concurrency verification from a clean checkout, then repeat the fresh Gate 4 review."
+}

--- a/docs/domain-operations/evidence/gate-4/fresh-review-2026-07-30-final-artifact-validation.json
+++ b/docs/domain-operations/evidence/gate-4/fresh-review-2026-07-30-final-artifact-validation.json
@@ -1,0 +1,51 @@
+{
+  "reviewId": "PHASE-0-1-FINAL-ARTIFACT-VALIDATION-2026-07-30",
+  "recordedAt": "2026-07-30T01:40:00Z",
+  "verdict": "BLOCKED_BY_EXTERNAL_AUTHORITY",
+  "independentVerification": {
+    "cleanCheckoutSha": "1d5f33620a0cf780cbb1aed761dc39e2c57d0a97",
+    "worktree": "/tmp/dnsops-final-independent-verification",
+    "dependencyInstall": "bun install --frozen-lockfile",
+    "focusedTest": "bunx vitest run packages/contracts/src/live-fault-harness.test.ts",
+    "focusedTestResult": "9 passed"
+  },
+  "reviewChain": [
+    {
+      "run": "5cd04b81",
+      "scope": "clean checkout controlled-fault artifact validation",
+      "finding": "PASS artifacts could omit appliedAt and restoredAt",
+      "remediationCommit": "c0f4a6e6ed0a993db6f41d5dd7a2b5b6b0332f68"
+    },
+    {
+      "run": "cc8cdbb3",
+      "scope": "remediation re-review",
+      "result": "No remaining actionable code-level finding"
+    }
+  ],
+  "validation": {
+    "commandSet": [
+      "bun run lint",
+      "RUN_LIVE_DNS_TESTS=0 bun run test",
+      "bun run typecheck",
+      "bun run build",
+      "bun run --filter @dns-ops/db check-drift"
+    ],
+    "result": {
+      "lint": "8 of 8 workspace tasks passed",
+      "tests": "2730 passed; 41 skipped",
+      "typecheck": "14 of 14 workspace tasks passed",
+      "build": "8 of 8 workspace tasks passed",
+      "schemaDrift": "clean"
+    }
+  },
+  "scopeConfirmations": [
+    "The validation contract contains no provider SDK, network operation, environment-secret access, product write path, or MCP write path.",
+    "No production, client, provider, DNS Ops, or MCP write occurred.",
+    "The concrete live harness and LIVE-01 through LIVE-03 remain unimplemented and unexecuted pending issue #4 authority."
+  ],
+  "externalBlockers": [
+    "Authorized non-production domain, web host, mail subdomain, zone, selected provider kind, scoped-secret fingerprint, exact mutation allowlist, TTL history, test-host mechanism, and rollback/revocation owner.",
+    "Founder manual-work baseline, portfolio classification, and six playbook approvals.",
+    "Live artifacts and a fresh final review after authorized controlled execution."
+  ]
+}

--- a/docs/domain-operations/evidence/gate-4/isolated-browser-smoke.json
+++ b/docs/domain-operations/evidence/gate-4/isolated-browser-smoke.json
@@ -1,0 +1,32 @@
+{
+  "evidenceId": "GATE4-ISOLATED-BROWSER-SMOKE",
+  "recordedAt": "2026-07-29T18:51:00Z",
+  "implementationSha": "093301e",
+  "environment": {
+    "type": "ephemeral local Docker PostgreSQL plus Playwright Chromium",
+    "productionDatabase": false,
+    "containerRemovedAfterVerification": true
+  },
+  "setup": [
+    "Applied all application migrations using the web migration runner against the isolated database.",
+    "Ran the web server on an override port with deterministic development tenant/actor headers.",
+    "Installed the local Playwright Chromium runtime; it is not a repository artifact."
+  ],
+  "command": "PORT=3100 BASE_URL=http://localhost:3100 DATABASE_URL=<isolated> COLLECTOR_URL=http://127.0.0.1:3001 bun run e2e -- e2e/smoke.spec.ts",
+  "result": "9 browser smoke tests passed",
+  "coverage": [
+    "home page and navigation to Domain 360",
+    "domain tabs, delegation panel, refresh control, and portfolio workspace",
+    "mobile and tablet layouts",
+    "web migration resolution when the development working directory is apps/web"
+  ],
+  "limitations": [
+    "The smoke fixture intentionally has no collector process; collector proxy network errors during refresh attempts do not fail the browser UI assertions.",
+    "This is non-live UI smoke evidence, not controlled provider mutation evidence."
+  ],
+  "safety": {
+    "providerWrites": false,
+    "liveDns": false,
+    "productionWrites": false
+  }
+}

--- a/docs/domain-operations/evidence/gate-4/isolated-postgres-migration-concurrency.json
+++ b/docs/domain-operations/evidence/gate-4/isolated-postgres-migration-concurrency.json
@@ -1,0 +1,31 @@
+{
+  "evidenceId": "GATE4-ISOLATED-POSTGRES-MIGRATION-CONCURRENCY",
+  "recordedAt": "2026-07-29T18:41:00Z",
+  "implementationSha": "0c8167f",
+  "environment": {
+    "type": "ephemeral local Docker PostgreSQL 16 alpine",
+    "productionDatabase": false,
+    "containerRemovedAfterVerification": true
+  },
+  "migrationVerification": {
+    "command": "DATABASE_URL=<isolated> bun run --filter @dns-ops/db verify-migrations",
+    "result": "passed",
+    "tables": "32/32",
+    "enums": "32/32",
+    "foreignKeyConstraints": 28,
+    "migrationRepair": "0020_users_sessions.sql adds schema-exported users and sessions tables that were missing from fresh migration output"
+  },
+  "concurrencyVerification": {
+    "command": "DATABASE_URL=<isolated> bun run --filter @dns-ops/db verify-operations-concurrency",
+    "result": "passed",
+    "assertions": [
+      "two concurrent inserts for the same tenant and canonical condition admit exactly one row and reject the other with PostgreSQL 23505",
+      "two concurrent internal-case updates guarded by version=1 affect exactly one row"
+    ]
+  },
+  "safety": {
+    "providerWrites": false,
+    "liveDns": false,
+    "productionWrites": false
+  }
+}

--- a/docs/playbooks/domain-expiry.md
+++ b/docs/playbooks/domain-expiry.md
@@ -1,0 +1,39 @@
+# Domain expiry
+
+## What the condition proves
+
+A fresh RDAP observation reports that the registered domain expiration event is within the configured warning threshold and the event timestamp is later than the observation timestamp.
+
+## What it does not prove
+
+It does not prove registrar auto-renew status, billing health, registry grace-period behavior, or that renewal will fail. Missing, redacted, inconsistent, or stale RDAP data is `UNKNOWN`, not an expiry signal.
+
+## Deterministic evidence
+
+- normalized domain and RDAP authority queried;
+- response status and observation time;
+- expiration event value and source field;
+- evidence freshness and threshold used.
+
+## Purpose applicability
+
+Applies to every registered domain in the approved portfolio, including redirect-only and observation-only domains. Public suffixes and unregistered test names are not applicable.
+
+## Operator checks
+
+1. Confirm the domain is in the approved portfolio.
+2. Confirm the RDAP response belongs to the exact domain.
+3. Check the registrar directly for renewal state, payment method, and registry lock.
+4. Identify the renewal owner.
+
+## Safe next action
+
+Contact the declared renewal owner with the observed date and threshold. Do not change registrar settings or payment details through DNS Ops.
+
+## Verification
+
+Resolve only after a newer successful RDAP observation reports an expiration date outside the threshold or an operator dismisses the case with documented non-applicability.
+
+## Escalation boundary
+
+Escalate immediately when the date is inside the critical threshold, ownership is unknown, or registrar evidence conflicts with RDAP. DNS Ops remains read-only.

--- a/docs/playbooks/indexability-regression.md
+++ b/docs/playbooks/indexability-regression.md
@@ -1,0 +1,40 @@
+# Homepage indexability regression
+
+## What the condition proves
+
+A fresh bounded homepage observation differs from the accepted baseline by exposing an indexing prohibition, currently an applicable `X-Robots-Tag` or HTML robots meta directive containing `noindex`.
+
+## What it does not prove
+
+It does not prove that a search engine has indexed or removed a page, that rankings changed, or that canonical metadata controls indexing. Fetch failures and ambiguous parser results are setup/evidence gaps, not regressions.
+
+## Deterministic evidence
+
+- requested and final URL with redirect trace;
+- HTTP status, observation time, and bounded body size;
+- normalized `X-Robots-Tag` values;
+- parsed robots meta directives;
+- accepted baseline identifier.
+
+## Purpose applicability
+
+Applies only to public web domains declared indexable. Private applications, parked pages, redirect-only domains, and intentionally non-indexed sites are not applicable.
+
+## Operator checks
+
+1. Confirm the page is intended for public indexing.
+2. Inspect edge headers, templates, CMS settings, and deployment changes.
+3. Verify the directive applies to the relevant crawler or all crawlers.
+4. Confirm the accepted baseline is still valid.
+
+## Safe next action
+
+Use the web owner's reviewed deployment process. DNS Ops does not modify headers, HTML, robots files, or CMS configuration.
+
+## Verification
+
+Resolve only after a newer observation no longer reproduces the exact indexability condition.
+
+## Escalation boundary
+
+Escalate when purpose is unclear, directives conflict by layer, or removing a directive could expose private content.

--- a/docs/playbooks/mail-dns-configuration-regression.md
+++ b/docs/playbooks/mail-dns-configuration-regression.md
@@ -1,0 +1,39 @@
+# Mail DNS configuration regression
+
+## What the condition proves
+
+A fresh authoritative DNS observation for an approved mail test or managed mail name materially differs from its accepted baseline and matches the exact mail condition key.
+
+## What it does not prove
+
+It does not prove real-message delivery, sender authorization, recursive SPF compliance, DKIM signing behavior, or DMARC message outcomes. Missing authoritative evidence and unresolved SPF dependencies are setup/evidence gaps.
+
+## Deterministic evidence
+
+- exact queried name/type and accepted baseline;
+- authoritative nameserver, response code, AA flag, TTL, answer, and time;
+- recursive response only as supporting evidence;
+- first-level SPF or RFC 9989 DMARC limitations where applicable.
+
+## Purpose applicability
+
+Applies only to declared mail domains and authorized non-production mail fixtures. It must not infer mail purpose from a record alone.
+
+## Operator checks
+
+1. Confirm domain purpose, provider, and authorized sender inventory.
+2. Compare provider-issued values with authoritative evidence.
+3. Check change history, TTL, propagation window, and rollback owner.
+4. Treat DKIM selectors and report destinations as provider/operator evidence, never guesses.
+
+## Safe next action
+
+Follow the provider-confirmed playbook and normal reviewed DNS process. DNS Ops and MCP remain read-only and provide no ready-to-apply generic record.
+
+## Verification
+
+Resolve only after a newer authoritative observation clears the exact condition. Reintroduction reopens the same case.
+
+## Escalation boundary
+
+Escalate before any production mail change, when provider context is incomplete, or when authoritative servers disagree.

--- a/docs/playbooks/redirect-regression.md
+++ b/docs/playbooks/redirect-regression.md
@@ -1,0 +1,39 @@
+# Redirect topology regression
+
+## What the condition proves
+
+A fresh bounded HTTP probe shows that an approved source URL no longer reaches its accepted canonical destination through the expected redirect topology.
+
+## What it does not prove
+
+It does not prove user impact from every geography, SEO loss, or malicious redirection. A timeout, blocked probe, stale baseline, or unvalidated redirect hop is `UNKNOWN` and belongs in setup/evidence.
+
+## Deterministic evidence
+
+- source URL and accepted baseline identifier;
+- each status code and normalized `Location` target;
+- per-hop DNS/IP safety validation;
+- final URL, hop limit, timestamps, and truncation/error state.
+
+## Purpose applicability
+
+Applies to redirect-only domains and web domains with an explicitly declared canonical destination. Mail-only and undeclared domains are not automatically evaluated.
+
+## Operator checks
+
+1. Confirm the intended canonical URL with the domain owner.
+2. Inspect CDN, edge, load-balancer, and application redirect rules.
+3. Check whether a planned migration changed the accepted baseline.
+4. Verify every redirect target remains organization-controlled.
+
+## Safe next action
+
+Use the owning platform's reviewed change and rollback process. Do not copy a generic redirect rule from DNS Ops.
+
+## Verification
+
+Resolve only after a newer probe matches the accepted source-to-destination topology. Reintroduction reopens the same condition without a duplicate case.
+
+## Escalation boundary
+
+Escalate redirects to unowned domains, loops, private-network targets, or authentication/token-bearing URLs. Stop probing when hop safety cannot be established.

--- a/docs/playbooks/tls-regression.md
+++ b/docs/playbooks/tls-regression.md
@@ -1,0 +1,39 @@
+# TLS certificate regression
+
+## What the condition proves
+
+A fresh, allowlisted TLS probe for the declared HTTPS endpoint differs materially from its accepted baseline, such as failed hostname validation, expiration, or a shorter-than-approved validity window.
+
+## What it does not prove
+
+It does not prove compromise, private-key exposure, CA fault, or failure from every network. A failed or stale probe without a comparable baseline is a setup/evidence gap.
+
+## Deterministic evidence
+
+- exact hostname, port, resolved public address, and probe time;
+- TLS handshake and hostname-verification result;
+- certificate validity dates, issuer, subject/SAN, and fingerprint;
+- accepted baseline identifier and comparison result.
+
+## Purpose applicability
+
+Applies only to domains declared to serve HTTPS on the probed hostname. Parked, mail-only, and observation-only names may be not applicable.
+
+## Operator checks
+
+1. Verify endpoint purpose and ownership.
+2. Confirm the probe target was allowlisted and public.
+3. Compare CDN/load-balancer and origin certificates where applicable.
+4. Check renewal automation and recent deployment changes.
+
+## Safe next action
+
+Use the certificate owner's deployment and rollback process. DNS Ops supplies evidence only and does not issue, install, or rotate certificates.
+
+## Verification
+
+Resolve only after a newer successful probe no longer reproduces the exact condition key. Reproducing the regression reopens the same case.
+
+## Escalation boundary
+
+Escalate on expiration, hostname mismatch, trust failure, or unclear ownership. Never disable certificate validation as remediation.

--- a/docs/playbooks/unknown-evidence.md
+++ b/docs/playbooks/unknown-evidence.md
@@ -1,0 +1,40 @@
+# Unknown and missing evidence
+
+## What the condition proves
+
+`UNKNOWN` proves only that DNS Ops could not complete a trustworthy check or lacked required applicability/context evidence.
+
+## What it does not prove
+
+It does not prove safety, failure, regression, absence, or healthy configuration. Coverage gaps must not create automatic signals, alerts, or cases.
+
+## Deterministic evidence
+
+- typed unknown reason and explanation;
+- failed or skipped check identifier;
+- observation/probe status and timestamp when available;
+- required resolution action;
+- whether the gap blocks evaluation.
+
+## Purpose applicability
+
+This playbook applies to every portfolio domain. Purpose may determine which missing evidence matters, but an undeclared purpose is itself an actionable setup gap.
+
+## Operator checks
+
+1. Read the typed reason and requested action.
+2. Confirm domain purpose and ownership.
+3. Check evidence freshness, allowlisting, selector/provider context, and probe health.
+4. Retry only when the target and action remain authorized.
+
+## Safe next action
+
+Use the stated action: declare purpose, run a fresh scan, retry a probe, supply a selector, connect/confirm provider context, review manually, or record that the item is not currently observable.
+
+## Verification
+
+Close the setup/evidence item only when a newer check returns a determined result or explicit accepted/not-applicable disposition.
+
+## Escalation boundary
+
+Escalate repeated probe failures, unavailable authoritative evidence, ambiguous ownership, or any request that would require production mutation. Never convert UNKNOWN into a regression automatically.

--- a/packages/contracts/src/domain-profile.test.ts
+++ b/packages/contracts/src/domain-profile.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type DomainEvidenceCheck,
+  type DomainPurpose,
+  evidenceApplicability,
+} from './domain-profile.js';
+import { probeFailedUnknown, purposeUndeclaredUnknown } from './web-evidence.js';
+
+describe('domain evidence applicability', () => {
+  it.each<[DomainPurpose, DomainEvidenceCheck, string]>([
+    ['WEB', 'HOMEPAGE_INDEXABILITY', 'APPLICABLE'],
+    ['WEB_AND_MAIL', 'TLS_CERTIFICATE', 'APPLICABLE'],
+    ['REDIRECT', 'REDIRECT_TOPOLOGY', 'APPLICABLE'],
+    ['REDIRECT', 'HOMEPAGE_INDEXABILITY', 'NOT_APPLICABLE'],
+    ['MAIL', 'HTTP_REACHABILITY', 'NOT_APPLICABLE'],
+    ['PARKED', 'TLS_CERTIFICATE', 'NOT_APPLICABLE'],
+    ['MAIL', 'RDAP_EXPIRATION', 'APPLICABLE'],
+    ['UNKNOWN', 'RDAP_EXPIRATION', 'APPLICABLE'],
+    ['UNKNOWN', 'HTTP_REACHABILITY', 'UNKNOWN'],
+  ])('%s / %s is %s', (purpose, check, expected) => {
+    expect(evidenceApplicability(purpose, check)).toBe(expected);
+  });
+
+  it('gives every unknown an actionable explanation', () => {
+    for (const unknown of [
+      purposeUndeclaredUnknown('TLS certificate'),
+      probeFailedUnknown('HTTP', 'request timed out'),
+    ]) {
+      expect(unknown.explanation.length).toBeGreaterThan(0);
+      expect(unknown.actionLabel.length).toBeGreaterThan(0);
+      expect(unknown.blocking).toBe(true);
+    }
+  });
+});

--- a/packages/contracts/src/domain-profile.ts
+++ b/packages/contracts/src/domain-profile.ts
@@ -1,0 +1,50 @@
+export const DOMAIN_PURPOSES = [
+  'WEB',
+  'MAIL',
+  'WEB_AND_MAIL',
+  'REDIRECT',
+  'PARKED',
+  'UNKNOWN',
+] as const;
+
+export type DomainPurpose = (typeof DOMAIN_PURPOSES)[number];
+
+export const DOMAIN_CRITICALITIES = ['HIGH', 'NORMAL', 'LOW'] as const;
+
+export type DomainCriticality = (typeof DOMAIN_CRITICALITIES)[number];
+
+export interface InternalDomainProfile {
+  domainId: string;
+  purpose: DomainPurpose;
+  responsibleActorId?: string;
+  criticality: DomainCriticality;
+}
+
+export type DomainEvidenceCheck =
+  | 'RDAP_EXPIRATION'
+  | 'TLS_CERTIFICATE'
+  | 'HTTP_REACHABILITY'
+  | 'REDIRECT_TOPOLOGY'
+  | 'HOMEPAGE_INDEXABILITY';
+
+export type EvidenceApplicability = 'APPLICABLE' | 'NOT_APPLICABLE' | 'UNKNOWN';
+
+/**
+ * Purpose is declared by an operator and is never inferred from observed DNS or
+ * web behavior. RDAP applies to every registered portfolio domain; web checks
+ * require an explicit web or redirect purpose.
+ */
+export function evidenceApplicability(
+  purpose: DomainPurpose,
+  check: DomainEvidenceCheck
+): EvidenceApplicability {
+  if (check === 'RDAP_EXPIRATION') return 'APPLICABLE';
+  if (purpose === 'UNKNOWN') return 'UNKNOWN';
+
+  if (purpose === 'WEB' || purpose === 'WEB_AND_MAIL') return 'APPLICABLE';
+  if (purpose === 'REDIRECT') {
+    return check === 'HOMEPAGE_INDEXABILITY' ? 'NOT_APPLICABLE' : 'APPLICABLE';
+  }
+
+  return 'NOT_APPLICABLE';
+}

--- a/packages/contracts/src/evaluation.test.ts
+++ b/packages/contracts/src/evaluation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { evaluationCoverageOrUnknown, isEvaluationComplete } from './evaluation.js';
+
+describe('evaluation coverage compatibility', () => {
+  it('treats missing historical coverage as actionable UNKNOWN', () => {
+    const coverage = evaluationCoverageOrUnknown(undefined);
+
+    expect(coverage.state).toBe('PARTIAL');
+    expect(coverage.errors[0]).toMatchObject({
+      status: 'UNKNOWN',
+      unknown: {
+        reason: 'EVIDENCE_STALE',
+        action: 'RUN_FRESH_SCAN',
+        blocking: true,
+      },
+    });
+    expect(isEvaluationComplete(undefined)).toBe(false);
+  });
+
+  it('recognizes only explicit complete coverage as complete', () => {
+    expect(isEvaluationComplete({ state: 'COMPLETE', errors: [] })).toBe(true);
+    expect(isEvaluationComplete({ state: 'PARTIAL', errors: [] })).toBe(false);
+  });
+});

--- a/packages/contracts/src/evaluation.ts
+++ b/packages/contracts/src/evaluation.ts
@@ -39,6 +39,12 @@ export interface EvaluationCoverage {
   errors: RuleEvaluationFailure[];
 }
 
+export interface AuthoritativeEvidenceCoverage {
+  state: 'VERIFIED' | 'UNKNOWN' | 'NOT_REQUESTED';
+  nameservers: string[];
+  unknown?: UnknownResolution;
+}
+
 /**
  * Historical snapshots did not persist evaluation coverage. Absence must remain
  * actionable UNKNOWN rather than inheriting a green state from a ruleset ID.

--- a/packages/contracts/src/evaluation.ts
+++ b/packages/contracts/src/evaluation.ts
@@ -1,0 +1,73 @@
+export type UnknownReason =
+  | 'PURPOSE_UNDECLARED'
+  | 'EVIDENCE_STALE'
+  | 'PROBE_FAILED'
+  | 'AUTHORITATIVE_EVIDENCE_UNAVAILABLE'
+  | 'PROVIDER_NOT_CONNECTED'
+  | 'SELECTOR_NOT_DISCOVERED'
+  | 'UNSUPPORTED_CHECK'
+  | 'EXTERNAL_DECISION_REQUIRED'
+  | 'CHECK_EVALUATION_FAILED';
+
+export type UnknownResolutionAction =
+  | 'DECLARE_PURPOSE'
+  | 'RUN_FRESH_SCAN'
+  | 'RETRY_PROBE'
+  | 'SUPPLY_SELECTOR'
+  | 'CONNECT_PROVIDER'
+  | 'REVIEW_MANUALLY'
+  | 'NOT_CURRENTLY_OBSERVABLE';
+
+export interface UnknownResolution {
+  reason: UnknownReason;
+  explanation: string;
+  action: UnknownResolutionAction;
+  actionLabel: string;
+  blocking: boolean;
+}
+
+export interface RuleEvaluationFailure {
+  code: 'RULE_EXECUTION_FAILED' | 'INVALID_CONTEXT' | 'EVALUATION_TIMEOUT';
+  ruleId: string;
+  message: string;
+  status: 'UNKNOWN';
+  unknown: UnknownResolution;
+}
+
+export interface EvaluationCoverage {
+  state: 'COMPLETE' | 'PARTIAL';
+  errors: RuleEvaluationFailure[];
+}
+
+/**
+ * Historical snapshots did not persist evaluation coverage. Absence must remain
+ * actionable UNKNOWN rather than inheriting a green state from a ruleset ID.
+ */
+export function evaluationCoverageOrUnknown(
+  coverage: EvaluationCoverage | null | undefined
+): EvaluationCoverage {
+  if (coverage) return coverage;
+
+  return {
+    state: 'PARTIAL',
+    errors: [
+      {
+        code: 'INVALID_CONTEXT',
+        ruleId: 'ruleset',
+        message: 'Rule evaluation coverage was not recorded',
+        status: 'UNKNOWN',
+        unknown: {
+          reason: 'EVIDENCE_STALE',
+          explanation: 'This snapshot predates explicit rule-evaluation coverage evidence.',
+          action: 'RUN_FRESH_SCAN',
+          actionLabel: 'Run a fresh scan',
+          blocking: true,
+        },
+      },
+    ],
+  };
+}
+
+export function isEvaluationComplete(coverage: EvaluationCoverage | null | undefined): boolean {
+  return evaluationCoverageOrUnknown(coverage).state === 'COMPLETE';
+}

--- a/packages/contracts/src/guidance.ts
+++ b/packages/contracts/src/guidance.ts
@@ -1,0 +1,12 @@
+/**
+ * Non-executable operator guidance. Generic findings must use this shape until
+ * provider, domain-purpose, and proposed-value context are complete.
+ */
+export interface GuidanceOnlySuggestion {
+  kind: 'GUIDANCE_ONLY';
+  title: string;
+  explanation: string;
+  playbookId: string;
+  requiresProviderConfirmation: boolean;
+  executableMutation: null;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7,6 +7,7 @@
 // are used across web and collector runtimes.
 
 export * from './dns.js';
+export * from './domain-profile.js';
 export * from './enums.js';
 export * from './env.js';
 export * from './evaluation.js';
@@ -16,6 +17,7 @@ export * from './operations.js';
 export * from './requests.js';
 export * from './result.js';
 export * from './tenant.js';
+export * from './web-evidence.js';
 
 // -----------------------------------------------------------------------------
 // Persistence entity types — MOVED to @dns-ops/db

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,6 +12,7 @@ export * from './enums.js';
 export * from './env.js';
 export * from './evaluation.js';
 export * from './guidance.js';
+export * from './live-fault-harness.js';
 export * from './mail.js';
 export * from './operations.js';
 export * from './requests.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,6 +12,7 @@ export * from './env.js';
 export * from './evaluation.js';
 export * from './guidance.js';
 export * from './mail.js';
+export * from './operations.js';
 export * from './requests.js';
 export * from './result.js';
 export * from './tenant.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,6 +10,7 @@ export * from './dns.js';
 export * from './enums.js';
 export * from './env.js';
 export * from './evaluation.js';
+export * from './guidance.js';
 export * from './mail.js';
 export * from './requests.js';
 export * from './result.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@
 export * from './dns.js';
 export * from './enums.js';
 export * from './env.js';
+export * from './evaluation.js';
 export * from './requests.js';
 export * from './result.js';
 export * from './tenant.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,6 +10,7 @@ export * from './dns.js';
 export * from './enums.js';
 export * from './env.js';
 export * from './evaluation.js';
+export * from './mail.js';
 export * from './requests.js';
 export * from './result.js';
 export * from './tenant.js';

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -406,6 +406,33 @@ describe('controlled live-fault harness policy', () => {
         result: 'RECOVERY_REQUIRED',
         recovery: {
           ...recovery,
+          records: [
+            {
+              ...recovery.records[0],
+              desiredValue: 'ghp_abcdefghijklmnopqrstuvwxyz1234567890',
+            },
+          ],
+        },
+      })
+    ).toThrow('must not contain credential material');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+        recovery: {
+          ...recovery,
+          operatorCommands: ['restore record manually'],
+        },
+      })
+    ).toThrow('must contain approved operation references');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+        recovery: {
+          ...recovery,
           records: [],
         },
       })

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -344,6 +344,12 @@ describe('controlled live-fault harness policy', () => {
       })
     ).toThrow('restoredAt must not be earlier than appliedAt');
 
+    expect(() => {
+      const artifactWithoutApplication = artifact();
+      delete artifactWithoutApplication.appliedAt;
+      validateFaultRunArtifact(artifactWithoutApplication);
+    }).toThrow('restoredAt requires appliedAt');
+
     expect(() =>
       validateFaultRunArtifact({
         ...artifact(),

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   authorizeControlledFaultMutation,
   type ControlledFaultHarnessPolicy,
+  type FaultRunArtifact,
   validateControlledFaultHarnessPolicy,
+  validateFaultRunArtifact,
 } from './live-fault-harness.js';
 
 const fingerprint = `sha256:${'a'.repeat(64)}`;
@@ -27,6 +29,27 @@ function policy(): ControlledFaultHarnessPolicy {
         mutationIds: ['LIVE-03'],
       },
     ],
+  };
+}
+
+function artifact(): FaultRunArtifact {
+  return {
+    runId: 'run-01',
+    mutationId: 'LIVE-03',
+    zoneId: 'zone-123',
+    targetNames: ['mail.faults.example.test', '_dmarc.mail.faults.example.test'],
+    baselineHash: fingerprint,
+    providerCredentialFingerprint: fingerprint,
+    appliedAt: '2026-07-29T19:00:00Z',
+    restoredAt: '2026-07-29T19:01:00Z',
+    providerResponses: ['update-record: 200'],
+    authoritativeEvidenceIds: ['authoritative-01'],
+    recursiveEvidenceIds: ['recursive-01'],
+    scanTaskIds: ['scan-01'],
+    signalIds: ['signal-01'],
+    caseIds: ['case-01'],
+    auditEventIds: ['audit-01'],
+    result: 'PASS',
   };
 }
 
@@ -235,5 +258,97 @@ describe('controlled live-fault harness policy', () => {
         testMailSubdomain: 'faults.example.test',
       })
     ).toThrow('strict subdomain');
+  });
+
+  it('accepts a bounded, redacted fault-run artifact', () => {
+    expect(() => validateFaultRunArtifact(artifact())).not.toThrow();
+  });
+
+  it('rejects artifact secrets, malformed hashes, and incomplete recovery instructions', () => {
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        providerResponses: ['Authorization: Bearer must-not-be-stored'],
+      })
+    ).toThrow('providerResponses must contain only operation/status summaries');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        providerResponses: ['Cookie: session=must-not-be-stored'],
+      })
+    ).toThrow('providerResponses must contain only operation/status summaries');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        providerResponses: ['X-Auth-Token: must-not-be-stored'],
+      })
+    ).toThrow('providerResponses must contain only operation/status summaries');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        providerResponses: ['password=must-not-be-stored'],
+      })
+    ).toThrow('providerResponses must contain only operation/status summaries');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        zoneId: 'X-Auth-Token: must-not-be-stored',
+      })
+    ).toThrow('zoneId must be a bounded non-secret identifier');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        baselineHash: 'not-a-hash',
+      })
+    ).toThrow('baselineHash must be a sha256');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        appliedAt: '2025-02-29T12:00:00Z',
+      })
+    ).toThrow('calendar-valid');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        baselineHash: ` ${fingerprint}`,
+      })
+    ).toThrow('surrounding whitespace');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        targetNames: ['MAIL.FAULTS.EXAMPLE.TEST'],
+      })
+    ).toThrow('must be lowercase DNS names');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+      })
+    ).toThrow('recoveryInstructions are required');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+        recoveryInstructions: 'Use the secret abc123',
+      })
+    ).toThrow('must not contain credential material');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+        recoveryInstructions: 'Use API key sk_live_abc123 to restore the record',
+      })
+    ).toThrow('must not contain credential material');
   });
 });

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -84,6 +84,15 @@ describe('controlled live-fault harness policy', () => {
 
     expect(() =>
       authorizeControlledFaultMutation(policy(), {
+        zoneId: 'providerToken-secret',
+        name: 'www.faults.example.test',
+        type: 'CNAME',
+        mutationId: 'LIVE-01',
+      })
+    ).toThrow('controlled fault mutation zoneId must be a bounded non-secret identifier');
+
+    expect(() =>
+      authorizeControlledFaultMutation(policy(), {
         zoneId: 'zone-123',
         name: 'outside.example.test',
         type: 'CNAME',
@@ -248,6 +257,13 @@ describe('controlled live-fault harness policy', () => {
     expect(() =>
       validateControlledFaultHarnessPolicy({
         ...policy(),
+        zoneId: 'Authorization: Bearer must-not-be-accepted',
+      })
+    ).toThrow('zoneId must be a bounded non-secret identifier');
+
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
         providerCredentialFingerprint: 'not-a-fingerprint',
       })
     ).toThrow('sha256');
@@ -299,6 +315,13 @@ describe('controlled live-fault harness policy', () => {
         zoneId: 'X-Auth-Token: must-not-be-stored',
       })
     ).toThrow('zoneId must be a bounded non-secret identifier');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        signalIds: ['sk_live_must-not-be-stored'],
+      })
+    ).toThrow('signalIds must be a bounded non-secret identifier');
 
     expect(() =>
       validateFaultRunArtifact({

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import {
+  authorizeControlledFaultMutation,
+  type ControlledFaultHarnessPolicy,
+  validateControlledFaultHarnessPolicy,
+} from './live-fault-harness.js';
+
+const fingerprint = `sha256:${'a'.repeat(64)}`;
+
+function policy(): ControlledFaultHarnessPolicy {
+  return {
+    testDomain: 'faults.example.test',
+    testWebHost: 'www.faults.example.test',
+    testMailSubdomain: 'mail.faults.example.test',
+    providerKind: 'example-provider',
+    zoneId: 'zone-123',
+    providerCredentialFingerprint: fingerprint,
+    allowlist: [
+      {
+        name: 'www.faults.example.test',
+        types: ['CNAME'],
+        mutationIds: ['LIVE-01'],
+      },
+      {
+        name: '_dmarc.mail.faults.example.test',
+        types: ['TXT'],
+        mutationIds: ['LIVE-03'],
+      },
+    ],
+  };
+}
+
+describe('controlled live-fault harness policy', () => {
+  it('authorizes an exact allowlisted mutation without holding a credential value', () => {
+    const authorization = authorizeControlledFaultMutation(policy(), {
+      zoneId: 'zone-123',
+      name: 'WWW.FAULTS.EXAMPLE.TEST.',
+      type: 'CNAME',
+      mutationId: 'LIVE-01',
+    });
+
+    expect(authorization).toEqual({
+      zoneId: 'zone-123',
+      name: 'www.faults.example.test',
+      type: 'CNAME',
+      mutationId: 'LIVE-01',
+      providerKind: 'example-provider',
+      providerCredentialFingerprint: fingerprint,
+    });
+  });
+
+  it('rejects a zone, name, type, or mutation that is not explicitly allowlisted', () => {
+    expect(() =>
+      authorizeControlledFaultMutation(policy(), {
+        zoneId: 'other-zone',
+        name: 'www.faults.example.test',
+        type: 'CNAME',
+        mutationId: 'LIVE-01',
+      })
+    ).toThrow('zone is not authorized');
+
+    expect(() =>
+      authorizeControlledFaultMutation(policy(), {
+        zoneId: 'zone-123',
+        name: 'outside.example.test',
+        type: 'CNAME',
+        mutationId: 'LIVE-01',
+      })
+    ).toThrow('not allowlisted');
+
+    expect(() =>
+      authorizeControlledFaultMutation(policy(), {
+        zoneId: 'zone-123',
+        name: 'www.faults.example.test',
+        type: 'A',
+        mutationId: 'LIVE-01',
+      })
+    ).toThrow('not allowlisted');
+
+    expect(() =>
+      authorizeControlledFaultMutation(policy(), {
+        zoneId: 'zone-123',
+        name: 'www.faults.example.test',
+        type: 'CNAME',
+        mutationId: 'LIVE-02',
+      })
+    ).toThrow('not allowlisted');
+  });
+
+  it('rejects a policy that carries a credential value or escapes the designated test domain', () => {
+    const withToken = {
+      ...policy(),
+      providerToken: 'must-not-be-accepted',
+    } as ControlledFaultHarnessPolicy;
+    expect(() => validateControlledFaultHarnessPolicy(withToken)).toThrow(
+      'must not contain a provider credential'
+    );
+
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        allowlist: [
+          {
+            name: 'outside.example.test',
+            types: ['TXT'],
+            mutationIds: ['LIVE-03'],
+          },
+        ],
+      })
+    ).toThrow('inside testDomain');
+
+    const withNestedToken = {
+      ...policy(),
+      allowlist: [
+        {
+          ...policy().allowlist[0],
+          providerToken: 'must-not-be-accepted',
+        },
+      ],
+    } as unknown as ControlledFaultHarnessPolicy;
+    expect(() => validateControlledFaultHarnessPolicy(withNestedToken)).toThrow(
+      'must not contain a provider credential'
+    );
+
+    const inheritedTokenEntry = Object.assign(
+      Object.create({ providerToken: 'must-not-be-accepted' }),
+      policy().allowlist[0]
+    );
+    const withInheritedNestedToken = {
+      ...policy(),
+      allowlist: [inheritedTokenEntry],
+    } as unknown as ControlledFaultHarnessPolicy;
+    expect(() => validateControlledFaultHarnessPolicy(withInheritedNestedToken)).toThrow(
+      'must be plain enumerable data objects'
+    );
+  });
+
+  it('rejects non-enumerable, symbol, and accessor-backed configuration fields', () => {
+    const withHiddenToken = policy();
+    Object.defineProperty(withHiddenToken, 'providerToken', {
+      value: 'must-not-be-accepted',
+    });
+    expect(() => validateControlledFaultHarnessPolicy(withHiddenToken)).toThrow(
+      'must not contain a provider credential'
+    );
+
+    const withSymbolToken = policy();
+    Object.defineProperty(withSymbolToken, Symbol('providerToken'), {
+      value: 'must-not-be-accepted',
+      enumerable: true,
+    });
+    expect(() => validateControlledFaultHarnessPolicy(withSymbolToken)).toThrow(
+      'must not contain a provider credential'
+    );
+
+    const withAccessor = policy();
+    Object.defineProperty(withAccessor, 'allowlist', {
+      enumerable: true,
+      get: () => policy().allowlist,
+    });
+    expect(() => validateControlledFaultHarnessPolicy(withAccessor)).toThrow(
+      'must contain only enumerable data fields'
+    );
+  });
+
+  it('rejects malformed policy objects before they can be treated as configuration', () => {
+    expect(() =>
+      validateControlledFaultHarnessPolicy(null as unknown as ControlledFaultHarnessPolicy)
+    ).toThrow('must be plain enumerable data objects');
+
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        testDomain: 42,
+      } as unknown as ControlledFaultHarnessPolicy)
+    ).toThrow('testDomain must be a non-empty string');
+
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        allowlist: [null],
+      } as unknown as ControlledFaultHarnessPolicy)
+    ).toThrow('must be plain enumerable data objects');
+
+    const sparseAllowlist = new Array(2);
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        allowlist: sparseAllowlist,
+      } as unknown as ControlledFaultHarnessPolicy)
+    ).toThrow('must not be sparse');
+
+    const hugeSparseAllowlist = new Array(4_294_967_295);
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        allowlist: hugeSparseAllowlist,
+      } as unknown as ControlledFaultHarnessPolicy)
+    ).toThrow('no more than 64 values');
+  });
+
+  it('bounds and deduplicates approved record types and mutation IDs', () => {
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        allowlist: [
+          {
+            name: 'www.faults.example.test',
+            types: ['CNAME', 'CNAME'],
+            mutationIds: ['LIVE-01'],
+          },
+        ],
+      })
+    ).toThrow('must not contain duplicates');
+
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        allowlist: new Array(65).fill(policy().allowlist[0]),
+      })
+    ).toThrow('no more than 64 values');
+  });
+
+  it('requires a scoped fingerprint and a strict mail subdomain', () => {
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        providerCredentialFingerprint: 'not-a-fingerprint',
+      })
+    ).toThrow('sha256');
+
+    expect(() =>
+      validateControlledFaultHarnessPolicy({
+        ...policy(),
+        testMailSubdomain: 'faults.example.test',
+      })
+    ).toThrow('strict subdomain');
+  });
+});

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -399,5 +399,32 @@ describe('controlled live-fault harness policy', () => {
         },
       })
     ).toThrow('recovery.records must contain at least one record');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+        recovery: {
+          ...recovery,
+          zoneId: 'other-zone',
+        },
+      })
+    ).toThrow('recovery.zoneId must match the fault artifact zoneId');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+        recovery: {
+          ...recovery,
+          records: [
+            {
+              ...recovery.records[0],
+              name: 'outside.faults.example.test',
+            },
+          ],
+        },
+      })
+    ).toThrow('recovery.records names must be declared fault artifact targets');
   });
 });

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -350,6 +350,12 @@ describe('controlled live-fault harness policy', () => {
       validateFaultRunArtifact(artifactWithoutApplication);
     }).toThrow('restoredAt requires appliedAt');
 
+    expect(() => {
+      const artifactWithoutRestoration = artifact();
+      delete artifactWithoutRestoration.restoredAt;
+      validateFaultRunArtifact(artifactWithoutRestoration);
+    }).toThrow('PASS requires appliedAt and restoredAt');
+
     expect(() =>
       validateFaultRunArtifact({
         ...artifact(),

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -356,13 +356,36 @@ describe('controlled live-fault harness policy', () => {
         ...artifact(),
         result: 'RECOVERY_REQUIRED',
       })
-    ).toThrow('recoveryInstructions are required');
+    ).toThrow('recovery is required');
+
+    const recovery = {
+      provider: 'example-provider',
+      zoneId: 'zone-123',
+      records: [
+        {
+          name: 'mail.faults.example.test',
+          type: 'TXT' as const,
+          desiredValue: 'v=spf1 -all',
+        },
+      ],
+      operatorCommands: ['restore-record: 200'],
+    };
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+        recovery,
+      })
+    ).not.toThrow();
 
     expect(() =>
       validateFaultRunArtifact({
         ...artifact(),
         result: 'RECOVERY_REQUIRED',
-        recoveryInstructions: 'Use the secret abc123',
+        recovery: {
+          ...recovery,
+          operatorCommands: ['Use API key sk_live_abc123'],
+        },
       })
     ).toThrow('must not contain credential material');
 
@@ -370,8 +393,11 @@ describe('controlled live-fault harness policy', () => {
       validateFaultRunArtifact({
         ...artifact(),
         result: 'RECOVERY_REQUIRED',
-        recoveryInstructions: 'Use API key sk_live_abc123 to restore the record',
+        recovery: {
+          ...recovery,
+          records: [],
+        },
       })
-    ).toThrow('must not contain credential material');
+    ).toThrow('recovery.records must contain at least one record');
   });
 });

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -395,6 +395,17 @@ describe('controlled live-fault harness policy', () => {
         result: 'RECOVERY_REQUIRED',
         recovery: {
           ...recovery,
+          operatorCommands: ['Cookie: session=must-not-be-stored'],
+        },
+      })
+    ).toThrow('must not contain credential material');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
+        result: 'RECOVERY_REQUIRED',
+        recovery: {
+          ...recovery,
           records: [],
         },
       })

--- a/packages/contracts/src/live-fault-harness.test.ts
+++ b/packages/contracts/src/live-fault-harness.test.ts
@@ -340,6 +340,13 @@ describe('controlled live-fault harness policy', () => {
     expect(() =>
       validateFaultRunArtifact({
         ...artifact(),
+        restoredAt: '2026-07-29T18:59:59Z',
+      })
+    ).toThrow('restoredAt must not be earlier than appliedAt');
+
+    expect(() =>
+      validateFaultRunArtifact({
+        ...artifact(),
         baselineHash: ` ${fingerprint}`,
       })
     ).toThrow('surrounding whitespace');

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -43,6 +43,34 @@ export interface AuthorizedControlledFaultMutation {
   providerCredentialFingerprint: string;
 }
 
+export const FAULT_RUN_RESULTS = ['PASS', 'FAIL', 'RECOVERY_REQUIRED'] as const;
+
+export type FaultRunResult = (typeof FAULT_RUN_RESULTS)[number];
+
+/**
+ * Redacted, durable evidence emitted by the future isolated provider harness.
+ * It intentionally permits only a credential fingerprint, never a token value.
+ */
+export interface FaultRunArtifact {
+  runId: string;
+  mutationId: LiveFaultMutationId;
+  zoneId: string;
+  targetNames: readonly string[];
+  baselineHash: string;
+  providerCredentialFingerprint: string;
+  appliedAt?: string;
+  restoredAt?: string;
+  providerResponses: readonly string[];
+  authoritativeEvidenceIds: readonly string[];
+  recursiveEvidenceIds: readonly string[];
+  scanTaskIds: readonly string[];
+  signalIds: readonly string[];
+  caseIds: readonly string[];
+  auditEventIds: readonly string[];
+  result: FaultRunResult;
+  recoveryInstructions?: string;
+}
+
 interface ValidatedControlledFaultPolicy {
   testDomain: string;
   testWebHost: string;
@@ -79,7 +107,35 @@ const policyKeys = new Set([
 ]);
 const allowlistEntryKeys = new Set(['name', 'types', 'mutationIds']);
 const requestKeys = new Set(['zoneId', 'name', 'type', 'mutationId']);
+const faultRunArtifactKeys = new Set([
+  'runId',
+  'mutationId',
+  'zoneId',
+  'targetNames',
+  'baselineHash',
+  'providerCredentialFingerprint',
+  'appliedAt',
+  'restoredAt',
+  'providerResponses',
+  'authoritativeEvidenceIds',
+  'recursiveEvidenceIds',
+  'scanTaskIds',
+  'signalIds',
+  'caseIds',
+  'auditEventIds',
+  'result',
+  'recoveryInstructions',
+]);
 const maximumAllowlistEntries = 64;
+const maximumArtifactItems = 128;
+const maximumArtifactSummaryLength = 1_024;
+const redactedArtifactPattern =
+  /(?:authorization|x-auth-token|x-api-key|(?:access|api|provider)[_-]?token|(?:set-)?cookie|password|secret)\s*[:=]|bearer\s+/i;
+const artifactIdentifierPattern = /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,255}$/;
+const providerResponsePattern = /^[a-z][a-z0-9._-]{0,63}: (?:[1-5]\d\d|[A-Z][A-Z0-9_]{1,63})$/;
+const isoTimestampPattern = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?Z$/;
+const recoveryInstructionSecretPattern =
+  /\b(?:token|secret|password|authorization|cookie|bearer|api[ _-]?key|private[ _-]?key|credential)\b/i;
 
 type DataDescriptorMap = Record<string, PropertyDescriptor>;
 
@@ -91,6 +147,14 @@ function assertNonEmpty(value: unknown, label: string): string {
   const normalized = value.trim();
   if (!normalized) {
     throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function assertCanonicalArtifactText(value: unknown, label: string): string {
+  const normalized = assertNonEmpty(value, label);
+  if (value !== normalized) {
+    throw new Error(`${label} must not contain surrounding whitespace`);
   }
   return normalized;
 }
@@ -338,6 +402,141 @@ function normalizeControlledFaultMutationRequest(
       'controlled fault mutation ID'
     ),
   };
+}
+
+function validateArtifactSummary(value: unknown, label: string): void {
+  const summary = assertCanonicalArtifactText(value, label);
+  if (
+    summary.length > maximumArtifactSummaryLength ||
+    /[\r\n]/.test(summary) ||
+    redactedArtifactPattern.test(summary)
+  ) {
+    throw new Error(`${label} must be a bounded redacted summary`);
+  }
+}
+
+function validateArtifactIdentifier(value: unknown, label: string): void {
+  const identifier = assertCanonicalArtifactText(value, label);
+  if (!artifactIdentifierPattern.test(identifier) || redactedArtifactPattern.test(identifier)) {
+    throw new Error(`${label} must be a bounded non-secret identifier`);
+  }
+}
+
+function validateArtifactIdList(value: unknown, label: string): void {
+  const values = readDataArray(value, label, maximumArtifactItems);
+  for (const item of values) {
+    validateArtifactIdentifier(item, label);
+  }
+}
+
+function validateProviderResponseList(value: unknown): void {
+  const values = readDataArray(value, 'providerResponses', maximumArtifactItems);
+  for (const item of values) {
+    const response = assertCanonicalArtifactText(item, 'providerResponses');
+    if (!providerResponsePattern.test(response)) {
+      throw new Error('providerResponses must contain only operation/status summaries');
+    }
+  }
+}
+
+function validateRecoveryInstructions(value: unknown): void {
+  validateArtifactSummary(value, 'recoveryInstructions');
+  if (recoveryInstructionSecretPattern.test(value as string)) {
+    throw new Error('recoveryInstructions must not contain credential material');
+  }
+}
+
+function validateIsoTimestamp(value: unknown, label: string): void {
+  const timestamp = assertCanonicalArtifactText(value, label);
+  const match = isoTimestampPattern.exec(timestamp);
+  if (!match) {
+    throw new Error(`${label} must be an ISO-8601 UTC timestamp`);
+  }
+
+  const fraction = (match[2] ?? '').padEnd(3, '0');
+  const canonicalTimestamp = `${match[1]}.${fraction}Z`;
+  if (
+    Number.isNaN(Date.parse(timestamp)) ||
+    new Date(timestamp).toISOString() !== canonicalTimestamp
+  ) {
+    throw new Error(`${label} must be a calendar-valid ISO-8601 UTC timestamp`);
+  }
+}
+
+/**
+ * Validates the runbook's durable artifact shape and rejects credential/header
+ * material before an artifact can be stored or emitted. It performs no I/O.
+ */
+export function validateFaultRunArtifact(artifact: FaultRunArtifact): void {
+  const fields = readPlainDataObject(artifact, faultRunArtifactKeys);
+  validateArtifactIdentifier(readDataField(fields, 'runId'), 'runId');
+  normalizeMutationId(readDataField(fields, 'mutationId'), 'mutationId');
+  validateArtifactIdentifier(readDataField(fields, 'zoneId'), 'zoneId');
+
+  const targetNames = readDataArray(
+    readDataField(fields, 'targetNames'),
+    'targetNames',
+    maximumAllowlistEntries
+  );
+  if (targetNames.length === 0) {
+    throw new Error('targetNames must contain at least one name');
+  }
+  const normalizedTargetNames = targetNames.map((name) => {
+    const canonicalName = assertCanonicalArtifactText(name, 'targetNames entry');
+    const normalizedName = normalizeRecordName(canonicalName, 'targetNames entry');
+    if (canonicalName !== normalizedName) {
+      throw new Error('targetNames entries must be lowercase DNS names without a trailing dot');
+    }
+    return normalizedName;
+  });
+  if (new Set(normalizedTargetNames).size !== normalizedTargetNames.length) {
+    throw new Error('targetNames must not contain duplicates');
+  }
+
+  const baselineHash = assertCanonicalArtifactText(
+    readDataField(fields, 'baselineHash'),
+    'baselineHash'
+  );
+  if (!fingerprintPattern.test(baselineHash)) {
+    throw new Error('baselineHash must be a sha256:<64 lowercase hex> hash');
+  }
+  const credentialFingerprint = assertCanonicalArtifactText(
+    readDataField(fields, 'providerCredentialFingerprint'),
+    'providerCredentialFingerprint'
+  );
+  if (!fingerprintPattern.test(credentialFingerprint)) {
+    throw new Error(
+      'providerCredentialFingerprint must be a sha256:<64 lowercase hex> fingerprint'
+    );
+  }
+
+  const appliedAt = readDataField(fields, 'appliedAt');
+  if (appliedAt !== undefined) validateIsoTimestamp(appliedAt, 'appliedAt');
+  const restoredAt = readDataField(fields, 'restoredAt');
+  if (restoredAt !== undefined) validateIsoTimestamp(restoredAt, 'restoredAt');
+
+  validateProviderResponseList(readDataField(fields, 'providerResponses'));
+  validateArtifactIdList(
+    readDataField(fields, 'authoritativeEvidenceIds'),
+    'authoritativeEvidenceIds'
+  );
+  validateArtifactIdList(readDataField(fields, 'recursiveEvidenceIds'), 'recursiveEvidenceIds');
+  validateArtifactIdList(readDataField(fields, 'scanTaskIds'), 'scanTaskIds');
+  validateArtifactIdList(readDataField(fields, 'signalIds'), 'signalIds');
+  validateArtifactIdList(readDataField(fields, 'caseIds'), 'caseIds');
+  validateArtifactIdList(readDataField(fields, 'auditEventIds'), 'auditEventIds');
+
+  const result = readDataField(fields, 'result');
+  if (!FAULT_RUN_RESULTS.includes(result as FaultRunResult)) {
+    throw new Error('result is not permitted');
+  }
+  const recoveryInstructions = readDataField(fields, 'recoveryInstructions');
+  if (result === 'RECOVERY_REQUIRED' && recoveryInstructions === undefined) {
+    throw new Error('recoveryInstructions are required when result is RECOVERY_REQUIRED');
+  }
+  if (recoveryInstructions !== undefined) {
+    validateRecoveryInstructions(recoveryInstructions);
+  }
 }
 
 /**

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -590,6 +590,9 @@ export function validateFaultRunArtifact(artifact: FaultRunArtifact): void {
   const restoredAt = readDataField(fields, 'restoredAt');
   const restoredAtMilliseconds =
     restoredAt === undefined ? undefined : validateIsoTimestamp(restoredAt, 'restoredAt');
+  if (restoredAtMilliseconds !== undefined && appliedAtMilliseconds === undefined) {
+    throw new Error('restoredAt requires appliedAt');
+  }
   if (
     appliedAtMilliseconds !== undefined &&
     restoredAtMilliseconds !== undefined &&

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -134,8 +134,8 @@ const redactedArtifactPattern =
 const artifactIdentifierPattern = /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,255}$/;
 const providerResponsePattern = /^[a-z][a-z0-9._-]{0,63}: (?:[1-5]\d\d|[A-Z][A-Z0-9_]{1,63})$/;
 const isoTimestampPattern = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?Z$/;
-const recoveryInstructionSecretPattern =
-  /\b(?:token|secret|password|authorization|cookie|bearer|api[ _-]?key|private[ _-]?key|credential)\b/i;
+const credentialMaterialPattern =
+  /(?:token|secret|password|credential|authorization|bearer|api[ _-]?key|private[ _-]?key|sk_(?:live|test)_)/i;
 
 type DataDescriptorMap = Record<string, PropertyDescriptor>;
 
@@ -361,7 +361,8 @@ function normalizeControlledFaultHarnessPolicy(policy: unknown): ValidatedContro
     );
   }
 
-  const zoneId = assertNonEmpty(readDataField(fields, 'zoneId'), 'zoneId');
+  const zoneId = assertCanonicalArtifactText(readDataField(fields, 'zoneId'), 'zoneId');
+  validateArtifactIdentifier(zoneId, 'zoneId');
   const providerCredentialFingerprint = assertNonEmpty(
     readDataField(fields, 'providerCredentialFingerprint'),
     'providerCredentialFingerprint'
@@ -387,8 +388,13 @@ function normalizeControlledFaultMutationRequest(
   request: unknown
 ): ValidatedControlledFaultRequest {
   const fields = readPlainDataObject(request, requestKeys);
+  const zoneId = assertCanonicalArtifactText(
+    readDataField(fields, 'zoneId'),
+    'controlled fault mutation zoneId'
+  );
+  validateArtifactIdentifier(zoneId, 'controlled fault mutation zoneId');
   return {
-    zoneId: assertNonEmpty(readDataField(fields, 'zoneId'), 'controlled fault mutation zoneId'),
+    zoneId,
     name: normalizeRecordName(
       readDataField(fields, 'name'),
       'controlled fault mutation record name'
@@ -417,7 +423,7 @@ function validateArtifactSummary(value: unknown, label: string): void {
 
 function validateArtifactIdentifier(value: unknown, label: string): void {
   const identifier = assertCanonicalArtifactText(value, label);
-  if (!artifactIdentifierPattern.test(identifier) || redactedArtifactPattern.test(identifier)) {
+  if (!artifactIdentifierPattern.test(identifier) || credentialMaterialPattern.test(identifier)) {
     throw new Error(`${label} must be a bounded non-secret identifier`);
   }
 }
@@ -441,7 +447,7 @@ function validateProviderResponseList(value: unknown): void {
 
 function validateRecoveryInstructions(value: unknown): void {
   validateArtifactSummary(value, 'recoveryInstructions');
-  if (recoveryInstructionSecretPattern.test(value as string)) {
+  if (credentialMaterialPattern.test(value as string)) {
     throw new Error('recoveryInstructions must not contain credential material');
   }
 }

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -623,6 +623,15 @@ export function validateFaultRunArtifact(artifact: FaultRunArtifact): void {
   if (result !== 'RECOVERY_REQUIRED' && recovery !== undefined) {
     throw new Error('recovery is only permitted when result is RECOVERY_REQUIRED');
   }
+  if (
+    result === 'PASS' &&
+    (appliedAtMilliseconds === undefined || restoredAtMilliseconds === undefined)
+  ) {
+    throw new Error('PASS requires appliedAt and restoredAt');
+  }
+  if (result === 'RECOVERY_REQUIRED' && appliedAtMilliseconds === undefined) {
+    throw new Error('RECOVERY_REQUIRED requires appliedAt');
+  }
   if (recovery !== undefined) {
     validateRecoveryArtifact(recovery, artifactZoneId, normalizedTargetNames);
   }

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -520,7 +520,7 @@ function validateRecoveryArtifact(
   }
 }
 
-function validateIsoTimestamp(value: unknown, label: string): void {
+function validateIsoTimestamp(value: unknown, label: string): number {
   const timestamp = assertCanonicalArtifactText(value, label);
   const match = isoTimestampPattern.exec(timestamp);
   if (!match) {
@@ -529,12 +529,11 @@ function validateIsoTimestamp(value: unknown, label: string): void {
 
   const fraction = (match[2] ?? '').padEnd(3, '0');
   const canonicalTimestamp = `${match[1]}.${fraction}Z`;
-  if (
-    Number.isNaN(Date.parse(timestamp)) ||
-    new Date(timestamp).toISOString() !== canonicalTimestamp
-  ) {
+  const milliseconds = Date.parse(timestamp);
+  if (Number.isNaN(milliseconds) || new Date(milliseconds).toISOString() !== canonicalTimestamp) {
     throw new Error(`${label} must be a calendar-valid ISO-8601 UTC timestamp`);
   }
+  return milliseconds;
 }
 
 /**
@@ -586,9 +585,18 @@ export function validateFaultRunArtifact(artifact: FaultRunArtifact): void {
   }
 
   const appliedAt = readDataField(fields, 'appliedAt');
-  if (appliedAt !== undefined) validateIsoTimestamp(appliedAt, 'appliedAt');
+  const appliedAtMilliseconds =
+    appliedAt === undefined ? undefined : validateIsoTimestamp(appliedAt, 'appliedAt');
   const restoredAt = readDataField(fields, 'restoredAt');
-  if (restoredAt !== undefined) validateIsoTimestamp(restoredAt, 'restoredAt');
+  const restoredAtMilliseconds =
+    restoredAt === undefined ? undefined : validateIsoTimestamp(restoredAt, 'restoredAt');
+  if (
+    appliedAtMilliseconds !== undefined &&
+    restoredAtMilliseconds !== undefined &&
+    restoredAtMilliseconds < appliedAtMilliseconds
+  ) {
+    throw new Error('restoredAt must not be earlier than appliedAt');
+  }
 
   validateProviderResponseList(readDataField(fields, 'providerResponses'));
   validateArtifactIdList(

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -148,7 +148,7 @@ const artifactIdentifierPattern = /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,255}$/;
 const providerResponsePattern = /^[a-z][a-z0-9._-]{0,63}: (?:[1-5]\d\d|[A-Z][A-Z0-9_]{1,63})$/;
 const isoTimestampPattern = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?Z$/;
 const credentialMaterialPattern =
-  /(?:token|secret|password|credential|authorization|bearer|api[ _-]?key|private[ _-]?key|sk_(?:live|test)_)/i;
+  /(?:token|secret|password|credential|authorization|bearer|cookie|session|api[ _-]?key|private[ _-]?key|sk_(?:live|test)_)/i;
 
 type DataDescriptorMap = Record<string, PropertyDescriptor>;
 

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -454,10 +454,21 @@ function validateRecoveryText(value: unknown, label: string, maximumLength: numb
   }
 }
 
-function validateRecoveryArtifact(value: unknown): void {
+function validateRecoveryArtifact(
+  value: unknown,
+  artifactZoneId: string,
+  artifactTargetNames: readonly string[]
+): void {
   const fields = readPlainDataObject(value, faultRecoveryKeys);
   validateArtifactIdentifier(readDataField(fields, 'provider'), 'recovery.provider');
-  validateArtifactIdentifier(readDataField(fields, 'zoneId'), 'recovery.zoneId');
+  const recoveryZoneId = assertCanonicalArtifactText(
+    readDataField(fields, 'zoneId'),
+    'recovery.zoneId'
+  );
+  validateArtifactIdentifier(recoveryZoneId, 'recovery.zoneId');
+  if (recoveryZoneId !== artifactZoneId) {
+    throw new Error('recovery.zoneId must match the fault artifact zoneId');
+  }
 
   const records = readDataArray(
     readDataField(fields, 'records'),
@@ -476,6 +487,9 @@ function validateRecoveryArtifact(value: unknown): void {
     const normalizedName = normalizeRecordName(name, 'recovery.records name');
     if (name !== normalizedName) {
       throw new Error('recovery.records names must be lowercase DNS names without a trailing dot');
+    }
+    if (!artifactTargetNames.includes(normalizedName)) {
+      throw new Error('recovery.records names must be declared fault artifact targets');
     }
     normalizeRecordType(readDataField(recordFields, 'type'), 'recovery.records type');
     validateRecoveryText(
@@ -523,7 +537,8 @@ export function validateFaultRunArtifact(artifact: FaultRunArtifact): void {
   const fields = readPlainDataObject(artifact, faultRunArtifactKeys);
   validateArtifactIdentifier(readDataField(fields, 'runId'), 'runId');
   normalizeMutationId(readDataField(fields, 'mutationId'), 'mutationId');
-  validateArtifactIdentifier(readDataField(fields, 'zoneId'), 'zoneId');
+  const artifactZoneId = assertCanonicalArtifactText(readDataField(fields, 'zoneId'), 'zoneId');
+  validateArtifactIdentifier(artifactZoneId, 'zoneId');
 
   const targetNames = readDataArray(
     readDataField(fields, 'targetNames'),
@@ -590,7 +605,7 @@ export function validateFaultRunArtifact(artifact: FaultRunArtifact): void {
     throw new Error('recovery is only permitted when result is RECOVERY_REQUIRED');
   }
   if (recovery !== undefined) {
-    validateRecoveryArtifact(recovery);
+    validateRecoveryArtifact(recovery, artifactZoneId, normalizedTargetNames);
   }
 }
 

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -51,6 +51,19 @@ export type FaultRunResult = (typeof FAULT_RUN_RESULTS)[number];
  * Redacted, durable evidence emitted by the future isolated provider harness.
  * It intentionally permits only a credential fingerprint, never a token value.
  */
+export interface FaultRecoveryArtifact {
+  provider: string;
+  zoneId: string;
+  records: readonly FaultRecoveryRecord[];
+  operatorCommands: readonly string[];
+}
+
+export interface FaultRecoveryRecord {
+  name: string;
+  type: ControlledFaultRecordType;
+  desiredValue: string;
+}
+
 export interface FaultRunArtifact {
   runId: string;
   mutationId: LiveFaultMutationId;
@@ -68,7 +81,7 @@ export interface FaultRunArtifact {
   caseIds: readonly string[];
   auditEventIds: readonly string[];
   result: FaultRunResult;
-  recoveryInstructions?: string;
+  recovery?: FaultRecoveryArtifact;
 }
 
 interface ValidatedControlledFaultPolicy {
@@ -124,13 +137,13 @@ const faultRunArtifactKeys = new Set([
   'caseIds',
   'auditEventIds',
   'result',
-  'recoveryInstructions',
+  'recovery',
 ]);
+const faultRecoveryKeys = new Set(['provider', 'zoneId', 'records', 'operatorCommands']);
+const faultRecoveryRecordKeys = new Set(['name', 'type', 'desiredValue']);
 const maximumAllowlistEntries = 64;
 const maximumArtifactItems = 128;
 const maximumArtifactSummaryLength = 1_024;
-const redactedArtifactPattern =
-  /(?:authorization|x-auth-token|x-api-key|(?:access|api|provider)[_-]?token|(?:set-)?cookie|password|secret)\s*[:=]|bearer\s+/i;
 const artifactIdentifierPattern = /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,255}$/;
 const providerResponsePattern = /^[a-z][a-z0-9._-]{0,63}: (?:[1-5]\d\d|[A-Z][A-Z0-9_]{1,63})$/;
 const isoTimestampPattern = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?Z$/;
@@ -410,17 +423,6 @@ function normalizeControlledFaultMutationRequest(
   };
 }
 
-function validateArtifactSummary(value: unknown, label: string): void {
-  const summary = assertCanonicalArtifactText(value, label);
-  if (
-    summary.length > maximumArtifactSummaryLength ||
-    /[\r\n]/.test(summary) ||
-    redactedArtifactPattern.test(summary)
-  ) {
-    throw new Error(`${label} must be a bounded redacted summary`);
-  }
-}
-
 function validateArtifactIdentifier(value: unknown, label: string): void {
   const identifier = assertCanonicalArtifactText(value, label);
   if (!artifactIdentifierPattern.test(identifier) || credentialMaterialPattern.test(identifier)) {
@@ -445,10 +447,54 @@ function validateProviderResponseList(value: unknown): void {
   }
 }
 
-function validateRecoveryInstructions(value: unknown): void {
-  validateArtifactSummary(value, 'recoveryInstructions');
-  if (credentialMaterialPattern.test(value as string)) {
-    throw new Error('recoveryInstructions must not contain credential material');
+function validateRecoveryText(value: unknown, label: string, maximumLength: number): void {
+  const text = assertCanonicalArtifactText(value, label);
+  if (text.length > maximumLength || /[\r\n]/.test(text) || credentialMaterialPattern.test(text)) {
+    throw new Error(`${label} must be bounded and must not contain credential material`);
+  }
+}
+
+function validateRecoveryArtifact(value: unknown): void {
+  const fields = readPlainDataObject(value, faultRecoveryKeys);
+  validateArtifactIdentifier(readDataField(fields, 'provider'), 'recovery.provider');
+  validateArtifactIdentifier(readDataField(fields, 'zoneId'), 'recovery.zoneId');
+
+  const records = readDataArray(
+    readDataField(fields, 'records'),
+    'recovery.records',
+    maximumAllowlistEntries
+  );
+  if (records.length === 0) {
+    throw new Error('recovery.records must contain at least one record');
+  }
+  for (const record of records) {
+    const recordFields = readPlainDataObject(record, faultRecoveryRecordKeys);
+    const name = assertCanonicalArtifactText(
+      readDataField(recordFields, 'name'),
+      'recovery.records name'
+    );
+    const normalizedName = normalizeRecordName(name, 'recovery.records name');
+    if (name !== normalizedName) {
+      throw new Error('recovery.records names must be lowercase DNS names without a trailing dot');
+    }
+    normalizeRecordType(readDataField(recordFields, 'type'), 'recovery.records type');
+    validateRecoveryText(
+      readDataField(recordFields, 'desiredValue'),
+      'recovery.records desiredValue',
+      4_096
+    );
+  }
+
+  const commands = readDataArray(
+    readDataField(fields, 'operatorCommands'),
+    'recovery.operatorCommands',
+    maximumArtifactItems
+  );
+  if (commands.length === 0) {
+    throw new Error('recovery.operatorCommands must contain at least one command');
+  }
+  for (const command of commands) {
+    validateRecoveryText(command, 'recovery.operatorCommands', maximumArtifactSummaryLength);
   }
 }
 
@@ -536,12 +582,15 @@ export function validateFaultRunArtifact(artifact: FaultRunArtifact): void {
   if (!FAULT_RUN_RESULTS.includes(result as FaultRunResult)) {
     throw new Error('result is not permitted');
   }
-  const recoveryInstructions = readDataField(fields, 'recoveryInstructions');
-  if (result === 'RECOVERY_REQUIRED' && recoveryInstructions === undefined) {
-    throw new Error('recoveryInstructions are required when result is RECOVERY_REQUIRED');
+  const recovery = readDataField(fields, 'recovery');
+  if (result === 'RECOVERY_REQUIRED' && recovery === undefined) {
+    throw new Error('recovery is required when result is RECOVERY_REQUIRED');
   }
-  if (recoveryInstructions !== undefined) {
-    validateRecoveryInstructions(recoveryInstructions);
+  if (result !== 'RECOVERY_REQUIRED' && recovery !== undefined) {
+    throw new Error('recovery is only permitted when result is RECOVERY_REQUIRED');
+  }
+  if (recovery !== undefined) {
+    validateRecoveryArtifact(recovery);
   }
 }
 

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -1,0 +1,387 @@
+export const LIVE_FAULT_MUTATION_IDS = ['LIVE-01', 'LIVE-02', 'LIVE-03'] as const;
+
+export type LiveFaultMutationId = (typeof LIVE_FAULT_MUTATION_IDS)[number];
+
+export const CONTROLLED_FAULT_RECORD_TYPES = ['A', 'AAAA', 'CNAME', 'TXT'] as const;
+
+export type ControlledFaultRecordType = (typeof CONTROLLED_FAULT_RECORD_TYPES)[number];
+
+/**
+ * Secret-free configuration required by an isolated future live-fault harness.
+ * DNS Ops and MCP must never receive a provider token; the harness resolves its
+ * credential from its own runtime secret only after this policy is validated.
+ */
+export interface ControlledFaultHarnessPolicy {
+  testDomain: string;
+  testWebHost: string;
+  testMailSubdomain: string;
+  providerKind: string;
+  zoneId: string;
+  providerCredentialFingerprint: string;
+  allowlist: readonly ControlledFaultAllowlistEntry[];
+}
+
+export interface ControlledFaultAllowlistEntry {
+  name: string;
+  types: readonly ControlledFaultRecordType[];
+  mutationIds: readonly LiveFaultMutationId[];
+}
+
+export interface ControlledFaultMutationRequest {
+  zoneId: string;
+  name: string;
+  type: ControlledFaultRecordType;
+  mutationId: LiveFaultMutationId;
+}
+
+export interface AuthorizedControlledFaultMutation {
+  zoneId: string;
+  name: string;
+  type: ControlledFaultRecordType;
+  mutationId: LiveFaultMutationId;
+  providerKind: string;
+  providerCredentialFingerprint: string;
+}
+
+interface ValidatedControlledFaultPolicy {
+  testDomain: string;
+  testWebHost: string;
+  testMailSubdomain: string;
+  providerKind: string;
+  zoneId: string;
+  providerCredentialFingerprint: string;
+  allowlist: readonly {
+    name: string;
+    types: readonly ControlledFaultRecordType[];
+    mutationIds: readonly LiveFaultMutationId[];
+  }[];
+}
+
+interface ValidatedControlledFaultRequest {
+  zoneId: string;
+  name: string;
+  type: ControlledFaultRecordType;
+  mutationId: LiveFaultMutationId;
+}
+
+const hostnameLabel = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const recordLabel = /^[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?$/;
+const fingerprintPattern = /^sha256:[a-f0-9]{64}$/;
+const providerKindPattern = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const policyKeys = new Set([
+  'testDomain',
+  'testWebHost',
+  'testMailSubdomain',
+  'providerKind',
+  'zoneId',
+  'providerCredentialFingerprint',
+  'allowlist',
+]);
+const allowlistEntryKeys = new Set(['name', 'types', 'mutationIds']);
+const requestKeys = new Set(['zoneId', 'name', 'type', 'mutationId']);
+const maximumAllowlistEntries = 64;
+
+type DataDescriptorMap = Record<string, PropertyDescriptor>;
+
+function assertNonEmpty(value: unknown, label: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function normalizeDnsName(value: unknown, label: string, pattern: RegExp): string {
+  const normalized = assertNonEmpty(value, label).toLowerCase().replace(/\.$/, '');
+  if (normalized.length > 253) {
+    throw new Error(`${label} must contain a DNS name of 1-253 characters`);
+  }
+
+  const labels = normalized.split('.');
+  if (labels.some((part) => !pattern.test(part))) {
+    throw new Error(`${label} must be a valid lowercase DNS name`);
+  }
+
+  return normalized;
+}
+
+function normalizeHostname(value: unknown, label: string): string {
+  return normalizeDnsName(value, label, hostnameLabel);
+}
+
+function normalizeRecordName(value: unknown, label: string): string {
+  return normalizeDnsName(value, label, recordLabel);
+}
+
+function normalizeRecordType(value: unknown, label: string): ControlledFaultRecordType {
+  if (!CONTROLLED_FAULT_RECORD_TYPES.includes(value as ControlledFaultRecordType)) {
+    throw new Error(`${label} is not permitted`);
+  }
+  return value as ControlledFaultRecordType;
+}
+
+function normalizeMutationId(value: unknown, label: string): LiveFaultMutationId {
+  if (!LIVE_FAULT_MUTATION_IDS.includes(value as LiveFaultMutationId)) {
+    throw new Error(`${label} is not permitted`);
+  }
+  return value as LiveFaultMutationId;
+}
+
+function isNameInDomain(name: string, domain: string): boolean {
+  return name === domain || name.endsWith(`.${domain}`);
+}
+
+/**
+ * Accept only plain, enumerable data objects. This rejects accessors,
+ * non-enumerable keys, symbols, prototypes, and unknown fields before values
+ * are copied into a canonical immutable validation snapshot.
+ */
+function readPlainDataObject(value: unknown, allowedKeys: ReadonlySet<string>): DataDescriptorMap {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Controlled fault policy objects must be plain enumerable data objects');
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error('Controlled fault policy objects must be plain enumerable data objects');
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (typeof key !== 'string' || !allowedKeys.has(key)) {
+      throw new Error(
+        'Controlled fault policy must not contain a provider credential value or unknown field'
+      );
+    }
+
+    const descriptor = descriptors[key];
+    if (!descriptor.enumerable || !('value' in descriptor)) {
+      throw new Error('Controlled fault policy objects must contain only enumerable data fields');
+    }
+  }
+
+  return descriptors;
+}
+
+function readDataField(descriptors: DataDescriptorMap, key: string): unknown {
+  return descriptors[key]?.value;
+}
+
+function readDataArray(value: unknown, label: string, maximumLength: number): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+
+  const declaredLengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
+  if (
+    !declaredLengthDescriptor ||
+    !('value' in declaredLengthDescriptor) ||
+    !Number.isSafeInteger(declaredLengthDescriptor.value)
+  ) {
+    throw new Error(`${label} must be a plain data array`);
+  }
+  if (declaredLengthDescriptor.value > maximumLength) {
+    throw new Error(`${label} must contain no more than ${maximumLength} values`);
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(value) as DataDescriptorMap;
+  const lengthDescriptor = descriptors.length;
+  if (
+    !lengthDescriptor ||
+    !('value' in lengthDescriptor) ||
+    !Number.isSafeInteger(lengthDescriptor.value)
+  ) {
+    throw new Error(`${label} must be a plain data array`);
+  }
+
+  const length = lengthDescriptor.value as number;
+  const indexedValues: Array<{ index: number; value: unknown }> = [];
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (key === 'length') continue;
+    if (typeof key !== 'string' || !/^(0|[1-9]\d*)$/.test(key)) {
+      throw new Error(`${label} must not contain extra fields`);
+    }
+
+    const index = Number(key);
+    if (index >= length) {
+      throw new Error(`${label} contains an index outside its declared length`);
+    }
+
+    const descriptor = descriptors[key];
+    if (!descriptor.enumerable || !('value' in descriptor)) {
+      throw new Error(`${label} must contain only enumerable data values`);
+    }
+    indexedValues.push({ index, value: descriptor.value });
+  }
+
+  if (indexedValues.length !== length) {
+    throw new Error(`${label} must not be sparse or accessor-backed`);
+  }
+
+  return indexedValues.sort((left, right) => left.index - right.index).map(({ value }) => value);
+}
+
+function normalizeAllowlist(
+  value: unknown,
+  testDomain: string
+): ValidatedControlledFaultPolicy['allowlist'] {
+  const entries = readDataArray(value, 'allowlist', maximumAllowlistEntries);
+  if (entries.length === 0) {
+    throw new Error('allowlist must contain at least one explicitly approved record');
+  }
+
+  const seenEntries = new Set<string>();
+  return entries.map((entry) => {
+    const fields = readPlainDataObject(entry, allowlistEntryKeys);
+    const name = normalizeRecordName(readDataField(fields, 'name'), 'allowlist record name');
+    if (!isNameInDomain(name, testDomain)) {
+      throw new Error('allowlist record name must remain inside testDomain');
+    }
+
+    const types = readDataArray(
+      readDataField(fields, 'types'),
+      'allowlist record types',
+      CONTROLLED_FAULT_RECORD_TYPES.length
+    ).map((type) => normalizeRecordType(type, 'allowlist record type'));
+    const mutationIds = readDataArray(
+      readDataField(fields, 'mutationIds'),
+      'allowlist mutation IDs',
+      LIVE_FAULT_MUTATION_IDS.length
+    ).map((mutationId) => normalizeMutationId(mutationId, 'allowlist mutation ID'));
+    if (types.length === 0 || mutationIds.length === 0) {
+      throw new Error(
+        'each allowlist entry must authorize at least one record type and mutation ID'
+      );
+    }
+    if (new Set(types).size !== types.length || new Set(mutationIds).size !== mutationIds.length) {
+      throw new Error('allowlist record types and mutation IDs must not contain duplicates');
+    }
+
+    const entryKey = `${name}:${[...types].sort().join(',')}:${[...mutationIds].sort().join(',')}`;
+    if (seenEntries.has(entryKey)) {
+      throw new Error('allowlist must not contain duplicate authorization entries');
+    }
+    seenEntries.add(entryKey);
+
+    return { name, types, mutationIds };
+  });
+}
+
+function normalizeControlledFaultHarnessPolicy(policy: unknown): ValidatedControlledFaultPolicy {
+  const fields = readPlainDataObject(policy, policyKeys);
+  const testDomain = normalizeHostname(readDataField(fields, 'testDomain'), 'testDomain');
+  const testWebHost = normalizeHostname(readDataField(fields, 'testWebHost'), 'testWebHost');
+  const testMailSubdomain = normalizeHostname(
+    readDataField(fields, 'testMailSubdomain'),
+    'testMailSubdomain'
+  );
+
+  if (!isNameInDomain(testWebHost, testDomain)) {
+    throw new Error('testWebHost must be the test domain or one of its subdomains');
+  }
+  if (testMailSubdomain === testDomain || !isNameInDomain(testMailSubdomain, testDomain)) {
+    throw new Error('testMailSubdomain must be a strict subdomain of testDomain');
+  }
+
+  const providerKind = assertNonEmpty(
+    readDataField(fields, 'providerKind'),
+    'providerKind'
+  ).toLowerCase();
+  if (!providerKindPattern.test(providerKind)) {
+    throw new Error(
+      'providerKind must contain 1-64 lowercase letters, digits, dots, underscores, or hyphens'
+    );
+  }
+
+  const zoneId = assertNonEmpty(readDataField(fields, 'zoneId'), 'zoneId');
+  const providerCredentialFingerprint = assertNonEmpty(
+    readDataField(fields, 'providerCredentialFingerprint'),
+    'providerCredentialFingerprint'
+  );
+  if (!fingerprintPattern.test(providerCredentialFingerprint)) {
+    throw new Error(
+      'providerCredentialFingerprint must be a sha256:<64 lowercase hex> fingerprint'
+    );
+  }
+
+  return {
+    testDomain,
+    testWebHost,
+    testMailSubdomain,
+    providerKind,
+    zoneId,
+    providerCredentialFingerprint,
+    allowlist: normalizeAllowlist(readDataField(fields, 'allowlist'), testDomain),
+  };
+}
+
+function normalizeControlledFaultMutationRequest(
+  request: unknown
+): ValidatedControlledFaultRequest {
+  const fields = readPlainDataObject(request, requestKeys);
+  return {
+    zoneId: assertNonEmpty(readDataField(fields, 'zoneId'), 'controlled fault mutation zoneId'),
+    name: normalizeRecordName(
+      readDataField(fields, 'name'),
+      'controlled fault mutation record name'
+    ),
+    type: normalizeRecordType(
+      readDataField(fields, 'type'),
+      'controlled fault mutation record type'
+    ),
+    mutationId: normalizeMutationId(
+      readDataField(fields, 'mutationId'),
+      'controlled fault mutation ID'
+    ),
+  };
+}
+
+/**
+ * Validates the complete fail-closed policy before a future isolated harness can
+ * resolve a runtime credential or contact a provider. This module has no
+ * provider client and therefore cannot perform any DNS or hosting mutation.
+ */
+export function validateControlledFaultHarnessPolicy(policy: ControlledFaultHarnessPolicy): void {
+  normalizeControlledFaultHarnessPolicy(policy);
+}
+
+/**
+ * Returns an authorization only for an exact zone/name/type/mutation tuple.
+ * Policy and request values are canonicalized before comparison, so later
+ * getter/mutation changes to caller-owned objects cannot alter authorization.
+ * A future provider adapter must call this before every provider operation.
+ */
+export function authorizeControlledFaultMutation(
+  policy: ControlledFaultHarnessPolicy,
+  request: ControlledFaultMutationRequest
+): AuthorizedControlledFaultMutation {
+  const validatedPolicy = normalizeControlledFaultHarnessPolicy(policy);
+  const validatedRequest = normalizeControlledFaultMutationRequest(request);
+
+  if (validatedRequest.zoneId !== validatedPolicy.zoneId) {
+    throw new Error('controlled fault mutation zone is not authorized');
+  }
+
+  const authorized = validatedPolicy.allowlist.some(
+    (entry) =>
+      entry.name === validatedRequest.name &&
+      entry.types.includes(validatedRequest.type) &&
+      entry.mutationIds.includes(validatedRequest.mutationId)
+  );
+  if (!authorized) {
+    throw new Error('controlled fault mutation is not allowlisted');
+  }
+
+  return {
+    zoneId: validatedPolicy.zoneId,
+    name: validatedRequest.name,
+    type: validatedRequest.type,
+    mutationId: validatedRequest.mutationId,
+    providerKind: validatedPolicy.providerKind,
+    providerCredentialFingerprint: validatedPolicy.providerCredentialFingerprint,
+  };
+}

--- a/packages/contracts/src/live-fault-harness.ts
+++ b/packages/contracts/src/live-fault-harness.ts
@@ -148,7 +148,8 @@ const artifactIdentifierPattern = /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,255}$/;
 const providerResponsePattern = /^[a-z][a-z0-9._-]{0,63}: (?:[1-5]\d\d|[A-Z][A-Z0-9_]{1,63})$/;
 const isoTimestampPattern = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?Z$/;
 const credentialMaterialPattern =
-  /(?:token|secret|password|credential|authorization|bearer|cookie|session|api[ _-]?key|private[ _-]?key|sk_(?:live|test)_)/i;
+  /(?:token|secret|password|credential|authorization|bearer|cookie|session|api[ _-]?key|private[ _-]?key|sk_(?:live|test)_|gh[pousr]_[a-zA-Z0-9]{20,}|AKIA[0-9A-Z]{16}|xox[baprs]-[a-zA-Z0-9-]{10,}|eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,})/i;
+const recoveryOperationPattern = /^[a-z][a-z0-9._-]{0,63}: (?:[1-5]\d\d|[A-Z][A-Z0-9_]{1,63})$/;
 
 type DataDescriptorMap = Record<string, PropertyDescriptor>;
 
@@ -454,6 +455,13 @@ function validateRecoveryText(value: unknown, label: string, maximumLength: numb
   }
 }
 
+function validateRecoveryOperationReference(value: unknown): void {
+  validateRecoveryText(value, 'recovery.operatorCommands', maximumArtifactSummaryLength);
+  if (!recoveryOperationPattern.test(value as string)) {
+    throw new Error('recovery.operatorCommands must contain approved operation references');
+  }
+}
+
 function validateRecoveryArtifact(
   value: unknown,
   artifactZoneId: string,
@@ -508,7 +516,7 @@ function validateRecoveryArtifact(
     throw new Error('recovery.operatorCommands must contain at least one command');
   }
   for (const command of commands) {
-    validateRecoveryText(command, 'recovery.operatorCommands', maximumArtifactSummaryLength);
+    validateRecoveryOperationReference(command);
   }
 }
 

--- a/packages/contracts/src/mail.ts
+++ b/packages/contracts/src/mail.ts
@@ -1,0 +1,11 @@
+export type SpfAnalysisScope = 'FIRST_LEVEL_ONLY';
+
+export interface FirstLevelSpfAssessment {
+  scope: SpfAnalysisScope;
+  directDnsLookupTerms: number;
+  includeDomains: string[];
+  redirectDomain?: string;
+  status: 'DIRECT_SYNTAX_VALID' | 'DIRECT_SYNTAX_INVALID' | 'UNKNOWN';
+  completeEvaluation: false;
+  limitation: string;
+}

--- a/packages/contracts/src/operations.test.ts
+++ b/packages/contracts/src/operations.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { internalConditionKey } from './operations.js';
+
+describe('internalConditionKey', () => {
+  it('normalizes bounded discriminators', () => {
+    expect(
+      internalConditionKey('tenant', 'domain', 'HTTP_ENDPOINT_UNAVAILABLE', ' Homepage ')
+    ).toBe('tenant:domain:HTTP_ENDPOINT_UNAVAILABLE:homepage');
+  });
+
+  it('rejects empty and oversized discriminators', () => {
+    expect(() =>
+      internalConditionKey('tenant', 'domain', 'HTTP_ENDPOINT_UNAVAILABLE', ' ')
+    ).toThrow('1-64');
+    expect(() =>
+      internalConditionKey('tenant', 'domain', 'HTTP_ENDPOINT_UNAVAILABLE', 'x'.repeat(65))
+    ).toThrow('1-64');
+  });
+});

--- a/packages/contracts/src/operations.ts
+++ b/packages/contracts/src/operations.ts
@@ -12,6 +12,56 @@ export type InternalCaseStatus = 'OPEN' | 'ACKNOWLEDGED' | 'BLOCKED' | 'RESOLVED
 
 export type LegacyConditionDisposition = 'MIGRATED' | 'LEGACY_ONLY' | 'DISABLED';
 
+export interface TlsCertificateBaselinePolicy {
+  kind: 'TLS_CERTIFICATE';
+  requireHostnameAuthorized: boolean;
+  requireChainAuthorized: boolean;
+  minimumRemainingValiditySeconds: number;
+}
+
+export interface SpfPresenceBaselinePolicy {
+  kind: 'SPF_PRESENT';
+}
+
+/** Accepted, explicit policy — never inferred from a scan. */
+export type OperationalConditionBaselinePolicy =
+  | TlsCertificateBaselinePolicy
+  | SpfPresenceBaselinePolicy;
+
+/** The initial baseline policies are only valid for their corresponding signal kinds. */
+export type SupportedOperationalBaseline =
+  | {
+      signalKind: 'TLS_CERTIFICATE_REGRESSION';
+      policy: TlsCertificateBaselinePolicy;
+    }
+  | {
+      signalKind: 'MAIL_DNS_CONFIGURATION_REGRESSION';
+      policy: SpfPresenceBaselinePolicy;
+    };
+
+export interface OperationalConditionBaseline {
+  id: string;
+  tenantId: string;
+  domainId: string;
+  signalKind: InternalSignalKind;
+  discriminator: string;
+  sourceSnapshotId: string;
+  policy: OperationalConditionBaselinePolicy;
+  maxEvidenceAgeSeconds: number;
+  acceptedAt: string;
+  acceptedBy: string;
+  supersededAt?: string;
+  supersededBy?: string;
+}
+
+export function normalizeOperationalDiscriminator(discriminator: string): string {
+  const normalized = discriminator.trim().toLowerCase();
+  if (!normalized || normalized.length > 64) {
+    throw new Error('Signal discriminator must contain 1-64 characters');
+  }
+  return normalized;
+}
+
 export interface LegacyConditionMapEntry {
   conditionId: string;
   disposition: LegacyConditionDisposition;
@@ -25,9 +75,6 @@ export function internalConditionKey(
   kind: InternalSignalKind,
   discriminator = 'default'
 ): string {
-  const normalizedDiscriminator = discriminator.trim().toLowerCase();
-  if (!normalizedDiscriminator || normalizedDiscriminator.length > 64) {
-    throw new Error('Signal discriminator must contain 1-64 characters');
-  }
+  const normalizedDiscriminator = normalizeOperationalDiscriminator(discriminator);
   return `${tenantId}:${domainId}:${kind}:${normalizedDiscriminator}`;
 }

--- a/packages/contracts/src/operations.ts
+++ b/packages/contracts/src/operations.ts
@@ -1,0 +1,33 @@
+export type InternalSignalKind =
+  | 'DOMAIN_EXPIRING_SOON'
+  | 'TLS_CERTIFICATE_REGRESSION'
+  | 'HTTP_ENDPOINT_UNAVAILABLE'
+  | 'REDIRECT_TOPOLOGY_REGRESSION'
+  | 'HOMEPAGE_INDEXABILITY_REGRESSION'
+  | 'MAIL_DNS_CONFIGURATION_REGRESSION';
+
+export type InternalSignalStatus = 'ACTIVE' | 'RESOLVED';
+
+export type InternalCaseStatus = 'OPEN' | 'ACKNOWLEDGED' | 'BLOCKED' | 'RESOLVED' | 'DISMISSED';
+
+export type LegacyConditionDisposition = 'MIGRATED' | 'LEGACY_ONLY' | 'DISABLED';
+
+export interface LegacyConditionMapEntry {
+  conditionId: string;
+  disposition: LegacyConditionDisposition;
+  replacementSignalKind?: InternalSignalKind;
+  notificationPath: 'SIGNAL_ALERT' | 'LEGACY_ALERT' | 'NONE';
+}
+
+export function internalConditionKey(
+  tenantId: string,
+  domainId: string,
+  kind: InternalSignalKind,
+  discriminator = 'default'
+): string {
+  const normalizedDiscriminator = discriminator.trim().toLowerCase();
+  if (!normalizedDiscriminator || normalizedDiscriminator.length > 64) {
+    throw new Error('Signal discriminator must contain 1-64 characters');
+  }
+  return `${tenantId}:${domainId}:${kind}:${normalizedDiscriminator}`;
+}

--- a/packages/contracts/src/requests.ts
+++ b/packages/contracts/src/requests.ts
@@ -246,6 +246,8 @@ export interface UpdateRemediationRequest {
   status?: RemediationStatus;
   assignedTo?: string;
   notes?: string;
+  /** Required when transitioning to resolved/closed; must be fresh and complete. */
+  verificationSnapshotId?: string;
 }
 
 export interface UpdateRemediationResponse {

--- a/packages/contracts/src/responses.ts
+++ b/packages/contracts/src/responses.ts
@@ -5,6 +5,7 @@
 
 import type { Confidence, KnownProvider, RiskPosture, Severity } from './enums.js';
 import type { EvaluationCoverage } from './evaluation.js';
+import type { GuidanceOnlySuggestion } from './guidance.js';
 import type {
   FindingSummary,
   RemediationRequestDto,
@@ -1171,21 +1172,23 @@ export interface SuggestionErrorResponse {
   error: string;
   code: string;
   suggestionId: string;
-  appliedAt?: Date;
-  appliedBy?: string;
+  historicalAcknowledgement?: {
+    acknowledgedAt: Date;
+    acknowledgedBy?: string | null;
+  };
   dismissedAt?: Date;
   reviewOnly?: boolean;
   hint?: string;
 }
 
 /**
- * PATCH /suggestions/:suggestionId/apply
- * Apply suggestion
+ * Legacy apply route refusal for guidance-only suggestions.
  */
 export interface SuggestionApplyResponse {
-  success: boolean;
-  suggestion: Suggestion;
-  confirmed?: boolean;
+  error: string;
+  code: 'GUIDANCE_ONLY';
+  suggestionId: string;
+  guidance: GuidanceOnlySuggestion;
 }
 
 /**
@@ -1735,47 +1738,24 @@ export interface RulesetVersionActivateResponse {
 // =============================================================================
 
 /**
- * Proposed DNS change
- */
-export interface ProposedChange {
-  type: string;
-  name: string;
-  recordType: string;
-  action: 'add' | 'remove' | 'modify';
-  currentValue?: string;
-  proposedValue: string;
-  rationale: string;
-}
-
-/**
- * Finding prediction
- */
-export interface FindingPrediction {
-  type: string;
-  title: string;
-  severity: Severity;
-  predictedResolution: 'resolved' | 'improved' | 'unchanged' | 'worsened';
-  confidence: Confidence;
-}
-
-/**
- * POST /simulate
- * Run simulation
+ * POST /simulate legacy route response. Generic findings produce guidance and
+ * cannot produce record mutations without complete provider-confirmed context.
  */
 export interface SimulationResponse {
-  snapshotId: string;
-  domainName: string;
-  proposedChanges: ProposedChange[];
-  predictedFindings: FindingPrediction[];
+  mode: 'GUIDANCE_ONLY';
+  domain: string;
+  detectedProvider: 'unknown';
+  proposedChanges: [];
+  guidanceOnlySuggestions: GuidanceOnlySuggestion[];
   summary: {
-    totalChanges: number;
-    predictedResolutions: number;
-    riskLevel: RiskPosture;
+    changesProposed: 0;
+    guidanceProvided: number;
+    currentFindings: number;
   };
 }
 
 /**
- * Actionable finding type
+ * Finding type with a supported guidance playbook.
  */
 export interface ActionableFindingType {
   type: string;
@@ -1784,11 +1764,15 @@ export interface ActionableFindingType {
 }
 
 /**
- * GET /simulate/actionable-types
- * List actionable finding types
+ * GET /simulate/actionable-types (legacy alias)
+ * List finding types with guidance playbooks
  */
 export interface ActionableTypesResponse {
+  mode: 'GUIDANCE_ONLY';
+  guidanceSupportedTypes: ActionableFindingType[];
+  /** Legacy response alias. */
   actionableTypes: ActionableFindingType[];
+  supportedTypeIds: string[];
 }
 
 // =============================================================================

--- a/packages/contracts/src/responses.ts
+++ b/packages/contracts/src/responses.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Confidence, KnownProvider, RiskPosture, Severity } from './enums.js';
+import type { EvaluationCoverage } from './evaluation.js';
 import type {
   FindingSummary,
   RemediationRequestDto,
@@ -428,6 +429,7 @@ export interface SnapshotListItem {
   createdAt: Date;
   rulesetVersionId: string | null;
   findingsEvaluated: boolean;
+  evaluationCoverage: EvaluationCoverage;
   queryScope: {
     names: string[];
     types: string[];
@@ -455,6 +457,7 @@ export interface SnapshotResponse {
   createdAt: Date;
   rulesetVersionId: string | null;
   findingsEvaluated: boolean;
+  evaluationCoverage: EvaluationCoverage;
   queryScope: {
     names: string[];
     types: string[];
@@ -893,6 +896,7 @@ export interface DomainWithFindings {
   updatedAt: Date;
   findings: Finding[];
   findingsEvaluated: boolean;
+  evaluationCoverage: EvaluationCoverage;
   latestSnapshot: {
     id: string;
     createdAt: Date;

--- a/packages/contracts/src/web-evidence.ts
+++ b/packages/contracts/src/web-evidence.ts
@@ -1,0 +1,113 @@
+import type { UnknownResolution } from './evaluation.js';
+
+export type EvidenceCheckResult<T> =
+  | {
+      status: 'OBSERVED';
+      observedAt: string;
+      evidence: T;
+    }
+  | {
+      status: 'UNKNOWN';
+      observedAt?: string;
+      evidence?: T;
+      unknown: UnknownResolution;
+    }
+  | {
+      status: 'NOT_APPLICABLE';
+      explanation: string;
+    };
+
+export interface RdapEventEvidence {
+  action: string;
+  date: string;
+}
+
+export interface RdapExpirationEvidence {
+  kind: 'RDAP_EXPIRATION';
+  domain: string;
+  sourceUrl: string;
+  responseStatus: number;
+  events: RdapEventEvidence[];
+  expirationDate?: string;
+  notices: string[];
+}
+
+export interface TLSCertificateEvidence {
+  kind: 'TLS_CERTIFICATE';
+  hostname: string;
+  port: number;
+  protocol: string;
+  cipher: string;
+  hostnameAuthorized: boolean;
+  chainAuthorized: boolean;
+  authorizationError?: string;
+  subject: string;
+  issuer: string;
+  subjectAlternativeNames: string[];
+  validFrom: string;
+  validTo: string;
+  fingerprintSha256: string;
+}
+
+export interface HttpRedirectHopEvidence {
+  url: string;
+  status: number;
+  location?: string;
+  resolvedAddresses: string[];
+  observedAt: string;
+}
+
+export interface HttpReachabilityEvidence {
+  kind: 'HTTP_REACHABILITY';
+  url: string;
+  responseStatus: number;
+  resolvedAddresses: string[];
+  responseTimeMs: number;
+}
+
+export interface HttpRedirectEvidence {
+  kind: 'HTTP_REDIRECT';
+  startUrl: string;
+  hops: HttpRedirectHopEvidence[];
+  finalUrl: string;
+  truncated: boolean;
+}
+
+export interface HomepageIndexabilityEvidence {
+  kind: 'HOMEPAGE_INDEXABILITY';
+  requestedUrl: string;
+  finalUrl: string;
+  responseStatus: number;
+  xRobotsTags: string[];
+  metaRobots: string[];
+  canonicalUrl?: string;
+  bodyBytesInspected: number;
+  bodyTruncated: boolean;
+}
+
+export type ExternalEvidenceData =
+  | RdapExpirationEvidence
+  | TLSCertificateEvidence
+  | HttpReachabilityEvidence
+  | HttpRedirectEvidence
+  | HomepageIndexabilityEvidence;
+
+export function purposeUndeclaredUnknown(checkLabel: string): UnknownResolution {
+  return {
+    reason: 'PURPOSE_UNDECLARED',
+    explanation: `${checkLabel} applicability cannot be determined until domain purpose is declared.`,
+    action: 'DECLARE_PURPOSE',
+    actionLabel: 'Declare domain purpose',
+    blocking: true,
+  };
+}
+
+export function probeFailedUnknown(checkLabel: string, detail: string): UnknownResolution {
+  return {
+    reason: 'PROBE_FAILED',
+    explanation: `${checkLabel} evidence could not be collected: ${detail}`,
+    action: 'RETRY_PROBE',
+    actionLabel: `Retry ${checkLabel.toLowerCase()} probe`,
+    blocking: true,
+  };
+}

--- a/packages/contracts/src/web-evidence.ts
+++ b/packages/contracts/src/web-evidence.ts
@@ -35,6 +35,7 @@ export interface RdapExpirationEvidence {
 export interface TLSCertificateEvidence {
   kind: 'TLS_CERTIFICATE';
   hostname: string;
+  resolvedAddress: string;
   port: number;
   protocol: string;
   cipher: string;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,6 +23,7 @@
     "generate": "drizzle-kit generate:pg",
     "studio": "drizzle-kit studio",
     "verify-migrations": "npx tsx scripts/verify-migrations.ts",
+    "verify-operations-concurrency": "npx tsx scripts/verify-operations-concurrency.ts",
     "check-drift": "npx tsx scripts/check-drift.ts"
   },
   "dependencies": {

--- a/packages/db/scripts/verify-operations-concurrency.ts
+++ b/packages/db/scripts/verify-operations-concurrency.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env npx tsx
+/**
+ * Verifies database-enforced canonical-signal deduplication and case-version CAS
+ * against a freshly migrated, disposable PostgreSQL schema.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... bun run --filter @dns-ops/db verify-operations-concurrency
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const { Client } = pg;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TEST_SCHEMA = `operations_concurrency_${Date.now()}`;
+const TENANT_ID = '11111111-1111-4111-8111-111111111111';
+const DOMAIN_ID = '22222222-2222-4222-8222-222222222222';
+
+function schemaQuery(schema: string): string {
+  return `SET search_path TO "${schema}", public`;
+}
+
+async function applyMigrations(client: pg.Client): Promise<void> {
+  await client.query(`CREATE SCHEMA "${TEST_SCHEMA}"`);
+  await client.query(schemaQuery(TEST_SCHEMA));
+  const migrationDirectory = join(__dirname, '../src/migrations');
+  const files = readdirSync(migrationDirectory)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  for (const file of files) {
+    const statements = readFileSync(join(migrationDirectory, file), 'utf8')
+      .split('--> statement-breakpoint')
+      .map((statement) => statement.trim())
+      .filter(Boolean);
+    for (const statement of statements) await client.query(statement);
+  }
+}
+
+async function main(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is required for isolated concurrency verification');
+  }
+
+  const setup = new Client({ connectionString });
+  const first = new Client({ connectionString });
+  const second = new Client({ connectionString });
+  try {
+    await setup.connect();
+    await applyMigrations(setup);
+    await setup.query(
+      `INSERT INTO domains (id, name, normalized_name, zone_management, tenant_id)
+       VALUES ($1, 'concurrency.example', 'concurrency.example', 'managed', $2)`,
+      [DOMAIN_ID, TENANT_ID]
+    );
+
+    await Promise.all([first.connect(), second.connect()]);
+    await Promise.all([
+      first.query(schemaQuery(TEST_SCHEMA)),
+      second.query(schemaQuery(TEST_SCHEMA)),
+    ]);
+
+    const conditionKey = `${TENANT_ID}:${DOMAIN_ID}:MAIL_DNS_CONFIGURATION_REGRESSION:spf`;
+    const inserts = await Promise.allSettled(
+      [first, second].map((client) =>
+        client.query(
+          `INSERT INTO internal_signals (tenant_id, domain_id, kind, condition_key)
+           VALUES ($1, $2, 'MAIL_DNS_CONFIGURATION_REGRESSION', $3)
+           RETURNING id`,
+          [TENANT_ID, DOMAIN_ID, conditionKey]
+        )
+      )
+    );
+    const successfulInserts = inserts.filter(
+      (result): result is PromiseFulfilledResult<pg.QueryResult<{ id: string }>> =>
+        result.status === 'fulfilled'
+    );
+    const duplicateInserts = inserts.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    );
+    if (successfulInserts.length !== 1 || duplicateInserts.length !== 1) {
+      throw new Error('Canonical signal uniqueness did not admit exactly one concurrent insert');
+    }
+    const duplicateCode = (duplicateInserts[0].reason as { code?: unknown }).code;
+    if (duplicateCode !== '23505') {
+      throw new Error(
+        `Expected unique-constraint conflict 23505, received ${String(duplicateCode)}`
+      );
+    }
+
+    const signalId = successfulInserts[0].value.rows[0]?.id;
+    if (!signalId) throw new Error('Canonical signal insert did not return an ID');
+    const caseResult = await setup.query<{ id: string }>(
+      `INSERT INTO internal_cases (tenant_id, signal_id)
+       VALUES ($1, $2)
+       RETURNING id`,
+      [TENANT_ID, signalId]
+    );
+    const caseId = caseResult.rows[0]?.id;
+    if (!caseId) throw new Error('Canonical case insert did not return an ID');
+
+    const updates = await Promise.all([
+      first.query(
+        `UPDATE internal_cases
+         SET disposition = 'first', version = version + 1, updated_at = now()
+         WHERE id = $1 AND version = 1
+         RETURNING id`,
+        [caseId]
+      ),
+      second.query(
+        `UPDATE internal_cases
+         SET disposition = 'second', version = version + 1, updated_at = now()
+         WHERE id = $1 AND version = 1
+         RETURNING id`,
+        [caseId]
+      ),
+    ]);
+    const updateCount = updates.reduce((total, result) => total + result.rowCount, 0);
+    if (updateCount !== 1) {
+      throw new Error(`Case version CAS admitted ${updateCount} concurrent updates instead of one`);
+    }
+
+    console.log('✅ Isolated canonical-signal uniqueness and case-version CAS verification passed');
+  } finally {
+    await Promise.allSettled([first.end(), second.end()]);
+    try {
+      await setup.query(`DROP SCHEMA IF EXISTS "${TEST_SCHEMA}" CASCADE`);
+    } finally {
+      await setup.end();
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('❌ Isolated operations concurrency verification failed:', error);
+  process.exitCode = 1;
+});

--- a/packages/db/src/migrations/0012_internal_signals_cases.sql
+++ b/packages/db/src/migrations/0012_internal_signals_cases.sql
@@ -1,0 +1,67 @@
+CREATE TYPE "internal_signal_kind" AS ENUM (
+  'DOMAIN_EXPIRING_SOON',
+  'TLS_CERTIFICATE_REGRESSION',
+  'HTTP_ENDPOINT_UNAVAILABLE',
+  'REDIRECT_TOPOLOGY_REGRESSION',
+  'HOMEPAGE_INDEXABILITY_REGRESSION',
+  'MAIL_DNS_CONFIGURATION_REGRESSION'
+);
+CREATE TYPE "internal_signal_status" AS ENUM ('ACTIVE', 'RESOLVED');
+CREATE TYPE "internal_case_status" AS ENUM (
+  'OPEN', 'ACKNOWLEDGED', 'BLOCKED', 'RESOLVED', 'DISMISSED'
+);
+
+CREATE TABLE "internal_signals" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "domain_id" uuid NOT NULL REFERENCES "domains"("id") ON DELETE CASCADE,
+  "kind" "internal_signal_kind" NOT NULL,
+  "condition_key" varchar(500) NOT NULL,
+  "status" "internal_signal_status" DEFAULT 'ACTIVE' NOT NULL,
+  "first_seen_snapshot_id" uuid REFERENCES "snapshots"("id"),
+  "last_seen_snapshot_id" uuid REFERENCES "snapshots"("id"),
+  "first_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "resolved_at" timestamp with time zone
+);
+CREATE UNIQUE INDEX "internal_signal_tenant_condition_unique"
+  ON "internal_signals" ("tenant_id", "condition_key");
+CREATE INDEX "internal_signal_tenant_idx" ON "internal_signals" ("tenant_id");
+CREATE INDEX "internal_signal_domain_idx" ON "internal_signals" ("domain_id");
+CREATE INDEX "internal_signal_status_idx" ON "internal_signals" ("status");
+
+CREATE TABLE "internal_cases" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "signal_id" uuid NOT NULL REFERENCES "internal_signals"("id") ON DELETE CASCADE,
+  "status" "internal_case_status" DEFAULT 'OPEN' NOT NULL,
+  "disposition" text,
+  "note" text,
+  "acknowledged_at" timestamp with time zone,
+  "acknowledged_by" varchar(100),
+  "resolved_at" timestamp with time zone,
+  "verification_snapshot_id" uuid REFERENCES "snapshots"("id"),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX "internal_case_signal_unique" ON "internal_cases" ("signal_id");
+CREATE INDEX "internal_case_tenant_idx" ON "internal_cases" ("tenant_id");
+CREATE INDEX "internal_case_status_idx" ON "internal_cases" ("status");
+
+CREATE TABLE "internal_case_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "case_id" uuid NOT NULL REFERENCES "internal_cases"("id") ON DELETE CASCADE,
+  "tenant_id" uuid NOT NULL,
+  "actor_id" varchar(100) NOT NULL,
+  "from_status" "internal_case_status",
+  "to_status" "internal_case_status" NOT NULL,
+  "note" text,
+  "disposition" text,
+  "verification_snapshot_id" uuid REFERENCES "snapshots"("id"),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX "internal_case_event_case_idx" ON "internal_case_events" ("case_id");
+CREATE INDEX "internal_case_event_tenant_idx" ON "internal_case_events" ("tenant_id");
+
+ALTER TABLE "alerts" ADD COLUMN "signal_id" uuid REFERENCES "internal_signals"("id");
+CREATE UNIQUE INDEX "alert_signal_unique" ON "alerts" ("signal_id");

--- a/packages/db/src/migrations/0013_domain_profiles_external_evidence.sql
+++ b/packages/db/src/migrations/0013_domain_profiles_external_evidence.sql
@@ -1,0 +1,24 @@
+CREATE TYPE "domain_purpose" AS ENUM (
+  'WEB', 'MAIL', 'WEB_AND_MAIL', 'REDIRECT', 'PARKED', 'UNKNOWN'
+);
+CREATE TYPE "domain_criticality" AS ENUM ('HIGH', 'NORMAL', 'LOW');
+
+CREATE UNIQUE INDEX "domain_id_tenant_idx" ON "domains" ("id", "tenant_id");
+
+CREATE TABLE "domain_profiles" (
+  "domain_id" uuid PRIMARY KEY NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "purpose" "domain_purpose" DEFAULT 'UNKNOWN' NOT NULL,
+  "responsible_actor_id" varchar(100),
+  "criticality" "domain_criticality" DEFAULT 'NORMAL' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "domain_profile_domain_tenant_fk"
+    FOREIGN KEY ("domain_id", "tenant_id")
+    REFERENCES "domains" ("id", "tenant_id")
+    ON DELETE CASCADE
+);
+CREATE INDEX "domain_profile_tenant_idx" ON "domain_profiles" ("tenant_id");
+CREATE INDEX "domain_profile_purpose_idx" ON "domain_profiles" ("purpose");
+
+ALTER TYPE "probe_type" ADD VALUE IF NOT EXISTS 'rdap';

--- a/packages/db/src/migrations/0014_domain_profile_audit.sql
+++ b/packages/db/src/migrations/0014_domain_profile_audit.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'domain_profile_updated';

--- a/packages/db/src/migrations/0015_operational_condition_baselines.sql
+++ b/packages/db/src/migrations/0015_operational_condition_baselines.sql
@@ -1,0 +1,62 @@
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'operational_baseline_accepted';
+
+CREATE TABLE "operational_condition_baselines" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "domain_id" uuid NOT NULL,
+  "kind" "internal_signal_kind" NOT NULL,
+  "discriminator" varchar(64) NOT NULL,
+  "source_snapshot_id" uuid NOT NULL REFERENCES "snapshots"("id"),
+  "policy" jsonb NOT NULL,
+  "max_evidence_age_seconds" integer NOT NULL,
+  "accepted_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "accepted_by" varchar(100) NOT NULL,
+  "superseded_at" timestamp with time zone,
+  "superseded_by" varchar(100),
+  CONSTRAINT "operational_baseline_domain_tenant_fk"
+    FOREIGN KEY ("domain_id", "tenant_id")
+    REFERENCES "domains" ("id", "tenant_id")
+    ON DELETE CASCADE,
+  CONSTRAINT "operational_baseline_max_evidence_age_positive"
+    CHECK ("max_evidence_age_seconds" > 0)
+);
+CREATE UNIQUE INDEX "operational_baseline_active_condition_unique"
+  ON "operational_condition_baselines" ("tenant_id", "domain_id", "kind", "discriminator")
+  WHERE "superseded_at" IS NULL;
+CREATE INDEX "operational_baseline_tenant_idx" ON "operational_condition_baselines" ("tenant_id");
+CREATE INDEX "operational_baseline_snapshot_idx" ON "operational_condition_baselines" ("source_snapshot_id");
+
+CREATE FUNCTION prevent_operational_baseline_rewrite() RETURNS trigger AS $$
+BEGIN
+  IF OLD.tenant_id IS DISTINCT FROM NEW.tenant_id
+    OR OLD.domain_id IS DISTINCT FROM NEW.domain_id
+    OR OLD.kind IS DISTINCT FROM NEW.kind
+    OR OLD.discriminator IS DISTINCT FROM NEW.discriminator
+    OR OLD.source_snapshot_id IS DISTINCT FROM NEW.source_snapshot_id
+    OR OLD.policy IS DISTINCT FROM NEW.policy
+    OR OLD.max_evidence_age_seconds IS DISTINCT FROM NEW.max_evidence_age_seconds
+    OR OLD.accepted_at IS DISTINCT FROM NEW.accepted_at
+    OR OLD.accepted_by IS DISTINCT FROM NEW.accepted_by
+    OR OLD.superseded_at IS NOT NULL THEN
+    RAISE EXCEPTION 'accepted operational baselines are immutable';
+  END IF;
+  IF NEW.superseded_at IS NULL OR NEW.superseded_by IS NULL THEN
+    RAISE EXCEPTION 'operational baseline supersession requires timestamp and actor';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER operational_baseline_immutable_update
+  BEFORE UPDATE ON "operational_condition_baselines"
+  FOR EACH ROW EXECUTE FUNCTION prevent_operational_baseline_rewrite();
+
+CREATE FUNCTION prevent_operational_baseline_delete() RETURNS trigger AS $$
+BEGIN
+  RAISE EXCEPTION 'accepted operational baselines cannot be deleted';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER operational_baseline_immutable_delete
+  BEFORE DELETE ON "operational_condition_baselines"
+  FOR EACH ROW EXECUTE FUNCTION prevent_operational_baseline_delete();

--- a/packages/db/src/migrations/0016_internal_case_version.sql
+++ b/packages/db/src/migrations/0016_internal_case_version.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "internal_cases"
+  ADD COLUMN "version" integer DEFAULT 1 NOT NULL;
+
+ALTER TABLE "internal_cases"
+  ADD CONSTRAINT "internal_case_version_positive" CHECK ("version" > 0);

--- a/packages/db/src/migrations/0017_mcp_command_idempotency.sql
+++ b/packages/db/src/migrations/0017_mcp_command_idempotency.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "mcp_command_status" AS ENUM ('PENDING', 'COMPLETED');
+
+CREATE TABLE "mcp_commands" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "actor_id" varchar(100) NOT NULL,
+  "operation" varchar(100) NOT NULL,
+  "idempotency_key" varchar(200) NOT NULL,
+  "request_fingerprint" varchar(64) NOT NULL,
+  "status" "mcp_command_status" DEFAULT 'PENDING' NOT NULL,
+  "resource_id" uuid,
+  "response" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "completed_at" timestamp with time zone
+);
+CREATE UNIQUE INDEX "mcp_command_tenant_operation_key_unique"
+  ON "mcp_commands" ("tenant_id", "actor_id", "operation", "idempotency_key");
+CREATE INDEX "mcp_command_tenant_idx" ON "mcp_commands" ("tenant_id");

--- a/packages/db/src/migrations/0018_mcp_case_disposition_audit.sql
+++ b/packages/db/src/migrations/0018_mcp_case_disposition_audit.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'mcp_case_disposition_set';

--- a/packages/db/src/migrations/0019_mcp_command_failed_status.sql
+++ b/packages/db/src/migrations/0019_mcp_command_failed_status.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "mcp_command_status" ADD VALUE IF NOT EXISTS 'FAILED';

--- a/packages/db/src/migrations/0020_users_sessions.sql
+++ b/packages/db/src/migrations/0020_users_sessions.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "users" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "email" varchar(255) NOT NULL UNIQUE,
+  "password_hash" text NOT NULL,
+  "name" varchar(255),
+  "tenant_id" uuid NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "sessions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "token" varchar(255) NOT NULL UNIQUE,
+  "user_email" varchar(255) NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "expires_at" timestamp NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);

--- a/packages/db/src/repos/domain-profile.test.ts
+++ b/packages/db/src/repos/domain-profile.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import { domainProfiles, domains } from '../schema/index.js';
+import { DomainProfileRepository } from './domain-profile.js';
+
+function conditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
+  const candidate = condition as {
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
+  };
+  if (candidate.constructor?.name === 'Param') return [candidate.value];
+  return (candidate.queryChunks ?? []).flatMap(conditionParams);
+}
+
+function createDb(domainTenantId = 'tenant-1') {
+  const domain = {
+    id: 'domain-1',
+    name: 'example.com',
+    normalizedName: 'example.com',
+    punycodeName: null,
+    zoneManagement: 'unknown' as const,
+    tenantId: domainTenantId,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  const profiles: Array<typeof domainProfiles.$inferSelect> = [];
+
+  const db = {
+    async selectOne(table: unknown, condition: unknown) {
+      const params = conditionParams(condition);
+      if (table === domains) {
+        return params.includes(domain.id) && params.includes(domain.tenantId) ? domain : undefined;
+      }
+      if (table === domainProfiles) {
+        return profiles.find(
+          (profile) => params.includes(profile.domainId) && params.includes(profile.tenantId)
+        );
+      }
+      return undefined;
+    },
+    async selectWhere(table: unknown, condition: unknown) {
+      if (table !== domainProfiles) return [];
+      const params = conditionParams(condition);
+      return profiles.filter((profile) => params.includes(profile.tenantId));
+    },
+    async insert(table: unknown, values: typeof domainProfiles.$inferInsert) {
+      if (table !== domainProfiles) throw new Error('Unexpected table');
+      const row = {
+        ...values,
+        responsibleActorId: values.responsibleActorId ?? null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as typeof domainProfiles.$inferSelect;
+      profiles.push(row);
+      return row;
+    },
+    async updateOne(
+      table: unknown,
+      values: Partial<typeof domainProfiles.$inferInsert>,
+      condition: unknown
+    ) {
+      if (table !== domainProfiles || !profiles[0]) return undefined;
+      const params = conditionParams(condition);
+      if (!params.includes(profiles[0].domainId) || !params.includes(profiles[0].tenantId)) {
+        return undefined;
+      }
+      profiles[0] = { ...profiles[0], ...values } as typeof domainProfiles.$inferSelect;
+      return profiles[0];
+    },
+    async transaction<T>(callback: (tx: IDatabaseAdapter) => Promise<T>) {
+      return callback(db as unknown as IDatabaseAdapter);
+    },
+  };
+
+  return { db: db as unknown as IDatabaseAdapter, profiles };
+}
+
+describe('DomainProfileRepository', () => {
+  it('creates and updates the single tenant-owned profile', async () => {
+    const { db, profiles } = createDb();
+    const repository = new DomainProfileRepository(db);
+
+    const created = await repository.set({
+      domainId: 'domain-1',
+      tenantId: 'tenant-1',
+      purpose: 'WEB',
+      criticality: 'HIGH',
+      responsibleActorId: 'operator-1',
+    });
+    const updated = await repository.set({
+      domainId: 'domain-1',
+      tenantId: 'tenant-1',
+      purpose: 'REDIRECT',
+      criticality: 'NORMAL',
+    });
+
+    expect(created.purpose).toBe('WEB');
+    expect(updated.purpose).toBe('REDIRECT');
+    expect(updated.responsibleActorId).toBeNull();
+    expect(profiles).toHaveLength(1);
+    await expect(repository.listByTenant('tenant-1')).resolves.toEqual([updated]);
+    await expect(repository.listByTenant('other-tenant')).resolves.toEqual([]);
+    await expect(repository.findByDomainId('domain-1', 'other-tenant')).resolves.toBeNull();
+  });
+
+  it('rejects cross-tenant writes', async () => {
+    const { db } = createDb('tenant-1');
+    await expect(
+      new DomainProfileRepository(db).set({
+        domainId: 'domain-1',
+        tenantId: 'other-tenant',
+        purpose: 'WEB',
+        criticality: 'NORMAL',
+      })
+    ).rejects.toThrow('outside the tenant');
+  });
+});

--- a/packages/db/src/repos/domain-profile.test.ts
+++ b/packages/db/src/repos/domain-profile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { IDatabaseAdapter } from '../database/simple-adapter.js';
-import { domainProfiles, domains } from '../schema/index.js';
+import { auditEvents, domainProfiles, domains } from '../schema/index.js';
 import { DomainProfileRepository } from './domain-profile.js';
 
 function conditionParams(condition: unknown): unknown[] {
@@ -27,6 +27,7 @@ function createDb(domainTenantId = 'tenant-1') {
     updatedAt: new Date(),
   };
   const profiles: Array<typeof domainProfiles.$inferSelect> = [];
+  const audits: Array<typeof auditEvents.$inferSelect> = [];
 
   const db = {
     async selectOne(table: unknown, condition: unknown) {
@@ -47,6 +48,15 @@ function createDb(domainTenantId = 'tenant-1') {
       return profiles.filter((profile) => params.includes(profile.tenantId));
     },
     async insert(table: unknown, values: typeof domainProfiles.$inferInsert) {
+      if (table === auditEvents) {
+        const event = {
+          id: 'audit-1',
+          createdAt: new Date(),
+          ...values,
+        } as typeof auditEvents.$inferSelect;
+        audits.push(event);
+        return event;
+      }
       if (table !== domainProfiles) throw new Error('Unexpected table');
       const row = {
         ...values,
@@ -75,7 +85,7 @@ function createDb(domainTenantId = 'tenant-1') {
     },
   };
 
-  return { db: db as unknown as IDatabaseAdapter, profiles };
+  return { db: db as unknown as IDatabaseAdapter, profiles, audits };
 }
 
 describe('DomainProfileRepository', () => {
@@ -104,6 +114,27 @@ describe('DomainProfileRepository', () => {
     await expect(repository.listByTenant('tenant-1')).resolves.toEqual([updated]);
     await expect(repository.listByTenant('other-tenant')).resolves.toEqual([]);
     await expect(repository.findByDomainId('domain-1', 'other-tenant')).resolves.toBeNull();
+  });
+
+  it('writes profile state and attribution in one transaction', async () => {
+    const { db, audits } = createDb();
+    const profile = await new DomainProfileRepository(db).setWithAudit(
+      { domainId: 'domain-1', tenantId: 'tenant-1', purpose: 'WEB', criticality: 'NORMAL' },
+      {
+        actorId: 'actor-1',
+        tenantId: 'tenant-1',
+        actorEmail: null,
+        ipAddress: null,
+        userAgent: null,
+      }
+    );
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      action: 'domain_profile_updated',
+      entityId: 'domain-1',
+      newValue: profile,
+      actorId: 'actor-1',
+    });
   });
 
   it('rejects cross-tenant writes', async () => {

--- a/packages/db/src/repos/domain-profile.test.ts
+++ b/packages/db/src/repos/domain-profile.test.ts
@@ -14,7 +14,7 @@ function conditionParams(condition: unknown): unknown[] {
   return (candidate.queryChunks ?? []).flatMap(conditionParams);
 }
 
-function createDb(domainTenantId = 'tenant-1') {
+function createDb(domainTenantId = 'tenant-1', failAuditInsert = false) {
   const domain = {
     id: 'domain-1',
     name: 'example.com',
@@ -49,11 +49,12 @@ function createDb(domainTenantId = 'tenant-1') {
     },
     async insert(table: unknown, values: typeof domainProfiles.$inferInsert) {
       if (table === auditEvents) {
+        if (failAuditInsert) throw new Error('audit insert failed');
         const event = {
           id: 'audit-1',
           createdAt: new Date(),
           ...values,
-        } as typeof auditEvents.$inferSelect;
+        } as unknown as typeof auditEvents.$inferSelect;
         audits.push(event);
         return event;
       }
@@ -81,7 +82,15 @@ function createDb(domainTenantId = 'tenant-1') {
       return profiles[0];
     },
     async transaction<T>(callback: (tx: IDatabaseAdapter) => Promise<T>) {
-      return callback(db as unknown as IDatabaseAdapter);
+      const profileBefore = [...profiles];
+      const auditBefore = [...audits];
+      try {
+        return await callback(db as unknown as IDatabaseAdapter);
+      } catch (error) {
+        profiles.splice(0, profiles.length, ...profileBefore);
+        audits.splice(0, audits.length, ...auditBefore);
+        throw error;
+      }
     },
   };
 
@@ -135,6 +144,24 @@ describe('DomainProfileRepository', () => {
       newValue: profile,
       actorId: 'actor-1',
     });
+  });
+
+  it('rolls profile state back when audit insertion fails', async () => {
+    const { db, profiles, audits } = createDb('tenant-1', true);
+    await expect(
+      new DomainProfileRepository(db).setWithAudit(
+        { domainId: 'domain-1', tenantId: 'tenant-1', purpose: 'WEB', criticality: 'NORMAL' },
+        {
+          actorId: 'actor-1',
+          tenantId: 'tenant-1',
+          actorEmail: null,
+          ipAddress: null,
+          userAgent: null,
+        }
+      )
+    ).rejects.toThrow('audit insert failed');
+    expect(profiles).toEqual([]);
+    expect(audits).toEqual([]);
   });
 
   it('rejects cross-tenant writes', async () => {

--- a/packages/db/src/repos/domain-profile.ts
+++ b/packages/db/src/repos/domain-profile.ts
@@ -2,9 +2,11 @@ import type { DomainCriticality, DomainPurpose } from '@dns-ops/contracts';
 import { and, eq, type SQL } from 'drizzle-orm';
 import type { IDatabaseAdapter } from '../database/simple-adapter.js';
 import {
+  auditEvents,
   type DomainProfile,
   domainProfiles,
   domains,
+  type NewAuditEvent,
   type NewDomainProfile,
 } from '../schema/index.js';
 
@@ -22,6 +24,11 @@ export interface SetDomainProfile {
   criticality: DomainCriticality;
 }
 
+export type DomainProfileAuditContext = Omit<
+  NewAuditEvent,
+  'action' | 'entityType' | 'entityId' | 'previousValue' | 'newValue'
+>;
+
 export class DomainProfileRepository {
   constructor(private db: IDatabaseAdapter) {}
 
@@ -38,6 +45,20 @@ export class DomainProfileRepository {
   }
 
   async set(input: SetDomainProfile): Promise<DomainProfile> {
+    return this.setInternal(input);
+  }
+
+  async setWithAudit(
+    input: SetDomainProfile,
+    audit: DomainProfileAuditContext
+  ): Promise<DomainProfile> {
+    return this.setInternal(input, audit);
+  }
+
+  private async setInternal(
+    input: SetDomainProfile,
+    audit?: DomainProfileAuditContext
+  ): Promise<DomainProfile> {
     return this.db.transaction(async (tx) => {
       const domain = await tx.selectOne(
         domains,
@@ -62,20 +83,32 @@ export class DomainProfileRepository {
         criticality: input.criticality,
       };
 
-      if (!existing) return tx.insert(domainProfiles, values);
-      if (existing.tenantId !== input.tenantId)
-        throw new Error('Domain profile is outside the tenant');
-
-      const updated = await tx.updateOne(
-        domainProfiles,
-        { ...values, updatedAt: new Date() },
-        requiredAnd(
-          eq(domainProfiles.domainId, input.domainId),
-          eq(domainProfiles.tenantId, input.tenantId)
-        )
-      );
-      if (!updated) throw new Error('Domain profile changed during update');
-      return updated;
+      let profile: DomainProfile;
+      if (!existing) {
+        profile = await tx.insert(domainProfiles, values);
+      } else {
+        const updated = await tx.updateOne(
+          domainProfiles,
+          { ...values, updatedAt: new Date() },
+          requiredAnd(
+            eq(domainProfiles.domainId, input.domainId),
+            eq(domainProfiles.tenantId, input.tenantId)
+          )
+        );
+        if (!updated) throw new Error('Domain profile changed during update');
+        profile = updated;
+      }
+      if (audit) {
+        await tx.insert(auditEvents, {
+          ...audit,
+          action: 'domain_profile_updated',
+          entityType: 'domain_profile',
+          entityId: input.domainId,
+          previousValue: existing ?? null,
+          newValue: profile,
+        });
+      }
+      return profile;
     });
   }
 }

--- a/packages/db/src/repos/domain-profile.ts
+++ b/packages/db/src/repos/domain-profile.ts
@@ -1,0 +1,81 @@
+import type { DomainCriticality, DomainPurpose } from '@dns-ops/contracts';
+import { and, eq, type SQL } from 'drizzle-orm';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import {
+  type DomainProfile,
+  domainProfiles,
+  domains,
+  type NewDomainProfile,
+} from '../schema/index.js';
+
+function requiredAnd(...conditions: SQL[]): SQL {
+  const condition = and(...conditions);
+  if (!condition) throw new Error('Expected profile tenant predicates');
+  return condition;
+}
+
+export interface SetDomainProfile {
+  domainId: string;
+  tenantId: string;
+  purpose: DomainPurpose;
+  responsibleActorId?: string;
+  criticality: DomainCriticality;
+}
+
+export class DomainProfileRepository {
+  constructor(private db: IDatabaseAdapter) {}
+
+  async findByDomainId(domainId: string, tenantId: string): Promise<DomainProfile | null> {
+    const profile = await this.db.selectOne(
+      domainProfiles,
+      requiredAnd(eq(domainProfiles.domainId, domainId), eq(domainProfiles.tenantId, tenantId))
+    );
+    return profile?.tenantId === tenantId ? profile : null;
+  }
+
+  async listByTenant(tenantId: string): Promise<DomainProfile[]> {
+    return this.db.selectWhere(domainProfiles, eq(domainProfiles.tenantId, tenantId));
+  }
+
+  async set(input: SetDomainProfile): Promise<DomainProfile> {
+    return this.db.transaction(async (tx) => {
+      const domain = await tx.selectOne(
+        domains,
+        requiredAnd(eq(domains.id, input.domainId), eq(domains.tenantId, input.tenantId))
+      );
+      if (!domain || domain.tenantId !== input.tenantId) {
+        throw new Error('Domain is outside the tenant');
+      }
+
+      const existing = await tx.selectOne(
+        domainProfiles,
+        requiredAnd(
+          eq(domainProfiles.domainId, input.domainId),
+          eq(domainProfiles.tenantId, input.tenantId)
+        )
+      );
+      const values: NewDomainProfile = {
+        domainId: input.domainId,
+        tenantId: input.tenantId,
+        purpose: input.purpose,
+        responsibleActorId: input.responsibleActorId ?? null,
+        criticality: input.criticality,
+      };
+
+      if (!existing) return tx.insert(domainProfiles, values);
+      if (existing.tenantId !== input.tenantId)
+        throw new Error('Domain profile is outside the tenant');
+
+      const updated = await tx.updateOne(
+        domainProfiles,
+        { ...values, updatedAt: new Date() },
+        requiredAnd(
+          eq(domainProfiles.domainId, input.domainId),
+          eq(domainProfiles.tenantId, input.tenantId)
+        )
+      );
+      if (!updated) throw new Error('Domain profile changed during update');
+      return updated;
+    });
+  }
+}

--- a/packages/db/src/repos/index.ts
+++ b/packages/db/src/repos/index.ts
@@ -10,12 +10,13 @@ export {
   type IDatabaseAdapter,
   SimpleDatabaseAdapter,
 } from '../database/index.js';
-// Domain repositories
 export { type DomainFilter, DomainRepository } from './domain.js';
 export {
   DomainRepositoryResults,
   withDomainResults,
 } from './domain.result.js';
+// Domain repositories
+export { DomainProfileRepository, type SetDomainProfile } from './domain-profile.js';
 export { FindingRepository } from './finding.js';
 export { FleetReportRepository } from './fleet-report.js';
 // Mail evidence repositories

--- a/packages/db/src/repos/index.ts
+++ b/packages/db/src/repos/index.ts
@@ -21,6 +21,11 @@ export { FleetReportRepository } from './fleet-report.js';
 // Mail evidence repositories
 export { DkimSelectorRepository, MailEvidenceRepository } from './mail-evidence.js';
 export { ObservationRepository } from './observation.js';
+export {
+  type ObserveOperationalCondition,
+  type OperationalConditionResult,
+  OperationalConditionService,
+} from './operations.js';
 // Parity evidence repositories
 export {
   LegacyAccessLogRepository,

--- a/packages/db/src/repos/index.ts
+++ b/packages/db/src/repos/index.ts
@@ -21,6 +21,7 @@ export { FindingRepository } from './finding.js';
 export { FleetReportRepository } from './fleet-report.js';
 // Mail evidence repositories
 export { DkimSelectorRepository, MailEvidenceRepository } from './mail-evidence.js';
+export { type McpCommandClaim, McpCommandRepository } from './mcp-command.js';
 export { ObservationRepository } from './observation.js';
 export {
   type AcceptOperationalBaseline,

--- a/packages/db/src/repos/index.ts
+++ b/packages/db/src/repos/index.ts
@@ -23,6 +23,10 @@ export { FleetReportRepository } from './fleet-report.js';
 export { DkimSelectorRepository, MailEvidenceRepository } from './mail-evidence.js';
 export { ObservationRepository } from './observation.js';
 export {
+  type AcceptOperationalBaseline,
+  OperationalBaselineRepository,
+} from './operational-baseline.js';
+export {
   type ObserveOperationalCondition,
   type OperationalConditionResult,
   OperationalConditionService,

--- a/packages/db/src/repos/mcp-command.test.ts
+++ b/packages/db/src/repos/mcp-command.test.ts
@@ -57,6 +57,24 @@ describe('McpCommandRepository', () => {
     });
   });
 
+  it('replays a completed deterministic failure rather than leaving a pending command', async () => {
+    const { db } = createDb();
+    const repository = new McpCommandRepository(db);
+    const claim = await repository.claim(input);
+    if (claim.state !== 'CLAIMED') throw new Error('Expected claimed command');
+    await repository.complete(
+      input.tenantId,
+      claim.command.id,
+      { error: { code: 'CASE_VERSION_STALE' } },
+      undefined,
+      'FAILED'
+    );
+    await expect(repository.claim(input)).resolves.toMatchObject({
+      state: 'REPLAY',
+      command: { status: 'FAILED' },
+    });
+  });
+
   it('rejects a key reused for different input', async () => {
     const { db } = createDb();
     const repository = new McpCommandRepository(db);

--- a/packages/db/src/repos/mcp-command.test.ts
+++ b/packages/db/src/repos/mcp-command.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import { mcpCommands } from '../schema/index.js';
+import { McpCommandRepository } from './mcp-command.js';
+
+function createDb() {
+  const rows: Array<Record<string, unknown>> = [];
+  const db = {
+    async selectWhere(table: unknown) {
+      return table === mcpCommands ? rows : [];
+    },
+    async insert(table: unknown, values: Record<string, unknown>) {
+      if (table !== mcpCommands) throw new Error('Unexpected table');
+      const row = {
+        id: `command-${rows.length + 1}`,
+        status: 'PENDING',
+        response: null,
+        completedAt: null,
+        ...values,
+      };
+      rows.push(row);
+      return row;
+    },
+    async updateOne(table: unknown, values: Record<string, unknown>) {
+      if (table !== mcpCommands || !rows[0] || rows[0].status !== 'PENDING') return undefined;
+      Object.assign(rows[0], values);
+      return rows[0];
+    },
+  };
+  return { db: db as unknown as IDatabaseAdapter, rows };
+}
+
+const input = {
+  tenantId: 'tenant-1',
+  actorId: 'actor-1',
+  operation: 'scan_request',
+  idempotencyKey: 'key-1',
+  requestFingerprint: 'a'.repeat(64),
+};
+
+describe('McpCommandRepository', () => {
+  it('claims once and replays the completed response', async () => {
+    const { db } = createDb();
+    const repository = new McpCommandRepository(db);
+    const claim = await repository.claim(input);
+    expect(claim.state).toBe('CLAIMED');
+    if (claim.state !== 'CLAIMED') throw new Error('Expected claimed command');
+    await repository.complete(
+      input.tenantId,
+      claim.command.id,
+      { snapshotId: 'snapshot-1' },
+      'snapshot-1'
+    );
+    await expect(repository.claim(input)).resolves.toMatchObject({
+      state: 'REPLAY',
+      command: { response: { snapshotId: 'snapshot-1' } },
+    });
+  });
+
+  it('rejects a key reused for different input', async () => {
+    const { db } = createDb();
+    const repository = new McpCommandRepository(db);
+    await repository.claim(input);
+    await expect(
+      repository.claim({ ...input, requestFingerprint: 'b'.repeat(64) })
+    ).rejects.toMatchObject({ code: 'MCP_IDEMPOTENCY_CONFLICT' });
+  });
+});

--- a/packages/db/src/repos/mcp-command.ts
+++ b/packages/db/src/repos/mcp-command.ts
@@ -1,0 +1,82 @@
+import { and, eq, type SQL } from 'drizzle-orm';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import { type McpCommand, mcpCommands } from '../schema/index.js';
+
+function requiredAnd(...conditions: SQL[]): SQL {
+  const condition = and(...conditions);
+  if (!condition) throw new Error('Expected MCP command predicates');
+  return condition;
+}
+
+function commandError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
+}
+
+export type McpCommandClaim =
+  | { state: 'CLAIMED'; command: McpCommand }
+  | { state: 'REPLAY'; command: McpCommand };
+
+export class McpCommandRepository {
+  constructor(private db: IDatabaseAdapter) {}
+
+  async claim(input: {
+    tenantId: string;
+    actorId: string;
+    operation: string;
+    idempotencyKey: string;
+    requestFingerprint: string;
+  }): Promise<McpCommandClaim> {
+    if (!/^[a-f0-9]{64}$/.test(input.requestFingerprint)) {
+      throw new Error('MCP request fingerprint must be a SHA-256 hex digest');
+    }
+    const predicate = requiredAnd(
+      eq(mcpCommands.tenantId, input.tenantId),
+      eq(mcpCommands.actorId, input.actorId),
+      eq(mcpCommands.operation, input.operation),
+      eq(mcpCommands.idempotencyKey, input.idempotencyKey)
+    );
+    const existing = (await this.db.selectWhere(mcpCommands, predicate))[0];
+    if (existing) return this.resolveExisting(existing, input.requestFingerprint);
+    try {
+      return { state: 'CLAIMED', command: await this.db.insert(mcpCommands, input) };
+    } catch (error) {
+      if (!(typeof error === 'object' && error && 'code' in error && error.code === '23505'))
+        throw error;
+      const raced = (await this.db.selectWhere(mcpCommands, predicate))[0];
+      if (!raced) throw error;
+      return this.resolveExisting(raced, input.requestFingerprint);
+    }
+  }
+
+  async complete(
+    tenantId: string,
+    commandId: string,
+    response: Record<string, unknown>,
+    resourceId?: string
+  ): Promise<McpCommand> {
+    const completed = await this.db.updateOne(
+      mcpCommands,
+      { status: 'COMPLETED', response, resourceId: resourceId ?? null, completedAt: new Date() },
+      requiredAnd(
+        eq(mcpCommands.id, commandId),
+        eq(mcpCommands.tenantId, tenantId),
+        eq(mcpCommands.status, 'PENDING')
+      )
+    );
+    if (!completed) throw commandError('MCP_COMMAND_CONFLICT', 'MCP command completion changed');
+    return completed;
+  }
+
+  private resolveExisting(command: McpCommand, fingerprint: string): McpCommandClaim {
+    if (command.requestFingerprint !== fingerprint) {
+      throw commandError(
+        'MCP_IDEMPOTENCY_CONFLICT',
+        'MCP idempotency key was reused for different input'
+      );
+    }
+    if (command.status !== 'COMPLETED' || !command.response) {
+      throw commandError('MCP_COMMAND_IN_PROGRESS', 'MCP command is already in progress');
+    }
+    return { state: 'REPLAY', command };
+  }
+}

--- a/packages/db/src/repos/mcp-command.ts
+++ b/packages/db/src/repos/mcp-command.ts
@@ -52,11 +52,12 @@ export class McpCommandRepository {
     tenantId: string,
     commandId: string,
     response: Record<string, unknown>,
-    resourceId?: string
+    resourceId?: string,
+    status: 'COMPLETED' | 'FAILED' = 'COMPLETED'
   ): Promise<McpCommand> {
     const completed = await this.db.updateOne(
       mcpCommands,
-      { status: 'COMPLETED', response, resourceId: resourceId ?? null, completedAt: new Date() },
+      { status, response, resourceId: resourceId ?? null, completedAt: new Date() },
       requiredAnd(
         eq(mcpCommands.id, commandId),
         eq(mcpCommands.tenantId, tenantId),
@@ -74,7 +75,7 @@ export class McpCommandRepository {
         'MCP idempotency key was reused for different input'
       );
     }
-    if (command.status !== 'COMPLETED' || !command.response) {
+    if ((command.status !== 'COMPLETED' && command.status !== 'FAILED') || !command.response) {
       throw commandError('MCP_COMMAND_IN_PROGRESS', 'MCP command is already in progress');
     }
     return { state: 'REPLAY', command };

--- a/packages/db/src/repos/operational-baseline.test.ts
+++ b/packages/db/src/repos/operational-baseline.test.ts
@@ -14,7 +14,7 @@ function params(condition: unknown): unknown[] {
   return (candidate.queryChunks ?? []).flatMap(params);
 }
 
-function createDb(failAuditAt?: number) {
+function createDb(failAuditAt?: number, snapshotState: 'complete' | 'partial' = 'complete') {
   const baselines: Array<Record<string, unknown>> = [];
   const audits: Array<Record<string, unknown>> = [];
   const db = {
@@ -24,7 +24,7 @@ function createDb(failAuditAt?: number) {
         return values.includes('domain-1') ? { id: 'domain-1', tenantId: 'tenant-1' } : undefined;
       if (table === snapshots)
         return values.includes('snapshot-1')
-          ? { id: 'snapshot-1', domainId: 'domain-1' }
+          ? { id: 'snapshot-1', domainId: 'domain-1', resultState: snapshotState }
           : undefined;
       return undefined;
     },
@@ -130,6 +130,15 @@ describe('OperationalBaselineRepository', () => {
     await expect(
       new OperationalBaselineRepository(db).accept({ ...input, tenantId: 'other-tenant' })
     ).rejects.toThrow('outside the tenant domain');
+  });
+
+  it('rejects incomplete source snapshots before persistence', async () => {
+    const { db, baselines, audits } = createDb(undefined, 'partial');
+    await expect(new OperationalBaselineRepository(db).accept(input)).rejects.toThrow(
+      'source snapshot must be complete'
+    );
+    expect(baselines).toEqual([]);
+    expect(audits).toEqual([]);
   });
 
   it('rejects an unsupported signal kind before persistence', async () => {

--- a/packages/db/src/repos/operational-baseline.test.ts
+++ b/packages/db/src/repos/operational-baseline.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import { auditEvents, domains, operationalConditionBaselines, snapshots } from '../schema/index.js';
+import { OperationalBaselineRepository } from './operational-baseline.js';
+
+function params(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
+  const candidate = condition as {
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
+  };
+  if (candidate.constructor?.name === 'Param') return [candidate.value];
+  return (candidate.queryChunks ?? []).flatMap(params);
+}
+
+function createDb(failAuditAt?: number) {
+  const baselines: Array<Record<string, unknown>> = [];
+  const audits: Array<Record<string, unknown>> = [];
+  const db = {
+    async selectOne(table: unknown, condition: unknown) {
+      const values = params(condition);
+      if (table === domains)
+        return values.includes('domain-1') ? { id: 'domain-1', tenantId: 'tenant-1' } : undefined;
+      if (table === snapshots)
+        return values.includes('snapshot-1')
+          ? { id: 'snapshot-1', domainId: 'domain-1' }
+          : undefined;
+      return undefined;
+    },
+    async selectWhere(table: unknown, condition: unknown) {
+      if (table !== operationalConditionBaselines) return [];
+      const values = params(condition);
+      return baselines.filter(
+        (baseline) =>
+          values.includes(baseline.tenantId) &&
+          values.includes(baseline.domainId) &&
+          values.includes(baseline.kind) &&
+          values.includes(baseline.discriminator) &&
+          !baseline.supersededAt
+      );
+    },
+    async insert(table: unknown, values: Record<string, unknown>) {
+      if (table === operationalConditionBaselines) {
+        const row = {
+          id: `baseline-${baselines.length + 1}`,
+          acceptedAt: new Date(),
+          supersededAt: null,
+          supersededBy: null,
+          ...values,
+        };
+        baselines.push(row);
+        return row;
+      }
+      if (table === auditEvents) {
+        if (failAuditAt !== undefined && audits.length + 1 === failAuditAt) {
+          throw new Error('audit unavailable');
+        }
+        const row = { id: `audit-${audits.length + 1}`, ...values };
+        audits.push(row);
+        return row;
+      }
+      throw new Error('Unexpected table');
+    },
+    async updateOne(table: unknown, values: Record<string, unknown>, condition: unknown) {
+      if (table !== operationalConditionBaselines) return undefined;
+      const id = params(condition).find(
+        (value) => typeof value === 'string' && value.startsWith('baseline-')
+      );
+      const row = baselines.find((baseline) => baseline.id === id);
+      if (!row) return undefined;
+      Object.assign(row, values);
+      return row;
+    },
+    async transaction<T>(callback: (tx: IDatabaseAdapter) => Promise<T>) {
+      const baselineSnapshot = structuredClone(baselines);
+      const auditSnapshot = structuredClone(audits);
+      try {
+        return await callback(db as unknown as IDatabaseAdapter);
+      } catch (error) {
+        baselines.splice(0, baselines.length, ...baselineSnapshot);
+        audits.splice(0, audits.length, ...auditSnapshot);
+        throw error;
+      }
+    },
+  };
+  return { db: db as unknown as IDatabaseAdapter, baselines, audits };
+}
+
+const input = {
+  tenantId: 'tenant-1',
+  domainId: 'domain-1',
+  kind: 'TLS_CERTIFICATE_REGRESSION' as const,
+  discriminator: 'Example.COM:443',
+  sourceSnapshotId: 'snapshot-1',
+  policy: {
+    kind: 'TLS_CERTIFICATE' as const,
+    requireHostnameAuthorized: true,
+    requireChainAuthorized: true,
+    minimumRemainingValiditySeconds: 86400,
+  },
+  maxEvidenceAgeSeconds: 3600,
+  actorId: 'operator-1',
+};
+
+describe('OperationalBaselineRepository', () => {
+  it('accepts immutable baseline and atomically supersedes the prior active baseline', async () => {
+    const { db, baselines, audits } = createDb();
+    const repository = new OperationalBaselineRepository(db);
+    await repository.accept(input);
+    const active = await repository.accept({ ...input, sourceSnapshotId: 'snapshot-1' });
+    expect(baselines).toHaveLength(2);
+    expect(baselines[0]).toMatchObject({ supersededBy: 'operator-1' });
+    expect(active).toMatchObject({ discriminator: 'example.com:443' });
+    expect(audits).toHaveLength(2);
+  });
+
+  it('rolls back supersession and insert when its audit event cannot be stored', async () => {
+    const { db, baselines, audits } = createDb(2);
+    const repository = new OperationalBaselineRepository(db);
+    await repository.accept(input);
+    await expect(repository.accept(input)).rejects.toThrow('audit unavailable');
+    expect(baselines).toHaveLength(1);
+    expect(baselines[0]).toMatchObject({ supersededAt: null, supersededBy: null });
+    expect(audits).toHaveLength(1);
+  });
+
+  it('rejects a source snapshot outside the tenant domain', async () => {
+    const { db } = createDb();
+    await expect(
+      new OperationalBaselineRepository(db).accept({ ...input, tenantId: 'other-tenant' })
+    ).rejects.toThrow('outside the tenant domain');
+  });
+
+  it('rejects an unsupported signal kind before persistence', async () => {
+    const { db } = createDb();
+    await expect(
+      new OperationalBaselineRepository(db).accept({
+        ...input,
+        kind: 'HTTP_ENDPOINT_UNAVAILABLE',
+      } as never)
+    ).rejects.toThrow('Invalid SPF baseline policy');
+  });
+});

--- a/packages/db/src/repos/operational-baseline.ts
+++ b/packages/db/src/repos/operational-baseline.ts
@@ -69,6 +69,17 @@ function assertPolicy(
 export class OperationalBaselineRepository {
   constructor(private db: IDatabaseAdapter) {}
 
+  async listActive(tenantId: string, domainId: string): Promise<OperationalConditionBaseline[]> {
+    return this.db.selectWhere(
+      operationalConditionBaselines,
+      requiredAnd(
+        eq(operationalConditionBaselines.tenantId, tenantId),
+        eq(operationalConditionBaselines.domainId, domainId),
+        isNull(operationalConditionBaselines.supersededAt)
+      )
+    );
+  }
+
   async findActive(
     tenantId: string,
     domainId: string,

--- a/packages/db/src/repos/operational-baseline.ts
+++ b/packages/db/src/repos/operational-baseline.ts
@@ -112,6 +112,9 @@ export class OperationalBaselineRepository {
       if (!domain || domain.tenantId !== input.tenantId || snapshot?.domainId !== input.domainId) {
         throw new Error('Baseline source snapshot is outside the tenant domain');
       }
+      if (snapshot.resultState !== 'complete') {
+        throw new Error('Baseline source snapshot must be complete');
+      }
       const active = await tx.selectWhere(
         operationalConditionBaselines,
         requiredAnd(

--- a/packages/db/src/repos/operational-baseline.ts
+++ b/packages/db/src/repos/operational-baseline.ts
@@ -1,0 +1,148 @@
+import {
+  type InternalSignalKind,
+  normalizeOperationalDiscriminator,
+  type OperationalConditionBaselinePolicy,
+  type SupportedOperationalBaseline,
+} from '@dns-ops/contracts';
+import { and, eq, isNull, type SQL } from 'drizzle-orm';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import {
+  auditEvents,
+  domains,
+  type OperationalConditionBaseline,
+  operationalConditionBaselines,
+  snapshots,
+} from '../schema/index.js';
+
+function requiredAnd(...conditions: SQL[]): SQL {
+  const condition = and(...conditions);
+  if (!condition) throw new Error('Expected baseline predicates');
+  return condition;
+}
+
+type BaselinePolicyInput =
+  | {
+      kind: 'TLS_CERTIFICATE_REGRESSION';
+      policy: Extract<
+        SupportedOperationalBaseline,
+        { signalKind: 'TLS_CERTIFICATE_REGRESSION' }
+      >['policy'];
+    }
+  | {
+      kind: 'MAIL_DNS_CONFIGURATION_REGRESSION';
+      policy: Extract<
+        SupportedOperationalBaseline,
+        { signalKind: 'MAIL_DNS_CONFIGURATION_REGRESSION' }
+      >['policy'];
+    };
+
+export type AcceptOperationalBaseline = BaselinePolicyInput & {
+  tenantId: string;
+  domainId: string;
+  discriminator: string;
+  sourceSnapshotId: string;
+  maxEvidenceAgeSeconds: number;
+  actorId: string;
+  actorEmail?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+};
+
+function assertPolicy(
+  input: AcceptOperationalBaseline
+): asserts input is AcceptOperationalBaseline {
+  if (input.kind === 'TLS_CERTIFICATE_REGRESSION') {
+    const policy = input.policy as OperationalConditionBaselinePolicy;
+    if (
+      policy.kind !== 'TLS_CERTIFICATE' ||
+      typeof policy.requireHostnameAuthorized !== 'boolean' ||
+      typeof policy.requireChainAuthorized !== 'boolean' ||
+      !Number.isInteger(policy.minimumRemainingValiditySeconds) ||
+      policy.minimumRemainingValiditySeconds < 0
+    )
+      throw new Error('Invalid TLS certificate baseline policy');
+    return;
+  }
+  if (input.policy.kind !== 'SPF_PRESENT') throw new Error('Invalid SPF baseline policy');
+}
+
+export class OperationalBaselineRepository {
+  constructor(private db: IDatabaseAdapter) {}
+
+  async findActive(
+    tenantId: string,
+    domainId: string,
+    kind: InternalSignalKind,
+    discriminator: string
+  ): Promise<OperationalConditionBaseline | null> {
+    const normalized = normalizeOperationalDiscriminator(discriminator);
+    const rows = await this.db.selectWhere(
+      operationalConditionBaselines,
+      requiredAnd(
+        eq(operationalConditionBaselines.tenantId, tenantId),
+        eq(operationalConditionBaselines.domainId, domainId),
+        eq(operationalConditionBaselines.kind, kind),
+        eq(operationalConditionBaselines.discriminator, normalized),
+        isNull(operationalConditionBaselines.supersededAt)
+      )
+    );
+    return rows[0] ?? null;
+  }
+
+  async accept(input: AcceptOperationalBaseline): Promise<OperationalConditionBaseline> {
+    if (!Number.isInteger(input.maxEvidenceAgeSeconds) || input.maxEvidenceAgeSeconds < 1) {
+      throw new Error('Baseline max evidence age must be a positive integer');
+    }
+    assertPolicy(input);
+    const discriminator = normalizeOperationalDiscriminator(input.discriminator);
+    return this.db.transaction(async (tx) => {
+      const domain = await tx.selectOne(domains, eq(domains.id, input.domainId));
+      const snapshot = await tx.selectOne(snapshots, eq(snapshots.id, input.sourceSnapshotId));
+      if (!domain || domain.tenantId !== input.tenantId || snapshot?.domainId !== input.domainId) {
+        throw new Error('Baseline source snapshot is outside the tenant domain');
+      }
+      const active = await tx.selectWhere(
+        operationalConditionBaselines,
+        requiredAnd(
+          eq(operationalConditionBaselines.tenantId, input.tenantId),
+          eq(operationalConditionBaselines.domainId, input.domainId),
+          eq(operationalConditionBaselines.kind, input.kind),
+          eq(operationalConditionBaselines.discriminator, discriminator),
+          isNull(operationalConditionBaselines.supersededAt)
+        )
+      );
+      const now = new Date();
+      for (const prior of active) {
+        const updated = await tx.updateOne(
+          operationalConditionBaselines,
+          { supersededAt: now, supersededBy: input.actorId },
+          eq(operationalConditionBaselines.id, prior.id)
+        );
+        if (!updated) throw new Error('Baseline changed during supersession');
+      }
+      const baseline = await tx.insert(operationalConditionBaselines, {
+        tenantId: input.tenantId,
+        domainId: input.domainId,
+        kind: input.kind,
+        discriminator,
+        sourceSnapshotId: input.sourceSnapshotId,
+        policy: input.policy,
+        maxEvidenceAgeSeconds: input.maxEvidenceAgeSeconds,
+        acceptedBy: input.actorId,
+      });
+      await tx.insert(auditEvents, {
+        action: 'operational_baseline_accepted',
+        entityType: 'operational_condition_baseline',
+        entityId: baseline.id,
+        previousValue: active,
+        newValue: baseline,
+        actorId: input.actorId,
+        actorEmail: input.actorEmail ?? null,
+        tenantId: input.tenantId,
+        ipAddress: input.ipAddress ?? null,
+        userAgent: input.userAgent ?? null,
+      });
+      return baseline;
+    });
+  }
+}

--- a/packages/db/src/repos/operations.test.ts
+++ b/packages/db/src/repos/operations.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import { OperationalConditionService } from './operations.js';
+
+function tableName(table: unknown): string {
+  if (!table || typeof table !== 'object') return '';
+  const value = (table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')];
+  return typeof value === 'string' ? value : '';
+}
+
+function conditionParam(condition: unknown): unknown {
+  if (!condition || typeof condition !== 'object') return undefined;
+  const candidate = condition as {
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
+  };
+  if (candidate.constructor?.name === 'Param') return candidate.value;
+  for (const chunk of candidate.queryChunks ?? []) {
+    const value = conditionParam(chunk);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function createDb() {
+  const rows: Record<string, Array<Record<string, unknown>>> = {
+    internal_signals: [],
+    internal_cases: [],
+    internal_case_events: [],
+    alerts: [],
+    monitored_domains: [{ id: 'monitored-1', tenantId: 'tenant-1', domainId: 'domain-1' }],
+    domains: [{ id: 'domain-1', tenantId: 'tenant-1', name: 'example.com' }],
+    snapshots: [
+      {
+        id: 'snapshot-1',
+        domainId: 'domain-1',
+        resultState: 'complete',
+        metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+      },
+      {
+        id: 'snapshot-2',
+        domainId: 'domain-1',
+        resultState: 'complete',
+        metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+        createdAt: new Date('2099-01-01T00:00:00Z'),
+      },
+      {
+        id: 'snapshot-3',
+        domainId: 'domain-1',
+        resultState: 'complete',
+        metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+        createdAt: new Date('2099-01-02T00:00:00Z'),
+      },
+    ],
+  };
+  let nextId = 1;
+
+  const db = {
+    select: vi.fn(async (table: unknown) => [...(rows[tableName(table)] ?? [])]),
+    selectWhere: vi.fn(async (table: unknown, condition: unknown) => {
+      const name = tableName(table);
+      const param = conditionParam(condition);
+      const key =
+        name === 'internal_signals'
+          ? 'conditionKey'
+          : name === 'internal_cases' || name === 'alerts'
+            ? 'signalId'
+            : 'id';
+      return (rows[name] ?? []).filter((row) => row[key] === param);
+    }),
+    selectOne: vi.fn(async (table: unknown, condition: unknown) => {
+      const name = tableName(table);
+      const param = conditionParam(condition);
+      return (rows[name] ?? []).find((row) => row.id === param);
+    }),
+    insert: vi.fn(async (table: unknown, values: Record<string, unknown>) => {
+      const name = tableName(table);
+      const now = new Date();
+      const row = {
+        id: `${name}-${nextId++}`,
+        createdAt: now,
+        updatedAt: now,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        ...values,
+      };
+      rows[name] ??= [];
+      rows[name].push(row);
+      return row;
+    }),
+    updateOne: vi.fn(
+      async (table: unknown, values: Record<string, unknown>, condition: unknown) => {
+        const name = tableName(table);
+        const param = conditionParam(condition);
+        const row = (rows[name] ?? []).find((candidate) => candidate.id === param);
+        if (!row) return undefined;
+        Object.assign(row, values);
+        return row;
+      }
+    ),
+    insertMany: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteOne: vi.fn(),
+    transaction: vi.fn(async (callback: (adapter: IDatabaseAdapter) => Promise<unknown>) =>
+      callback(db as unknown as IDatabaseAdapter)
+    ),
+    getDrizzle: vi.fn(),
+  } as unknown as IDatabaseAdapter;
+
+  return { db, rows };
+}
+
+const observation = {
+  tenantId: 'tenant-1',
+  domainId: 'domain-1',
+  snapshotId: 'snapshot-1',
+  kind: 'MAIL_DNS_CONFIGURATION_REGRESSION' as const,
+  monitoredDomainId: 'monitored-1',
+  title: 'Mail DNS regression',
+  description: 'Seeded test condition',
+  severity: 'high' as const,
+};
+
+describe('OperationalConditionService', () => {
+  it('deduplicates repeated observations to one signal, case, and alert', async () => {
+    const { db, rows } = createDb();
+    const service = new OperationalConditionService(db);
+
+    const first = await service.observe(observation);
+    const duplicate = await service.observe(observation);
+
+    expect(first.created).toEqual({ signal: true, case: true, alert: true });
+    expect(duplicate.created).toEqual({ signal: false, case: false, alert: false });
+    expect(rows.internal_signals).toHaveLength(1);
+    expect(rows.internal_cases).toHaveLength(1);
+    expect(rows.alerts).toHaveLength(1);
+    expect(rows.internal_case_events).toHaveLength(1);
+  });
+
+  it('resolves from fresh evidence and reopens the same operational objects', async () => {
+    const { db, rows } = createDb();
+    const service = new OperationalConditionService(db);
+    const first = await service.observe(observation);
+
+    const resolved = await service.resolveCase(
+      first.case.id,
+      'tenant-1',
+      'snapshot-2',
+      [],
+      'Fresh scan cleared condition'
+    );
+    expect(resolved?.status).toBe('RESOLVED');
+    if (!resolved) throw new Error('Expected case resolution fixture');
+    // Model a newer scan captured before the resolution transaction committed.
+    resolved.updatedAt = new Date('2100-01-01T00:00:00Z');
+
+    await expect(service.observe({ ...observation, snapshotId: 'snapshot-2' })).rejects.toThrow(
+      'newer than its resolution lifecycle'
+    );
+
+    const reopened = await service.observe({ ...observation, snapshotId: 'snapshot-3' });
+    expect(reopened.reopened).toEqual({ signal: true, case: true, alert: true });
+    expect(reopened.signal.id).toBe(first.signal.id);
+    expect(reopened.case.id).toBe(first.case.id);
+    expect(reopened.alert.id).toBe(first.alert.id);
+    expect(rows.internal_signals).toHaveLength(1);
+    expect(rows.internal_cases).toHaveLength(1);
+    expect(rows.alerts).toHaveLength(1);
+    expect(rows.internal_case_events).toHaveLength(3);
+  });
+
+  it('rejects cross-tenant observation ownership', async () => {
+    const { db } = createDb();
+    await expect(
+      new OperationalConditionService(db).observe({ ...observation, tenantId: 'other-tenant' })
+    ).rejects.toThrow('outside the tenant');
+  });
+
+  it('rejects cross-tenant, stale, and condition-present resolution evidence', async () => {
+    const { db } = createDb();
+    const service = new OperationalConditionService(db);
+    const first = await service.observe(observation);
+
+    await expect(service.resolveCase(first.case.id, 'tenant-1', 'snapshot-1', [])).rejects.toThrow(
+      'Fresh complete evidence'
+    );
+    await expect(
+      service.resolveCase(first.case.id, 'other-tenant', 'snapshot-2', [])
+    ).resolves.toBeNull();
+    await expect(
+      service.resolveCase(first.case.id, 'tenant-1', 'snapshot-2', [first.signal.conditionKey])
+    ).rejects.toThrow('still reproduces');
+  });
+});

--- a/packages/db/src/repos/operations.test.ts
+++ b/packages/db/src/repos/operations.test.ts
@@ -143,6 +143,28 @@ describe('OperationalConditionService', () => {
     expect(rows.internal_case_events).toHaveLength(1);
   });
 
+  it('opens only an existing active canonical signal case', async () => {
+    const { db } = createDb();
+    const service = new OperationalConditionService(db);
+    const observed = await service.observe({ ...observation, discriminator: 'spf' });
+    await expect(
+      service.openCanonicalCase('tenant-1', 'domain-1', observed.signal.conditionKey)
+    ).resolves.toMatchObject({
+      case: { id: observed.case.id },
+      signal: { id: observed.signal.id },
+    });
+    await expect(
+      service.openCanonicalCase(
+        'tenant-1',
+        'domain-1',
+        'tenant-1:domain-1:MAIL_DNS_CONFIGURATION_REGRESSION:absent'
+      )
+    ).resolves.toBeNull();
+    await expect(
+      service.openCanonicalCase('other-tenant', 'domain-1', observed.signal.conditionKey)
+    ).resolves.toBeNull();
+  });
+
   it('sets an attributed disposition with numeric optimistic concurrency', async () => {
     const { db, rows } = createDb();
     const service = new OperationalConditionService(db);

--- a/packages/db/src/repos/operations.test.ts
+++ b/packages/db/src/repos/operations.test.ts
@@ -165,6 +165,9 @@ describe('OperationalConditionService', () => {
       })
     ).rejects.toMatchObject({ code: 'OPERATION_CONFLICT' });
     expect(rows.internal_case_events).toHaveLength(2);
+    expect(rows.audit_events).toMatchObject([
+      { action: 'mcp_case_disposition_set', actorId: 'operator-1', tenantId: 'tenant-1' },
+    ]);
   });
 
   it('resolves from fresh evidence and reopens the same operational objects', async () => {

--- a/packages/db/src/repos/operations.test.ts
+++ b/packages/db/src/repos/operations.test.ts
@@ -68,7 +68,9 @@ function createDb() {
           : name === 'internal_cases' || name === 'alerts'
             ? 'signalId'
             : 'id';
-      return (rows[name] ?? []).filter((row) => row[key] === param);
+      return (rows[name] ?? []).filter(
+        (row) => row[key] === param || (name === 'internal_cases' && row.id === param)
+      );
     }),
     selectOne: vi.fn(async (table: unknown, condition: unknown) => {
       const name = tableName(table);
@@ -84,6 +86,7 @@ function createDb() {
         updatedAt: now,
         firstSeenAt: now,
         lastSeenAt: now,
+        ...(name === 'internal_cases' ? { version: 1 } : {}),
         ...values,
       };
       rows[name] ??= [];
@@ -138,6 +141,30 @@ describe('OperationalConditionService', () => {
     expect(rows.internal_cases).toHaveLength(1);
     expect(rows.alerts).toHaveLength(1);
     expect(rows.internal_case_events).toHaveLength(1);
+  });
+
+  it('sets an attributed disposition with numeric optimistic concurrency', async () => {
+    const { db, rows } = createDb();
+    const service = new OperationalConditionService(db);
+    const first = await service.observe(observation);
+    const updated = await service.setCaseDisposition({
+      tenantId: 'tenant-1',
+      caseId: first.case.id,
+      expectedVersion: first.case.version,
+      disposition: 'Investigating with owner',
+      actorId: 'operator-1',
+    });
+    expect(updated).toMatchObject({ disposition: 'Investigating with owner', version: 2 });
+    await expect(
+      service.setCaseDisposition({
+        tenantId: 'tenant-1',
+        caseId: first.case.id,
+        expectedVersion: 1,
+        disposition: 'Stale write',
+        actorId: 'operator-2',
+      })
+    ).rejects.toMatchObject({ code: 'OPERATION_CONFLICT' });
+    expect(rows.internal_case_events).toHaveLength(2);
   });
 
   it('resolves from fresh evidence and reopens the same operational objects', async () => {

--- a/packages/db/src/repos/operations.ts
+++ b/packages/db/src/repos/operations.ts
@@ -7,6 +7,7 @@ import { and, eq, isNull, type SQL } from 'drizzle-orm';
 import type { IDatabaseAdapter } from '../database/simple-adapter.js';
 import {
   alerts,
+  auditEvents,
   domains,
   findings,
   type InternalCase,
@@ -445,6 +446,15 @@ export class OperationalConditionService {
         fromStatus: current.status,
         toStatus: current.status,
         disposition: updated.disposition,
+      });
+      await tx.insert(auditEvents, {
+        action: 'mcp_case_disposition_set',
+        entityType: 'internal_case',
+        entityId: current.id,
+        tenantId: input.tenantId,
+        actorId: input.actorId,
+        previousValue: { disposition: current.disposition, version: current.version },
+        newValue: { disposition: updated.disposition, version: updated.version },
       });
       return updated;
     });

--- a/packages/db/src/repos/operations.ts
+++ b/packages/db/src/repos/operations.ts
@@ -352,6 +352,36 @@ export class OperationalConditionService {
     return snapshot;
   }
 
+  /**
+   * MCP/operator case_open is intentionally constrained to an existing active
+   * canonical signal. It never creates model-authored conditions, alerts, or cases.
+   */
+  async openCanonicalCase(
+    tenantId: string,
+    domainId: string,
+    conditionKey: string
+  ): Promise<{ case: InternalCase; signal: InternalSignal } | null> {
+    const signals = await this.db.selectWhere(
+      internalSignals,
+      eq(internalSignals.conditionKey, conditionKey)
+    );
+    const signal = signals.find(
+      (candidate) =>
+        candidate.tenantId === tenantId &&
+        candidate.domainId === domainId &&
+        candidate.status === 'ACTIVE'
+    );
+    if (!signal) return null;
+    const cases = await this.db.selectWhere(internalCases, eq(internalCases.signalId, signal.id));
+    const internalCase = cases.find(
+      (candidate) =>
+        candidate.tenantId === tenantId &&
+        candidate.status !== 'RESOLVED' &&
+        candidate.status !== 'DISMISSED'
+    );
+    return internalCase ? { case: internalCase, signal } : null;
+  }
+
   async getCase(
     tenantId: string,
     caseId: string

--- a/packages/db/src/repos/operations.ts
+++ b/packages/db/src/repos/operations.ts
@@ -351,6 +351,59 @@ export class OperationalConditionService {
     return snapshot;
   }
 
+  async getCase(
+    tenantId: string,
+    caseId: string
+  ): Promise<{
+    case: InternalCase;
+    signal: InternalSignal;
+    events: (typeof internalCaseEvents.$inferSelect)[];
+  } | null> {
+    const cases = await this.db.selectWhere(internalCases, eq(internalCases.id, caseId));
+    const internalCase = cases.find((candidate) => candidate.tenantId === tenantId);
+    if (!internalCase) return null;
+    const signals = await this.db.selectWhere(
+      internalSignals,
+      eq(internalSignals.id, internalCase.signalId)
+    );
+    const signal = signals.find((candidate) => candidate.tenantId === tenantId);
+    if (!signal) return null;
+    const events = await this.db.selectWhere(
+      internalCaseEvents,
+      eq(internalCaseEvents.caseId, caseId)
+    );
+    return {
+      case: internalCase,
+      signal,
+      events: events
+        .filter((event) => event.tenantId === tenantId)
+        .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime()),
+    };
+  }
+
+  async listCases(
+    tenantId: string,
+    domainId?: string
+  ): Promise<Array<{ case: InternalCase; signal: InternalSignal }>> {
+    const [cases, signals] = await Promise.all([
+      this.db.selectWhere(internalCases, eq(internalCases.tenantId, tenantId)),
+      this.db.selectWhere(internalSignals, eq(internalSignals.tenantId, tenantId)),
+    ]);
+    const signalsById = new Map(
+      signals
+        .filter((signal) => !domainId || signal.domainId === domainId)
+        .map((signal) => [signal.id, signal])
+    );
+    return cases
+      .map((internalCase) => ({
+        case: internalCase,
+        signal: signalsById.get(internalCase.signalId),
+      }))
+      .filter((item): item is { case: InternalCase; signal: InternalSignal } =>
+        Boolean(item.signal)
+      );
+  }
+
   async setCaseDisposition(input: {
     tenantId: string;
     caseId: string;

--- a/packages/db/src/repos/operations.ts
+++ b/packages/db/src/repos/operations.ts
@@ -164,6 +164,7 @@ class InternalCaseRepository {
     const update: Partial<NewInternalCase> = {
       status,
       updatedAt: new Date(),
+      version: current.version + 1,
       note: metadata.note ?? current.note,
       disposition: metadata.disposition ?? current.disposition,
     };
@@ -186,6 +187,7 @@ class InternalCaseRepository {
       requiredAnd(
         eq(internalCases.id, current.id),
         eq(internalCases.status, current.status),
+        eq(internalCases.version, current.version),
         eq(internalCases.updatedAt, current.updatedAt)
       )
     );
@@ -347,6 +349,52 @@ export class OperationalConditionService {
       }
     }
     return snapshot;
+  }
+
+  async setCaseDisposition(input: {
+    tenantId: string;
+    caseId: string;
+    expectedVersion: number;
+    disposition: string;
+    actorId: string;
+  }): Promise<InternalCase | null> {
+    if (!Number.isInteger(input.expectedVersion) || input.expectedVersion < 1) {
+      throw new Error('Case expected version must be a positive integer');
+    }
+    if (!input.disposition.trim() || input.disposition.length > 500) {
+      throw new Error('Case disposition must contain 1-500 characters');
+    }
+    return this.db.transaction(async (tx) => {
+      const cases = await tx.selectWhere(internalCases, eq(internalCases.id, input.caseId));
+      const current = cases.find((internalCase) => internalCase.tenantId === input.tenantId);
+      if (!current) return null;
+      if (current.version !== input.expectedVersion) {
+        throw operationConflict('Case version is stale');
+      }
+      const updated = await tx.updateOne(
+        internalCases,
+        {
+          disposition: input.disposition.trim(),
+          version: current.version + 1,
+          updatedAt: new Date(),
+        },
+        requiredAnd(
+          eq(internalCases.id, current.id),
+          eq(internalCases.tenantId, input.tenantId),
+          eq(internalCases.version, input.expectedVersion)
+        )
+      );
+      if (!updated) throw operationConflict('Case changed during disposition update');
+      await tx.insert(internalCaseEvents, {
+        caseId: current.id,
+        tenantId: input.tenantId,
+        actorId: input.actorId,
+        fromStatus: current.status,
+        toStatus: current.status,
+        disposition: updated.disposition,
+      });
+      return updated;
+    });
   }
 
   async resolveCase(

--- a/packages/db/src/repos/operations.ts
+++ b/packages/db/src/repos/operations.ts
@@ -1,0 +1,413 @@
+import {
+  type InternalCaseStatus,
+  type InternalSignalKind,
+  internalConditionKey,
+} from '@dns-ops/contracts';
+import { and, eq, isNull, type SQL } from 'drizzle-orm';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import {
+  alerts,
+  domains,
+  findings,
+  type InternalCase,
+  type InternalSignal,
+  internalCaseEvents,
+  internalCases,
+  internalSignals,
+  monitoredDomains,
+  type NewAlert,
+  type NewInternalCase,
+  type NewInternalSignal,
+  snapshots,
+} from '../schema/index.js';
+
+export interface ObserveOperationalCondition {
+  tenantId: string;
+  domainId: string;
+  snapshotId: string;
+  kind: InternalSignalKind;
+  discriminator?: string;
+  monitoredDomainId: string;
+  title: string;
+  description: string;
+  severity: NewAlert['severity'];
+  triggeredByFindingId?: string;
+}
+
+export interface OperationalConditionResult {
+  signal: InternalSignal;
+  case: InternalCase;
+  alert: typeof alerts.$inferSelect;
+  created: { signal: boolean; case: boolean; alert: boolean };
+  reopened: { signal: boolean; case: boolean; alert: boolean };
+}
+
+function requiredAnd(...conditions: SQL[]): SQL {
+  const condition = and(...conditions);
+  if (!condition) throw new Error('Expected at least one database predicate');
+  return condition;
+}
+
+function operationConflict(message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code: 'OPERATION_CONFLICT' });
+}
+
+function isRetryableConflict(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (String(error.code) === '23505' || String(error.code) === 'OPERATION_CONFLICT')
+  );
+}
+
+class InternalSignalRepository {
+  constructor(private db: IDatabaseAdapter) {}
+
+  async findByConditionKey(tenantId: string, conditionKey: string): Promise<InternalSignal | null> {
+    const rows = await this.db.selectWhere(
+      internalSignals,
+      eq(internalSignals.conditionKey, conditionKey)
+    );
+    return rows.find((row) => row.tenantId === tenantId) ?? null;
+  }
+
+  async create(data: NewInternalSignal): Promise<InternalSignal> {
+    return this.db.insert(internalSignals, data);
+  }
+
+  async markObserved(signal: InternalSignal, snapshotId: string): Promise<InternalSignal> {
+    const lastSeenPredicate = signal.lastSeenSnapshotId
+      ? eq(internalSignals.lastSeenSnapshotId, signal.lastSeenSnapshotId)
+      : isNull(internalSignals.lastSeenSnapshotId);
+    const updated = await this.db.updateOne(
+      internalSignals,
+      {
+        status: 'ACTIVE',
+        lastSeenSnapshotId: snapshotId,
+        lastSeenAt: new Date(),
+        resolvedAt: signal.status === 'RESOLVED' ? null : signal.resolvedAt,
+      },
+      requiredAnd(
+        eq(internalSignals.id, signal.id),
+        eq(internalSignals.status, signal.status),
+        lastSeenPredicate
+      )
+    );
+    if (!updated) throw operationConflict('Signal changed during observation');
+    return updated;
+  }
+
+  async resolve(signal: InternalSignal, tenantId: string): Promise<InternalSignal | null> {
+    if (signal.tenantId !== tenantId) return null;
+    const updated = await this.db.updateOne(
+      internalSignals,
+      { status: 'RESOLVED', resolvedAt: new Date() },
+      requiredAnd(
+        eq(internalSignals.id, signal.id),
+        eq(internalSignals.status, signal.status),
+        signal.lastSeenSnapshotId
+          ? eq(internalSignals.lastSeenSnapshotId, signal.lastSeenSnapshotId)
+          : isNull(internalSignals.lastSeenSnapshotId)
+      )
+    );
+    if (!updated) throw operationConflict('Signal changed during resolution');
+    return updated;
+  }
+}
+
+class InternalCaseRepository {
+  constructor(private db: IDatabaseAdapter) {}
+
+  async findBySignalId(signalId: string, tenantId: string): Promise<InternalCase | null> {
+    const rows = await this.db.selectWhere(internalCases, eq(internalCases.signalId, signalId));
+    return rows.find((row) => row.tenantId === tenantId) ?? null;
+  }
+
+  async create(data: NewInternalCase, actorId = 'system'): Promise<InternalCase> {
+    const internalCase = await this.db.insert(internalCases, data);
+    await this.db.insert(internalCaseEvents, {
+      caseId: internalCase.id,
+      tenantId: internalCase.tenantId,
+      actorId,
+      fromStatus: null,
+      toStatus: internalCase.status,
+    });
+    return internalCase;
+  }
+
+  async transition(
+    current: InternalCase,
+    status: InternalCaseStatus,
+    metadata: {
+      actorId?: string;
+      note?: string;
+      disposition?: string;
+      verificationSnapshotId?: string;
+    } = {}
+  ): Promise<InternalCase> {
+    const allowed: Record<InternalCaseStatus, InternalCaseStatus[]> = {
+      OPEN: ['ACKNOWLEDGED', 'BLOCKED', 'RESOLVED', 'DISMISSED'],
+      ACKNOWLEDGED: ['BLOCKED', 'RESOLVED', 'DISMISSED'],
+      BLOCKED: ['OPEN', 'ACKNOWLEDGED', 'RESOLVED', 'DISMISSED'],
+      RESOLVED: ['OPEN'],
+      DISMISSED: ['OPEN'],
+    };
+    if (current.status !== status && !allowed[current.status].includes(status)) {
+      throw new Error(`Invalid case transition: ${current.status} -> ${status}`);
+    }
+    if (current.status === status) return current;
+    if (status === 'RESOLVED' && !metadata.verificationSnapshotId) {
+      throw new Error('Verified service evidence is required for case resolution');
+    }
+
+    const update: Partial<NewInternalCase> = {
+      status,
+      updatedAt: new Date(),
+      note: metadata.note ?? current.note,
+      disposition: metadata.disposition ?? current.disposition,
+    };
+    if (status === 'ACKNOWLEDGED') {
+      update.acknowledgedAt = new Date();
+      update.acknowledgedBy = metadata.actorId;
+    }
+    if (status === 'RESOLVED') {
+      update.resolvedAt = new Date();
+      update.verificationSnapshotId = metadata.verificationSnapshotId;
+    }
+    if (status === 'OPEN') {
+      update.resolvedAt = null;
+      update.verificationSnapshotId = null;
+    }
+
+    const transitioned = await this.db.updateOne(
+      internalCases,
+      update,
+      requiredAnd(
+        eq(internalCases.id, current.id),
+        eq(internalCases.status, current.status),
+        eq(internalCases.updatedAt, current.updatedAt)
+      )
+    );
+    if (!transitioned) throw operationConflict('Case changed during transition');
+    await this.db.insert(internalCaseEvents, {
+      caseId: current.id,
+      tenantId: current.tenantId,
+      actorId: metadata.actorId ?? 'system',
+      fromStatus: current.status,
+      toStatus: status,
+      note: metadata.note,
+      disposition: metadata.disposition,
+      verificationSnapshotId: metadata.verificationSnapshotId,
+    });
+    return transitioned;
+  }
+}
+
+export class OperationalConditionService {
+  constructor(private db: IDatabaseAdapter) {}
+
+  async observe(input: ObserveOperationalCondition): Promise<OperationalConditionResult> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        return await this.db.transaction((tx) =>
+          new OperationalConditionService(tx).observeTransaction(input)
+        );
+      } catch (error) {
+        if (!isRetryableConflict(error) || attempt === 2) throw error;
+      }
+    }
+    throw new Error('Unable to observe operational condition');
+  }
+
+  private async observeTransaction(
+    input: ObserveOperationalCondition
+  ): Promise<OperationalConditionResult> {
+    const snapshot = await this.validateObservationOwnership(input);
+    const signalRepo = new InternalSignalRepository(this.db);
+    const caseRepo = new InternalCaseRepository(this.db);
+    const conditionKey = internalConditionKey(
+      input.tenantId,
+      input.domainId,
+      input.kind,
+      input.discriminator
+    );
+
+    let signal = await signalRepo.findByConditionKey(input.tenantId, conditionKey);
+    const signalCreated = !signal;
+    const signalReopened = signal?.status === 'RESOLVED';
+    if (signal?.lastSeenSnapshotId && signal.lastSeenSnapshotId !== input.snapshotId) {
+      const priorSnapshot = await this.db.selectOne(
+        snapshots,
+        eq(snapshots.id, signal.lastSeenSnapshotId)
+      );
+      if (priorSnapshot && snapshot.createdAt <= priorSnapshot.createdAt) {
+        throw new Error('Signal evidence must be newer than its latest observed snapshot');
+      }
+    }
+    const existingCase = signal ? await caseRepo.findBySignalId(signal.id, input.tenantId) : null;
+    const priorVerificationSnapshot = existingCase?.verificationSnapshotId
+      ? await this.db.selectOne(snapshots, eq(snapshots.id, existingCase.verificationSnapshotId))
+      : null;
+    if (
+      signalReopened &&
+      (signal?.lastSeenSnapshotId === input.snapshotId ||
+        existingCase?.verificationSnapshotId === input.snapshotId ||
+        (priorVerificationSnapshot && snapshot.createdAt <= priorVerificationSnapshot.createdAt))
+    ) {
+      throw new Error('Resolved signal requires evidence newer than its resolution lifecycle');
+    }
+
+    signal = signal
+      ? await signalRepo.markObserved(signal, input.snapshotId)
+      : await signalRepo.create({
+          tenantId: input.tenantId,
+          domainId: input.domainId,
+          kind: input.kind,
+          conditionKey,
+          status: 'ACTIVE',
+          firstSeenSnapshotId: input.snapshotId,
+          lastSeenSnapshotId: input.snapshotId,
+        });
+
+    let internalCase = existingCase;
+    const caseCreated = !internalCase;
+    const caseReopened =
+      internalCase?.status === 'RESOLVED' || internalCase?.status === 'DISMISSED';
+    internalCase = internalCase
+      ? caseReopened
+        ? await caseRepo.transition(internalCase, 'OPEN')
+        : internalCase
+      : await caseRepo.create({ tenantId: input.tenantId, signalId: signal.id, status: 'OPEN' });
+
+    const existingAlerts = await this.db.selectWhere(alerts, eq(alerts.signalId, signal.id));
+    let alert = existingAlerts.find((row) => row.tenantId === input.tenantId);
+    const alertCreated = !alert;
+    const alertReopened = alert?.status === 'resolved';
+    if (!alert) {
+      alert = await this.db.insert(alerts, {
+        monitoredDomainId: input.monitoredDomainId,
+        tenantId: input.tenantId,
+        signalId: signal.id,
+        dedupKey: conditionKey,
+        title: input.title,
+        description: input.description,
+        severity: input.severity,
+        triggeredByFindingId: input.triggeredByFindingId,
+        status: 'pending',
+      });
+    } else if (alertReopened) {
+      alert =
+        (await this.db.updateOne(
+          alerts,
+          { status: 'pending', resolvedAt: null, resolutionNote: null },
+          requiredAnd(eq(alerts.id, alert.id), eq(alerts.status, 'resolved'))
+        )) ??
+        (() => {
+          throw operationConflict('Alert changed during reopen');
+        })();
+    }
+
+    return {
+      signal,
+      case: internalCase,
+      alert,
+      created: { signal: signalCreated, case: caseCreated, alert: alertCreated },
+      reopened: { signal: signalReopened, case: caseReopened, alert: alertReopened },
+    };
+  }
+
+  private async validateObservationOwnership(input: ObserveOperationalCondition) {
+    const domain = await this.db.selectOne(domains, eq(domains.id, input.domainId));
+    const snapshot = await this.db.selectOne(snapshots, eq(snapshots.id, input.snapshotId));
+    const monitored = await this.db.selectOne(
+      monitoredDomains,
+      eq(monitoredDomains.id, input.monitoredDomainId)
+    );
+    if (!domain || domain.tenantId !== input.tenantId) {
+      throw new Error('Operational condition domain is outside the tenant');
+    }
+    if (!snapshot || snapshot.domainId !== input.domainId) {
+      throw new Error('Operational condition snapshot does not belong to the domain');
+    }
+    if (
+      !monitored ||
+      monitored.tenantId !== input.tenantId ||
+      monitored.domainId !== input.domainId
+    ) {
+      throw new Error('Monitored domain is outside the operational condition tenant');
+    }
+    if (input.triggeredByFindingId) {
+      const finding = await this.db.selectOne(
+        findings,
+        eq(findings.id, input.triggeredByFindingId)
+      );
+      if (!finding || finding.snapshotId !== input.snapshotId) {
+        throw new Error('Finding does not belong to the operational condition snapshot');
+      }
+    }
+    return snapshot;
+  }
+
+  async resolveCase(
+    caseId: string,
+    tenantId: string,
+    verificationSnapshotId: string,
+    activeConditionKeys: string[],
+    note?: string,
+    actorId = 'system'
+  ): Promise<InternalCase | null> {
+    return this.db.transaction(async (tx) => {
+      const internalCase = await tx.selectOne(internalCases, eq(internalCases.id, caseId));
+      if (!internalCase || internalCase.tenantId !== tenantId) return null;
+      const signal = await tx.selectOne(
+        internalSignals,
+        eq(internalSignals.id, internalCase.signalId)
+      );
+      const snapshot = await tx.selectOne(snapshots, eq(snapshots.id, verificationSnapshotId));
+      if (
+        !signal ||
+        signal.tenantId !== tenantId ||
+        !snapshot ||
+        snapshot.domainId !== signal.domainId
+      ) {
+        throw new Error('Verification snapshot does not belong to this operational condition');
+      }
+      const domain = await tx.selectOne(domains, eq(domains.id, snapshot.domainId));
+      const lastObservedSnapshot = signal.lastSeenSnapshotId
+        ? await tx.selectOne(snapshots, eq(snapshots.id, signal.lastSeenSnapshotId))
+        : null;
+      if (!domain || domain.tenantId !== tenantId)
+        throw new Error('Verification snapshot not found');
+      if (
+        snapshot.createdAt <= internalCase.updatedAt ||
+        (lastObservedSnapshot && snapshot.createdAt <= lastObservedSnapshot.createdAt) ||
+        snapshot.resultState !== 'complete' ||
+        snapshot.metadata?.evaluation?.state !== 'COMPLETE'
+      ) {
+        throw new Error('Fresh complete evidence is required to resolve this case');
+      }
+      if (activeConditionKeys.includes(signal.conditionKey)) {
+        throw new Error('Verification evidence still reproduces the operational condition');
+      }
+
+      const resolved = await new InternalCaseRepository(tx).transition(internalCase, 'RESOLVED', {
+        actorId,
+        note,
+        verificationSnapshotId,
+      });
+      await new InternalSignalRepository(tx).resolve(signal, tenantId);
+      const linkedAlerts = await tx.selectWhere(alerts, eq(alerts.signalId, signal.id));
+      const alert = linkedAlerts.find((row) => row.tenantId === tenantId);
+      if (alert && alert.status !== 'resolved') {
+        const resolvedAlert = await tx.updateOne(
+          alerts,
+          { status: 'resolved', resolvedAt: new Date(), resolutionNote: note },
+          requiredAnd(eq(alerts.id, alert.id), eq(alerts.status, alert.status))
+        );
+        if (!resolvedAlert) throw operationConflict('Alert changed during resolution');
+      }
+      return resolved;
+    });
+  }
+}

--- a/packages/db/src/repos/portfolio.ts
+++ b/packages/db/src/repos/portfolio.ts
@@ -436,9 +436,14 @@ export class AlertRepository {
     );
   }
 
-  async findByDedupKey(dedupKey: string, since: Date): Promise<Alert[]> {
+  async findByDedupKey(tenantId: string, dedupKey: string, since: Date): Promise<Alert[]> {
     const results = await this.db.select(alerts);
-    return results.filter((r) => r.dedupKey === dedupKey && new Date(r.createdAt) > since);
+    return results.filter(
+      (alert) =>
+        alert.tenantId === tenantId &&
+        alert.dedupKey === dedupKey &&
+        new Date(alert.createdAt) > since
+    );
   }
 
   async create(data: NewAlert): Promise<Alert> {

--- a/packages/db/src/repos/probe-observation.ts
+++ b/packages/db/src/repos/probe-observation.ts
@@ -45,7 +45,7 @@ export class ProbeObservationRepository {
    */
   async findBySnapshotAndType(
     snapshotId: string,
-    probeType: 'smtp_starttls' | 'mta_sts' | 'tls_cert' | 'http'
+    probeType: 'smtp_starttls' | 'mta_sts' | 'tls_cert' | 'http' | 'rdap'
   ): Promise<ProbeObservation[]> {
     const results = await this.db.selectWhere(
       probeObservations,

--- a/packages/db/src/repos/snapshot.evaluation.test.ts
+++ b/packages/db/src/repos/snapshot.evaluation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import type { Snapshot } from '../schema/index.js';
+import { SnapshotRepository } from './snapshot.js';
+
+function snapshot(overrides: Partial<Snapshot> = {}): Snapshot {
+  return {
+    id: 'snapshot-1',
+    domainId: 'domain-1',
+    domainName: 'example.com',
+    resultState: 'complete',
+    queriedNames: ['example.com'],
+    queriedTypes: ['TXT'],
+    vantages: ['public-recursive'],
+    zoneManagement: 'managed',
+    rulesetVersionId: null,
+    triggeredBy: 'test',
+    collectionDurationMs: null,
+    errorMessage: null,
+    metadata: { vantageIdentifiers: ['8.8.8.8'] },
+    createdAt: new Date('2026-07-28T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('SnapshotRepository evaluation coverage', () => {
+  it('degrades complete to partial and preserves existing metadata', async () => {
+    const existing = snapshot();
+    const updateOne = vi.fn().mockImplementation(async (_table, values) => ({
+      ...existing,
+      ...values,
+    }));
+    const db = {
+      selectOne: vi.fn().mockResolvedValue(existing),
+      updateOne,
+    } as unknown as IDatabaseAdapter;
+    const repo = new SnapshotRepository(db);
+    const evaluation = {
+      state: 'PARTIAL' as const,
+      errors: [
+        {
+          code: 'RULE_EXECUTION_FAILED' as const,
+          ruleId: 'test.throwing-rule',
+          message: 'Rule test.throwing-rule could not be evaluated',
+          status: 'UNKNOWN' as const,
+          unknown: {
+            reason: 'CHECK_EVALUATION_FAILED' as const,
+            explanation: 'The check failed before it produced a trustworthy result.',
+            action: 'RUN_FRESH_SCAN' as const,
+            actionLabel: 'Run a fresh scan',
+            blocking: true,
+          },
+        },
+      ],
+    };
+
+    const updated = await repo.updateEvaluationCoverage(existing.id, evaluation);
+
+    expect(updated?.resultState).toBe('partial');
+    expect(updated?.metadata).toEqual({
+      vantageIdentifiers: ['8.8.8.8'],
+      evaluation,
+    });
+    expect(updateOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not upgrade an already failed snapshot', async () => {
+    const existing = snapshot({ resultState: 'failed' });
+    const updateOne = vi.fn().mockImplementation(async (_table, values) => ({
+      ...existing,
+      ...values,
+    }));
+    const db = {
+      selectOne: vi.fn().mockResolvedValue(existing),
+      updateOne,
+    } as unknown as IDatabaseAdapter;
+    const repo = new SnapshotRepository(db);
+
+    const updated = await repo.updateEvaluationCoverage(existing.id, {
+      state: 'PARTIAL',
+      errors: [],
+    });
+
+    expect(updated?.resultState).toBe('failed');
+  });
+});

--- a/packages/db/src/repos/snapshot.ts
+++ b/packages/db/src/repos/snapshot.ts
@@ -5,6 +5,7 @@
  * Snapshots represent point-in-time collections of DNS data.
  */
 
+import type { EvaluationCoverage } from '@dns-ops/contracts';
 import { eq } from 'drizzle-orm';
 import type { IDatabaseAdapter } from '../database/simple-adapter.js';
 import { type NewSnapshot, type Snapshot, snapshots } from '../schema/index.js';
@@ -129,6 +130,31 @@ export class SnapshotRepository {
    */
   async updateRulesetVersion(id: string, rulesetVersionId: string): Promise<Snapshot | undefined> {
     return this.db.updateOne(snapshots, { rulesetVersionId }, eq(snapshots.id, id));
+  }
+
+  /**
+   * Persist whether every enabled rule completed. Evaluation failures degrade a
+   * complete snapshot to partial so downstream API, UI, and MCP consumers cannot
+   * interpret zero findings as healthy.
+   */
+  async updateEvaluationCoverage(
+    id: string,
+    evaluation: EvaluationCoverage
+  ): Promise<Snapshot | undefined> {
+    const existing = await this.findById(id);
+    if (!existing) return undefined;
+
+    return this.db.updateOne(
+      snapshots,
+      {
+        resultState:
+          evaluation.state === 'PARTIAL' && existing.resultState === 'complete'
+            ? 'partial'
+            : existing.resultState,
+        metadata: { ...(existing.metadata ?? {}), evaluation },
+      },
+      eq(snapshots.id, id)
+    );
   }
 
   /**

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -11,7 +11,7 @@
  * - RulesetVersion: Version tracking for rules
  */
 
-import type { EvaluationCoverage } from '@dns-ops/contracts';
+import type { AuthoritativeEvidenceCoverage, EvaluationCoverage } from '@dns-ops/contracts';
 import {
   boolean,
   index,
@@ -187,6 +187,7 @@ export const snapshots = pgTable(
       // Rules evaluation coverage. A partial evaluation must remain visible even
       // when no findings were produced by the failed check.
       evaluation?: EvaluationCoverage;
+      authoritativeEvidence?: AuthoritativeEvidenceCoverage;
     }>(),
 
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -850,6 +850,8 @@ export const internalCases = pgTable(
       .notNull()
       .references(() => internalSignals.id, { onDelete: 'cascade' }),
     status: internalCaseStatusEnum('status').notNull().default('OPEN'),
+    /** Numeric optimistic-concurrency version exposed to operator/MCP disposition updates. */
+    version: integer('version').notNull().default(1),
     disposition: text('disposition'),
     note: text('note'),
     acknowledgedAt: timestamp('acknowledged_at', { withTimezone: true }),

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -16,10 +16,13 @@ import type {
   EvaluationCoverage,
   ExternalEvidenceData,
   InternalSignalKind,
+  OperationalConditionBaselinePolicy,
   UnknownResolution,
 } from '@dns-ops/contracts';
+import { sql } from 'drizzle-orm';
 import {
   boolean,
+  check,
   foreignKey,
   index,
   integer,
@@ -618,6 +621,7 @@ export const auditActionEnum = pgEnum('audit_action', [
   'alert_resolved',
   'alert_suppressed',
   'domain_profile_updated',
+  'operational_baseline_accepted',
 ]);
 
 export const auditEvents = pgTable(
@@ -769,6 +773,45 @@ export const internalCaseStatusEnum = pgEnum('internal_case_status', [
   'RESOLVED',
   'DISMISSED',
 ]);
+
+export const operationalConditionBaselines = pgTable(
+  'operational_condition_baselines',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').notNull(),
+    domainId: uuid('domain_id').notNull(),
+    kind: internalSignalKindEnum('kind').notNull().$type<InternalSignalKind>(),
+    discriminator: varchar('discriminator', { length: 64 }).notNull(),
+    sourceSnapshotId: uuid('source_snapshot_id')
+      .notNull()
+      .references(() => snapshots.id),
+    policy: jsonb('policy').notNull().$type<OperationalConditionBaselinePolicy>(),
+    maxEvidenceAgeSeconds: integer('max_evidence_age_seconds').notNull(),
+    acceptedAt: timestamp('accepted_at', { withTimezone: true }).notNull().defaultNow(),
+    acceptedBy: varchar('accepted_by', { length: 100 }).notNull(),
+    supersededAt: timestamp('superseded_at', { withTimezone: true }),
+    supersededBy: varchar('superseded_by', { length: 100 }),
+  },
+  (table) => ({
+    domainTenantFk: foreignKey({
+      columns: [table.domainId, table.tenantId],
+      foreignColumns: [domains.id, domains.tenantId],
+      name: 'operational_baseline_domain_tenant_fk',
+    }).onDelete('cascade'),
+    activeConditionUnique: uniqueIndex('operational_baseline_active_condition_unique')
+      .on(table.tenantId, table.domainId, table.kind, table.discriminator)
+      .where(sql`${table.supersededAt} IS NULL`),
+    tenantIdx: index('operational_baseline_tenant_idx').on(table.tenantId),
+    sourceSnapshotIdx: index('operational_baseline_snapshot_idx').on(table.sourceSnapshotId),
+    maxEvidenceAgePositive: check(
+      'operational_baseline_max_evidence_age_positive',
+      sql`${table.maxEvidenceAgeSeconds} > 0`
+    ),
+  })
+);
+
+export type OperationalConditionBaseline = typeof operationalConditionBaselines.$inferSelect;
+export type NewOperationalConditionBaseline = typeof operationalConditionBaselines.$inferInsert;
 
 export const internalSignals = pgTable(
   'internal_signals',

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -11,7 +11,11 @@
  * - RulesetVersion: Version tracking for rules
  */
 
-import type { AuthoritativeEvidenceCoverage, EvaluationCoverage } from '@dns-ops/contracts';
+import type {
+  AuthoritativeEvidenceCoverage,
+  EvaluationCoverage,
+  InternalSignalKind,
+} from '@dns-ops/contracts';
 import {
   boolean,
   index,
@@ -705,6 +709,109 @@ export type MonitoredDomain = typeof monitoredDomains.$inferSelect;
 export type NewMonitoredDomain = typeof monitoredDomains.$inferInsert;
 
 // =============================================================================
+// INTERNAL SIGNALS AND CASES (Phase 0-1 canonical operating loop)
+// =============================================================================
+
+export const internalSignalKindEnum = pgEnum('internal_signal_kind', [
+  'DOMAIN_EXPIRING_SOON',
+  'TLS_CERTIFICATE_REGRESSION',
+  'HTTP_ENDPOINT_UNAVAILABLE',
+  'REDIRECT_TOPOLOGY_REGRESSION',
+  'HOMEPAGE_INDEXABILITY_REGRESSION',
+  'MAIL_DNS_CONFIGURATION_REGRESSION',
+]);
+export const internalSignalStatusEnum = pgEnum('internal_signal_status', ['ACTIVE', 'RESOLVED']);
+export const internalCaseStatusEnum = pgEnum('internal_case_status', [
+  'OPEN',
+  'ACKNOWLEDGED',
+  'BLOCKED',
+  'RESOLVED',
+  'DISMISSED',
+]);
+
+export const internalSignals = pgTable(
+  'internal_signals',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').notNull(),
+    domainId: uuid('domain_id')
+      .notNull()
+      .references(() => domains.id, { onDelete: 'cascade' }),
+    kind: internalSignalKindEnum('kind').notNull().$type<InternalSignalKind>(),
+    conditionKey: varchar('condition_key', { length: 500 }).notNull(),
+    status: internalSignalStatusEnum('status').notNull().default('ACTIVE'),
+    firstSeenSnapshotId: uuid('first_seen_snapshot_id').references(() => snapshots.id),
+    lastSeenSnapshotId: uuid('last_seen_snapshot_id').references(() => snapshots.id),
+    firstSeenAt: timestamp('first_seen_at', { withTimezone: true }).notNull().defaultNow(),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull().defaultNow(),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+  },
+  (table) => ({
+    tenantConditionUnique: uniqueIndex('internal_signal_tenant_condition_unique').on(
+      table.tenantId,
+      table.conditionKey
+    ),
+    tenantIdx: index('internal_signal_tenant_idx').on(table.tenantId),
+    domainIdx: index('internal_signal_domain_idx').on(table.domainId),
+    statusIdx: index('internal_signal_status_idx').on(table.status),
+  })
+);
+
+export const internalCases = pgTable(
+  'internal_cases',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').notNull(),
+    signalId: uuid('signal_id')
+      .notNull()
+      .references(() => internalSignals.id, { onDelete: 'cascade' }),
+    status: internalCaseStatusEnum('status').notNull().default('OPEN'),
+    disposition: text('disposition'),
+    note: text('note'),
+    acknowledgedAt: timestamp('acknowledged_at', { withTimezone: true }),
+    acknowledgedBy: varchar('acknowledged_by', { length: 100 }),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+    verificationSnapshotId: uuid('verification_snapshot_id').references(() => snapshots.id),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    signalUnique: uniqueIndex('internal_case_signal_unique').on(table.signalId),
+    tenantIdx: index('internal_case_tenant_idx').on(table.tenantId),
+    statusIdx: index('internal_case_status_idx').on(table.status),
+  })
+);
+
+export const internalCaseEvents = pgTable(
+  'internal_case_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    caseId: uuid('case_id')
+      .notNull()
+      .references(() => internalCases.id, { onDelete: 'cascade' }),
+    tenantId: uuid('tenant_id').notNull(),
+    actorId: varchar('actor_id', { length: 100 }).notNull(),
+    fromStatus: internalCaseStatusEnum('from_status'),
+    toStatus: internalCaseStatusEnum('to_status').notNull(),
+    note: text('note'),
+    disposition: text('disposition'),
+    verificationSnapshotId: uuid('verification_snapshot_id').references(() => snapshots.id),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    caseIdx: index('internal_case_event_case_idx').on(table.caseId),
+    tenantIdx: index('internal_case_event_tenant_idx').on(table.tenantId),
+  })
+);
+
+export type InternalSignal = typeof internalSignals.$inferSelect;
+export type NewInternalSignal = typeof internalSignals.$inferInsert;
+export type InternalCase = typeof internalCases.$inferSelect;
+export type NewInternalCase = typeof internalCases.$inferInsert;
+export type InternalCaseEvent = typeof internalCaseEvents.$inferSelect;
+export type NewInternalCaseEvent = typeof internalCaseEvents.$inferInsert;
+
+// =============================================================================
 // ALERTS (Bead 15)
 // =============================================================================
 
@@ -744,6 +851,7 @@ export const alerts = pgTable(
 
     // Trigger
     triggeredByFindingId: uuid('triggered_by_finding_id').references(() => findings.id),
+    signalId: uuid('signal_id').references(() => internalSignals.id),
 
     // Status
     status: alertStatusEnum('status').notNull().default('pending'),
@@ -769,6 +877,7 @@ export const alerts = pgTable(
     statusIdx: index('alert_status_idx').on(table.status),
     tenantIdx: index('alert_tenant_idx').on(table.tenantId),
     dedupIdx: index('alert_dedup_idx').on(table.dedupKey),
+    signalUnique: uniqueIndex('alert_signal_unique').on(table.signalId),
     createdIdx: index('alert_created_idx').on(table.createdAt),
   })
 );

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -622,6 +622,7 @@ export const auditActionEnum = pgEnum('audit_action', [
   'alert_suppressed',
   'domain_profile_updated',
   'operational_baseline_accepted',
+  'mcp_case_disposition_set',
 ]);
 
 export const auditEvents = pgTable(

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -11,6 +11,7 @@
  * - RulesetVersion: Version tracking for rules
  */
 
+import type { EvaluationCoverage } from '@dns-ops/contracts';
 import {
   boolean,
   index,
@@ -183,6 +184,9 @@ export const snapshots = pgTable(
         hasDnskey?: boolean;
         hasDs?: boolean;
       };
+      // Rules evaluation coverage. A partial evaluation must remain visible even
+      // when no findings were produced by the failed check.
+      evaluation?: EvaluationCoverage;
     }>(),
 
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -766,6 +766,7 @@ export const internalSignalKindEnum = pgEnum('internal_signal_kind', [
   'MAIL_DNS_CONFIGURATION_REGRESSION',
 ]);
 export const internalSignalStatusEnum = pgEnum('internal_signal_status', ['ACTIVE', 'RESOLVED']);
+export const mcpCommandStatusEnum = pgEnum('mcp_command_status', ['PENDING', 'COMPLETED']);
 export const internalCaseStatusEnum = pgEnum('internal_case_status', [
   'OPEN',
   'ACKNOWLEDGED',
@@ -812,6 +813,35 @@ export const operationalConditionBaselines = pgTable(
 
 export type OperationalConditionBaseline = typeof operationalConditionBaselines.$inferSelect;
 export type NewOperationalConditionBaseline = typeof operationalConditionBaselines.$inferInsert;
+
+export const mcpCommands = pgTable(
+  'mcp_commands',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').notNull(),
+    actorId: varchar('actor_id', { length: 100 }).notNull(),
+    operation: varchar('operation', { length: 100 }).notNull(),
+    idempotencyKey: varchar('idempotency_key', { length: 200 }).notNull(),
+    requestFingerprint: varchar('request_fingerprint', { length: 64 }).notNull(),
+    status: mcpCommandStatusEnum('status').notNull().default('PENDING'),
+    resourceId: uuid('resource_id'),
+    response: jsonb('response').$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+  },
+  (table) => ({
+    tenantOperationKeyUnique: uniqueIndex('mcp_command_tenant_operation_key_unique').on(
+      table.tenantId,
+      table.actorId,
+      table.operation,
+      table.idempotencyKey
+    ),
+    tenantIdx: index('mcp_command_tenant_idx').on(table.tenantId),
+  })
+);
+
+export type McpCommand = typeof mcpCommands.$inferSelect;
+export type NewMcpCommand = typeof mcpCommands.$inferInsert;
 
 export const internalSignals = pgTable(
   'internal_signals',

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -14,10 +14,12 @@
 import type {
   AuthoritativeEvidenceCoverage,
   EvaluationCoverage,
+  ExternalEvidenceData,
   InternalSignalKind,
 } from '@dns-ops/contracts';
 import {
   boolean,
+  foreignKey,
   index,
   integer,
   jsonb,
@@ -100,10 +102,47 @@ export const domains = pgTable(
     // Composite unique index: allows same domain name per tenant
     // NULL tenant_id is allowed (system domains) - PostgreSQL treats NULLs as distinct
     nameTenantIdx: uniqueIndex('domain_name_tenant_idx').on(table.normalizedName, table.tenantId),
+    idTenantIdx: uniqueIndex('domain_id_tenant_idx').on(table.id, table.tenantId),
     tenantIdx: index('domain_tenant_idx').on(table.tenantId),
     zoneMgmtIdx: index('domain_zone_management_idx').on(table.zoneManagement),
   })
 );
+
+export const domainPurposeEnum = pgEnum('domain_purpose', [
+  'WEB',
+  'MAIL',
+  'WEB_AND_MAIL',
+  'REDIRECT',
+  'PARKED',
+  'UNKNOWN',
+]);
+
+export const domainCriticalityEnum = pgEnum('domain_criticality', ['HIGH', 'NORMAL', 'LOW']);
+
+export const domainProfiles = pgTable(
+  'domain_profiles',
+  {
+    domainId: uuid('domain_id').primaryKey(),
+    tenantId: uuid('tenant_id').notNull(),
+    purpose: domainPurposeEnum('purpose').notNull().default('UNKNOWN'),
+    responsibleActorId: varchar('responsible_actor_id', { length: 100 }),
+    criticality: domainCriticalityEnum('criticality').notNull().default('NORMAL'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tenantIdx: index('domain_profile_tenant_idx').on(table.tenantId),
+    purposeIdx: index('domain_profile_purpose_idx').on(table.purpose),
+    domainTenantFk: foreignKey({
+      columns: [table.domainId, table.tenantId],
+      foreignColumns: [domains.id, domains.tenantId],
+      name: 'domain_profile_domain_tenant_fk',
+    }).onDelete('cascade'),
+  })
+);
+
+export type DomainProfile = typeof domainProfiles.$inferSelect;
+export type NewDomainProfile = typeof domainProfiles.$inferInsert;
 
 // =============================================================================
 // RULESET VERSION TABLE
@@ -980,7 +1019,13 @@ export type NewFleetReport = typeof fleetReports.$inferInsert;
 // PROBE OBSERVATIONS TABLE
 // =============================================================================
 
-export const probeTypeEnum = pgEnum('probe_type', ['smtp_starttls', 'mta_sts', 'tls_cert', 'http']);
+export const probeTypeEnum = pgEnum('probe_type', [
+  'smtp_starttls',
+  'mta_sts',
+  'tls_cert',
+  'http',
+  'rdap',
+]);
 
 export const probeStatusEnum = pgEnum('probe_status', [
   'success',
@@ -1022,7 +1067,7 @@ export interface MTASTSProbeData {
   certificateValid?: boolean;
 }
 
-export type ProbeData = SMTPProbeData | MTASTSProbeData;
+export type ProbeData = SMTPProbeData | MTASTSProbeData | ExternalEvidenceData;
 
 export const probeObservations = pgTable(
   'probe_observations',

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -16,6 +16,7 @@ import type {
   EvaluationCoverage,
   ExternalEvidenceData,
   InternalSignalKind,
+  UnknownResolution,
 } from '@dns-ops/contracts';
 import {
   boolean,
@@ -1067,7 +1068,19 @@ export interface MTASTSProbeData {
   certificateValid?: boolean;
 }
 
-export type ProbeData = SMTPProbeData | MTASTSProbeData | ExternalEvidenceData;
+export interface ExternalEvidenceProbeData {
+  check:
+    | 'RDAP_EXPIRATION'
+    | 'TLS_CERTIFICATE'
+    | 'HTTP_REACHABILITY'
+    | 'REDIRECT_TOPOLOGY'
+    | 'HOMEPAGE_INDEXABILITY';
+  status: 'OBSERVED' | 'UNKNOWN';
+  evidence?: ExternalEvidenceData;
+  unknown?: UnknownResolution;
+}
+
+export type ProbeData = SMTPProbeData | MTASTSProbeData | ExternalEvidenceProbeData;
 
 export const probeObservations = pgTable(
   'probe_observations',

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -767,7 +767,11 @@ export const internalSignalKindEnum = pgEnum('internal_signal_kind', [
   'MAIL_DNS_CONFIGURATION_REGRESSION',
 ]);
 export const internalSignalStatusEnum = pgEnum('internal_signal_status', ['ACTIVE', 'RESOLVED']);
-export const mcpCommandStatusEnum = pgEnum('mcp_command_status', ['PENDING', 'COMPLETED']);
+export const mcpCommandStatusEnum = pgEnum('mcp_command_status', [
+  'PENDING',
+  'COMPLETED',
+  'FAILED',
+]);
 export const internalCaseStatusEnum = pgEnum('internal_case_status', [
   'OPEN',
   'ACKNOWLEDGED',

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -617,6 +617,7 @@ export const auditActionEnum = pgEnum('audit_action', [
   'alert_acknowledged',
   'alert_resolved',
   'alert_suppressed',
+  'domain_profile_updated',
 ]);
 
 export const auditEvents = pgTable(

--- a/packages/parsing/src/e2e/result-integration.e2e.test.ts
+++ b/packages/parsing/src/e2e/result-integration.e2e.test.ts
@@ -316,14 +316,11 @@ describe('E2E: Mail Record Result Integration', () => {
     }
   });
 
-  it('should reject DMARC without required policy field', () => {
+  it('should apply RFC 9989 p=none fallback without p when rua is valid', () => {
     const result = parseDMARCResult('v=DMARC1; rua=mailto:test@example.com');
 
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.code).toBe('MISSING_REQUIRED_FIELD');
-      expect(result.error.details?.field).toBe('p');
-    }
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value.policy).toBe('none');
   });
 
   it('should handle DKIM with all fields', () => {

--- a/packages/parsing/src/mail/index.test.ts
+++ b/packages/parsing/src/mail/index.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, it } from 'vitest';
-import { assessFirstLevelSpf, countDirectSpfLookupTerms, parseSPF } from './index.js';
+import { assessFirstLevelSpf, countDirectSpfLookupTerms, parseDMARC, parseSPF } from './index.js';
+
+describe('RFC 9989 DMARC tags', () => {
+  it('accepts RFC whitespace around the exact version tag', () => {
+    expect(parseDMARC('v = DMARC1 ; p=none')).toMatchObject({ policy: 'none' });
+    expect(parseDMARC('v=DMARC10; p=reject')).toBeNull();
+  });
+
+  it('accepts psd=u and ignores malformed psd values', () => {
+    expect(parseDMARC('v=DMARC1; p=reject; psd=u')).toMatchObject({
+      policy: 'reject',
+      publicSuffix: 'u',
+    });
+    const malformed = parseDMARC('v=DMARC1; p=reject; psd=bogus');
+    expect(malformed).toMatchObject({ policy: 'reject' });
+    expect(malformed?.publicSuffix).toBeUndefined();
+  });
+
+  it('applies the safe fallback consistently for duplicate policy tags', () => {
+    expect(parseDMARC('v=DMARC1; p=reject; p=bogus; rua=mailto:dmarc@example.com')).toMatchObject({
+      policy: 'none',
+    });
+  });
+
+  it('parses t=y and rejects malformed rua fallback URIs', () => {
+    expect(parseDMARC('v=DMARC1; p=reject; t=y')).toMatchObject({ testing: 'y' });
+    expect(parseDMARC('v=DMARC1; p=bogus; rua=mailto:%ZZ')).toBeNull();
+  });
+
+  it('parses non-existent-domain and public-suffix policy tags', () => {
+    expect(parseDMARC('v=DMARC1; p=reject; np=quarantine; psd=n')).toMatchObject({
+      policy: 'reject',
+      nonExistentSubdomainPolicy: 'quarantine',
+      publicSuffix: 'n',
+    });
+  });
+});
 
 describe('first-level SPF assessment', () => {
   it('FIX-03: exposes nested include and redirect as unresolved dependencies', () => {

--- a/packages/parsing/src/mail/index.test.ts
+++ b/packages/parsing/src/mail/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { assessFirstLevelSpf, countDirectSpfLookupTerms, parseSPF } from './index.js';
+
+describe('first-level SPF assessment', () => {
+  it('FIX-03: exposes nested include and redirect as unresolved dependencies', () => {
+    const parsed = parseSPF(
+      'v=spf1 include:_spf.example.net a mx ip4:192.0.2.0/24 redirect=_spf2.example.net'
+    );
+    expect(parsed).not.toBeNull();
+    if (!parsed) throw new Error('Expected SPF parser fixture to succeed');
+
+    const assessment = assessFirstLevelSpf(parsed);
+
+    expect(assessment).toEqual({
+      scope: 'FIRST_LEVEL_ONLY',
+      directDnsLookupTerms: 4,
+      includeDomains: ['_spf.example.net'],
+      redirectDomain: '_spf2.example.net',
+      status: 'DIRECT_SYNTAX_VALID',
+      completeEvaluation: false,
+      limitation: expect.stringContaining('recursive lookup-budget'),
+    });
+    expect(countDirectSpfLookupTerms(parsed)).toBe(4);
+  });
+
+  it('marks directly visible invalid mechanisms without resolving dependencies', () => {
+    const parsed = parseSPF('v=spf1 include ~all');
+    expect(parsed).not.toBeNull();
+    if (!parsed) throw new Error('Expected SPF parser fixture to succeed');
+
+    expect(assessFirstLevelSpf(parsed).status).toBe('DIRECT_SYNTAX_INVALID');
+  });
+
+  it('requires the SPF version to be the first term', () => {
+    expect(parseSPF('unrelated v=spf1 -all')).toBeNull();
+  });
+});

--- a/packages/parsing/src/mail/index.ts
+++ b/packages/parsing/src/mail/index.ts
@@ -163,6 +163,9 @@ export interface DMARCRecord {
   version: string;
   policy: 'none' | 'quarantine' | 'reject';
   subdomainPolicy?: 'none' | 'quarantine' | 'reject';
+  nonExistentSubdomainPolicy?: 'none' | 'quarantine' | 'reject';
+  publicSuffix?: 'y' | 'n' | 'u';
+  testing?: 'y' | 'n';
   percentage?: number;
   rua?: string[]; // Aggregate report URIs
   ruf?: string[]; // Forensic report URIs
@@ -174,44 +177,69 @@ export interface DMARCRecord {
   raw: string;
 }
 
+function isValidDmarcUri(candidate: string): boolean {
+  const uri = candidate.trim();
+  if (!/^[A-Za-z][A-Za-z0-9+.-]*:[A-Za-z0-9\-._~:/?#[\]@$&'()*+;=%]*$/.test(uri)) {
+    return false;
+  }
+  return !/%(?![0-9A-Fa-f]{2})/.test(uri);
+}
+
 /**
  * Parse a DMARC TXT record
  */
 export function parseDMARC(txtData: string): DMARCRecord | null {
-  // Check if this is a DMARC record
-  if (!txtData.includes('v=DMARC1')) {
-    return null;
-  }
+  if (!/^v[\t ]*=[\t ]*DMARC1(?:[\t ]*;|[\t ]*$)/.test(txtData)) return null;
 
   const record: Partial<DMARCRecord> = {
     version: 'DMARC1',
     raw: txtData,
   };
-
+  let invalidPolicyTag = false;
+  const seenPolicyTags = new Set<string>();
+  const policies = new Set(['none', 'quarantine', 'reject']);
   const parts = txtData.split(/\s*;\s*/).filter(Boolean);
 
   for (const part of parts) {
     const [key, ...valueParts] = part.split('=');
+    const name = key.trim().toLowerCase();
     const value = valueParts.join('=').trim();
 
-    switch (key.trim()) {
+    switch (name) {
       case 'v':
-        record.version = value;
+        if (value !== 'DMARC1') return null;
         break;
       case 'p':
-        record.policy = value as 'none' | 'quarantine' | 'reject';
+        if (seenPolicyTags.has(name) || !policies.has(value)) invalidPolicyTag = true;
+        else record.policy = value as DMARCRecord['policy'];
+        seenPolicyTags.add(name);
         break;
       case 'sp':
-        record.subdomainPolicy = value as 'none' | 'quarantine' | 'reject';
+        if (seenPolicyTags.has(name) || !policies.has(value)) invalidPolicyTag = true;
+        else record.subdomainPolicy = value as DMARCRecord['subdomainPolicy'];
+        seenPolicyTags.add(name);
+        break;
+      case 'np':
+        if (seenPolicyTags.has(name) || !policies.has(value)) invalidPolicyTag = true;
+        else {
+          record.nonExistentSubdomainPolicy = value as DMARCRecord['nonExistentSubdomainPolicy'];
+        }
+        seenPolicyTags.add(name);
+        break;
+      case 'psd':
+        if (value === 'y' || value === 'n' || value === 'u') record.publicSuffix = value;
+        break;
+      case 't':
+        if (value === 'y' || value === 'n') record.testing = value;
         break;
       case 'pct':
         record.percentage = parseInt(value, 10);
         break;
       case 'rua':
-        record.rua = value.split(',').map((s) => s.trim());
+        record.rua = value.split(',').map((item) => item.trim());
         break;
       case 'ruf':
-        record.ruf = value.split(',').map((s) => s.trim());
+        record.ruf = value.split(',').map((item) => item.trim());
         break;
       case 'fo':
         record.fo = value;
@@ -231,9 +259,10 @@ export function parseDMARC(txtData: string): DMARCRecord | null {
     }
   }
 
-  // Policy is required
-  if (!record.policy) {
-    return null;
+  if (invalidPolicyTag || !record.policy) {
+    const validRua = record.rua?.some(isValidDmarcUri);
+    if (!validRua) return null;
+    record.policy = 'none';
   }
 
   return record as DMARCRecord;

--- a/packages/parsing/src/mail/index.ts
+++ b/packages/parsing/src/mail/index.ts
@@ -4,6 +4,8 @@
  * Parse SPF, DMARC, and DKIM records.
  */
 
+import type { FirstLevelSpfAssessment } from '@dns-ops/contracts';
+
 // =============================================================================
 // SPF Parsing
 // =============================================================================
@@ -31,8 +33,9 @@ export interface SPFModifier {
  * Parse an SPF TXT record
  */
 export function parseSPF(txtData: string): SPFRecord | null {
-  // Check if this is an SPF record
-  if (!txtData.includes('v=spf1')) {
+  const normalized = txtData.trim();
+  // SPF version must be the first term, not an arbitrary substring.
+  if (!/^v=spf1(?:\s|$)/.test(normalized)) {
     return null;
   }
 
@@ -107,20 +110,49 @@ function parseMechanism(part: string): SPFMechanism | null {
   };
 }
 
+const DIRECT_DNS_LOOKUP_MECHANISMS = new Set(['include', 'a', 'mx', 'ptr', 'exists']);
+const VALID_SPF_MECHANISMS = new Set(['all', 'include', 'a', 'mx', 'ptr', 'ip4', 'ip6', 'exists']);
+
+/** Count only terms visible in the published record that trigger DNS lookups. */
+export function countDirectSpfLookupTerms(record: SPFRecord): number {
+  const mechanisms = record.mechanisms.filter((mechanism) =>
+    DIRECT_DNS_LOOKUP_MECHANISMS.has(mechanism.type)
+  ).length;
+  const redirects = record.modifiers.filter((modifier) => modifier.name === 'redirect').length;
+  return mechanisms + redirects;
+}
+
 /**
- * Count DNS lookups in an SPF record
+ * Assess only the directly published SPF record. Includes and redirect targets
+ * remain unresolved dependencies; this never claims recursive ten-term budget
+ * compliance or sender authorization.
  */
-export function countSPFLookups(record: SPFRecord): number {
-  let count = 0;
-  const lookupMechanisms = ['include', 'a', 'mx', 'ptr', 'exists', 'redirect'];
+export function assessFirstLevelSpf(record: SPFRecord): FirstLevelSpfAssessment {
+  const includeDomains = record.mechanisms
+    .filter((mechanism) => mechanism.type === 'include' && mechanism.value)
+    .map((mechanism) => mechanism.value as string);
+  const redirects = record.modifiers.filter((modifier) => modifier.name === 'redirect');
+  const invalidMechanism = record.mechanisms.some(
+    (mechanism) => !VALID_SPF_MECHANISMS.has(mechanism.type)
+  );
+  const missingIncludeTarget = record.mechanisms.some(
+    (mechanism) => mechanism.type === 'include' && !mechanism.value
+  );
+  const invalidRedirect = redirects.length > 1 || redirects.some((redirect) => !redirect.value);
 
-  for (const mech of record.mechanisms) {
-    if (lookupMechanisms.includes(mech.type)) {
-      count++;
-    }
-  }
-
-  return count;
+  return {
+    scope: 'FIRST_LEVEL_ONLY',
+    directDnsLookupTerms: countDirectSpfLookupTerms(record),
+    includeDomains,
+    redirectDomain: redirects[0]?.value,
+    status:
+      invalidMechanism || missingIncludeTarget || invalidRedirect
+        ? 'DIRECT_SYNTAX_INVALID'
+        : 'DIRECT_SYNTAX_VALID',
+    completeEvaluation: false,
+    limitation:
+      'Only the published SPF record was inspected. Include and redirect targets were not evaluated; recursive lookup-budget, cycle, void-lookup, nested validity, and sender-authorization claims are unavailable.',
+  };
 }
 
 // =============================================================================

--- a/packages/parsing/src/mail/result.test.ts
+++ b/packages/parsing/src/mail/result.test.ts
@@ -158,14 +158,11 @@ describe('Mail Record Result Utilities', () => {
       }
     });
 
-    it('should return Err for DMARC missing policy', () => {
+    it('applies RFC 9989 p=none fallback when p is missing and rua is valid', () => {
       const result = parseDMARCResult('v=DMARC1; rua=mailto:test@example.com');
 
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.code).toBe('MISSING_REQUIRED_FIELD');
-        expect(result.error.details?.field).toBe('p');
-      }
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.policy).toBe('none');
     });
 
     it('should support error pattern matching', () => {
@@ -355,11 +352,10 @@ describe('Mail Record Result Utilities', () => {
       expect(detected.result?.isOk()).toBe(true);
     });
 
-    it('should detect DMARC record', () => {
-      const detected = parseAnyMailRecord('v=DMARC1; p=reject');
-
-      expect(detected.type).toBe('dmarc');
-      expect(detected.result?.isOk()).toBe(true);
+    it('should detect only exact DMARC1 records including RFC whitespace', () => {
+      expect(parseAnyMailRecord('v=DMARC1; p=reject').type).toBe('dmarc');
+      expect(parseAnyMailRecord('v = DMARC1 ; p=none').type).toBe('dmarc');
+      expect(parseAnyMailRecord('v=DMARC10; p=reject').type).toBe('unknown');
     });
 
     it('should detect DKIM record', () => {

--- a/packages/parsing/src/mail/result.ts
+++ b/packages/parsing/src/mail/result.ts
@@ -104,7 +104,7 @@ export function parseDMARCResult(txtData: string): ResultOrError<DMARCRecord, Ma
 
   if (result === null) {
     // Check if it's because it's not a DMARC record
-    if (!txtData.includes('v=DMARC1')) {
+    if (!/^v[\t ]*=[\t ]*DMARC1(?:[\t ]*;|[\t ]*$)/.test(txtData)) {
       return Result.err(
         new MailParseError({
           message: 'Not a valid DMARC record: missing v=DMARC1',
@@ -114,13 +114,11 @@ export function parseDMARCResult(txtData: string): ResultOrError<DMARCRecord, Ma
       );
     }
 
-    // Missing required policy field
     return Result.err(
       new MailParseError({
-        message: 'DMARC record missing required policy (p=) field',
-        code: 'MISSING_REQUIRED_FIELD',
+        message: 'DMARC record contains invalid tag syntax',
+        code: 'INVALID_FORMAT',
         input: txtData,
-        field: 'p',
       })
     );
   }
@@ -294,7 +292,7 @@ export function parseAnyMailRecord(
   }
 
   // Check for DMARC
-  if (data.includes('v=DMARC1')) {
+  if (/^v[\t ]*=[\t ]*DMARC1(?:[\t ]*;|[\t ]*$)/.test(data)) {
     const dmarc = parseDMARCResult(txtData);
     if (dmarc.isOk()) {
       return { type: 'dmarc', result: dmarc };

--- a/packages/rules/src/dns/rules.ts
+++ b/packages/rules/src/dns/rules.ts
@@ -66,7 +66,7 @@ export const authoritativeFailureRule: Rule = {
           {
             title: 'Check authoritative server health',
             description: `Verify that authoritative nameservers for ${context.domainName} are responding correctly.`,
-            action: `Run connectivity checks to: ${[...new Set(queryFailures.map((f) => f.vantageIdentifier))].join(', ')}`,
+            action: 'Playbook: dns.authoritative.health-review',
             riskPosture: 'low',
             blastRadius,
             reviewOnly: true,
@@ -135,7 +135,7 @@ export const authoritativeMismatchRule: Rule = {
           {
             title: 'Investigate zone inconsistency',
             description: `Check for zone transfer issues or configuration differences between authoritative servers.`,
-            action: `Compare zone files on: ${rs.sourceVantages.filter((v) => !v.includes('(')).join(', ')}`,
+            action: 'Playbook: dns.authoritative.consistency-review',
             riskPosture: 'high',
             blastRadius,
             reviewOnly: true,
@@ -247,7 +247,7 @@ export const recursiveAuthoritativeMismatchRule: Rule = {
         {
           title: 'Check for stale cache',
           description: `Verify if this is a cache propagation issue or configuration problem.`,
-          action: `Compare TTL on recursive vs authoritative. Consider cache flush if values are stale.`,
+          action: 'Playbook: dns.propagation.evidence-review',
           riskPosture: 'low',
           blastRadius,
           reviewOnly: true,
@@ -323,9 +323,10 @@ export const cnameCoexistenceRule: Rule = {
       },
       suggestions: [
         {
-          title: 'Remove conflicting records',
-          description: `Either remove the CNAME or the conflicting record(s). CNAME cannot coexist with other data.`,
-          action: `Choose one: keep CNAME (${violation.cname.values.join(', ')}) OR keep ${violation.conflicting.map((r) => `${r.type} (${r.values.join(', ')})`).join(', ')}`,
+          title: 'Review CNAME conflict',
+          description:
+            'Confirm service ownership and dependencies before choosing which record family should remain. No removal is approved automatically.',
+          action: 'Playbook: dns.cname.conflict-review',
           riskPosture: 'high',
           blastRadius,
           reviewOnly: true,

--- a/packages/rules/src/engine/index.test.ts
+++ b/packages/rules/src/engine/index.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { type RuleContext, RulesEngine, type Ruleset } from './index.js';
+
+const context: RuleContext = {
+  snapshotId: 'snapshot-1',
+  domainId: 'domain-1',
+  domainName: 'example.com',
+  zoneManagement: 'managed',
+  observations: [],
+  recordSets: [],
+  rulesetVersion: 'test-1',
+};
+
+function rulesetWith(evaluate: Ruleset['rules'][number]['evaluate']): Ruleset {
+  return {
+    id: 'test-ruleset',
+    version: 'test-1',
+    name: 'Test ruleset',
+    description: 'Deterministic engine test',
+    createdAt: new Date('2026-07-28T00:00:00Z'),
+    rules: [
+      {
+        id: 'test.throwing-rule',
+        name: 'Throwing rule',
+        description: 'Throws intentionally',
+        version: '1.0.0',
+        enabled: true,
+        evaluate,
+      },
+    ],
+  };
+}
+
+describe('RulesEngine evaluation completeness', () => {
+  it('FIX-01: reports a throwing rule as explicit UNKNOWN instead of a clean result', () => {
+    const engine = new RulesEngine(
+      rulesetWith(() => {
+        throw new Error('intentional fixture failure');
+      })
+    );
+
+    const result = engine.evaluate(context);
+
+    expect(result.findings).toEqual([]);
+    expect(result.suggestions).toEqual([]);
+    expect(result.complete).toBe(false);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        code: 'RULE_EXECUTION_FAILED',
+        ruleId: 'test.throwing-rule',
+        status: 'UNKNOWN',
+        unknown: expect.objectContaining({
+          reason: 'CHECK_EVALUATION_FAILED',
+          action: 'RUN_FRESH_SCAN',
+          blocking: true,
+        }),
+      }),
+    ]);
+  });
+
+  it('reports a successful no-finding evaluation as complete', () => {
+    const engine = new RulesEngine(rulesetWith(() => null));
+
+    const result = engine.evaluate(context);
+
+    expect(result.findings).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.complete).toBe(true);
+  });
+});

--- a/packages/rules/src/engine/index.ts
+++ b/packages/rules/src/engine/index.ts
@@ -5,7 +5,7 @@
  * All findings are evidence-backed and versioned by ruleset.
  */
 
-import type { BlastRadius, Confidence, Severity } from '@dns-ops/contracts';
+import type { BlastRadius, Confidence, RuleEvaluationFailure, Severity } from '@dns-ops/contracts';
 import type { NewFinding, NewSuggestion, Observation, RecordSet } from '@dns-ops/db';
 
 // Result-based error handling
@@ -57,6 +57,13 @@ export interface Ruleset {
   createdAt: Date;
 }
 
+export interface RulesEvaluationResult {
+  findings: NewFinding[];
+  suggestions: NewSuggestion[];
+  errors: RuleEvaluationFailure[];
+  complete: boolean;
+}
+
 /**
  * Rules Engine - evaluates observations against rules and produces findings
  */
@@ -70,9 +77,10 @@ export class RulesEngine {
   /**
    * Evaluate all rules in the ruleset against the context
    */
-  evaluate(context: RuleContext): { findings: NewFinding[]; suggestions: NewSuggestion[] } {
+  evaluate(context: RuleContext): RulesEvaluationResult {
     const findings: NewFinding[] = [];
     const suggestions: NewSuggestion[] = [];
+    const errors: RuleEvaluationFailure[] = [];
 
     for (const rule of this.ruleset.rules) {
       if (!rule.enabled) continue;
@@ -100,13 +108,24 @@ export class RulesEngine {
             }
           }
         }
-      } catch (error) {
-        console.error(`Rule ${rule.id} failed:`, error);
-        // Continue with other rules - don't let one failing rule break the engine
+      } catch (_error) {
+        errors.push({
+          code: 'RULE_EXECUTION_FAILED',
+          ruleId: rule.id,
+          message: `Rule ${rule.id} could not be evaluated`,
+          status: 'UNKNOWN',
+          unknown: {
+            reason: 'CHECK_EVALUATION_FAILED',
+            explanation: `The ${rule.name} check failed before it could produce a trustworthy result.`,
+            action: 'RUN_FRESH_SCAN',
+            actionLabel: 'Run a fresh scan',
+            blocking: true,
+          },
+        });
       }
     }
 
-    return { findings, suggestions };
+    return { findings, suggestions, errors, complete: errors.length === 0 };
   }
 
   /**

--- a/packages/rules/src/mail/rules.test.ts
+++ b/packages/rules/src/mail/rules.test.ts
@@ -139,7 +139,7 @@ describe('MX Presence Rule', () => {
     expect(result?.finding?.type).toBe('mail.no-mx-record');
     expect(result?.finding?.severity).toBe('medium');
     expect(result?.suggestions).toBeDefined();
-    expect(result?.suggestions?.[0]?.title).toContain('Add MX');
+    expect(result?.suggestions?.[0]?.title).toContain('Review MX');
   });
 
   it('should detect MX query failures', () => {

--- a/packages/rules/src/mail/rules.test.ts
+++ b/packages/rules/src/mail/rules.test.ts
@@ -207,8 +207,11 @@ describe('SPF Rule', () => {
 
     expect(result).not.toBeNull();
     expect(result?.finding?.type).toBe('mail.spf-present');
-    // SPF present is informational - severity may be 'info' or 'medium' depending on strictness
+    // SPF present is informational - severity may be 'info' or 'medium' depending on direct policy.
     expect(['info', 'medium']).toContain(result?.finding?.severity);
+    expect(result?.finding?.description).toContain('FIRST_LEVEL_ONLY');
+    expect(result?.finding?.description).toContain('completeEvaluation=false');
+    expect(result?.finding?.description).toContain('were not evaluated');
   });
 
   it('should detect missing SPF record', () => {
@@ -280,11 +283,8 @@ describe('SPF Rule', () => {
 
     const result = spfRule.evaluate(context);
 
-    // Note: Current parseSPF implementation is lenient and returns valid for
-    // syntactically incorrect mechanisms. A stricter parser would return 'mail.spf-malformed'.
-    // For now, this is accepted as 'present' with warnings.
     expect(result).not.toBeNull();
-    expect(['mail.spf-malformed', 'mail.spf-present']).toContain(result?.finding?.type);
+    expect(result?.finding?.type).toBe('mail.spf-malformed');
   });
 
   it('should detect SPF query failures', () => {

--- a/packages/rules/src/mail/rules.ts
+++ b/packages/rules/src/mail/rules.ts
@@ -109,9 +109,10 @@ export const mxPresenceRule: Rule = {
         },
         suggestions: [
           {
-            title: 'Add MX record',
-            description: `Configure an MX record for ${context.domainName} to explicitly route mail.`,
-            action: `Add MX record pointing to your mail server(s), or add a Null MX (0 .) if the domain should not receive mail.`,
+            title: 'Review MX routing readiness',
+            description:
+              'Declare whether this domain receives mail, then obtain exact targets from the confirmed provider. This guidance contains no approved record value.',
+            action: 'Playbook: mail.mx.purpose-and-provider',
             riskPosture: 'medium',
             blastRadius: 'single-domain',
             reviewOnly: true,
@@ -229,9 +230,10 @@ export const spfRule: Rule = {
         },
         suggestions: [
           {
-            title: 'Add SPF record',
-            description: `Add an SPF record to prevent email spoofing of ${context.domainName}.`,
-            action: `Add TXT record at ${context.domainName}: "v=spf1 include:_spf.google.com ~all" (adjust for your mail provider)`,
+            title: 'Review SPF readiness',
+            description:
+              'Inventory authorized senders and confirm provider instructions before planning SPF. This guidance contains no approved record value.',
+            action: 'Playbook: mail.spf.provider-confirmation',
             riskPosture: 'medium',
             blastRadius: 'single-domain',
             reviewOnly: true,
@@ -267,9 +269,9 @@ export const spfRule: Rule = {
         },
         suggestions: [
           {
-            title: 'Fix SPF syntax',
+            title: 'Review SPF syntax',
             description: `The SPF record has syntax errors that need correction.`,
-            action: `Review and correct the SPF record syntax. Common issues: missing spaces, invalid mechanisms, or missing version tag.`,
+            action: 'Playbook: mail.spf.syntax-review',
             riskPosture: 'high',
             blastRadius: 'single-domain',
             reviewOnly: true,
@@ -364,7 +366,7 @@ export const spfRule: Rule = {
               {
                 title: 'Review SPF configuration',
                 description: `The SPF record has configuration issues that may affect mail delivery.`,
-                action: `Address: ${issues.join('; ')}`,
+                action: 'Playbook: mail.spf.first-level-review',
                 riskPosture: 'medium',
                 blastRadius: 'single-domain',
                 reviewOnly: true,
@@ -429,9 +431,10 @@ export const dmarcRule: Rule = {
         },
         suggestions: [
           {
-            title: 'Add DMARC record',
-            description: `Add a DMARC record to specify how receivers should handle authentication failures.`,
-            action: `Start with monitoring: "v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com", then progress to quarantine/reject`,
+            title: 'Review DMARC readiness',
+            description:
+              'Confirm aligned senders and an operated report destination before planning DMARC. This guidance contains no approved record value.',
+            action: 'Playbook: mail.dmarc.monitoring-readiness',
             riskPosture: 'medium',
             blastRadius: 'single-domain',
             reviewOnly: true,
@@ -527,8 +530,9 @@ export const dmarcRule: Rule = {
           ? [
               {
                 title: 'Strengthen DMARC policy',
-                description: `DMARC is in monitoring mode only. Consider progressing to quarantine or reject.`,
-                action: `After monitoring shows SPF/DKIM alignment, upgrade: "v=DMARC1; p=quarantine; rua=mailto:dmarc@${context.domainName}"`,
+                description:
+                  'Review aggregate reports and confirmed sender alignment before considering enforcement. This guidance contains no approved record value.',
+                action: 'Playbook: mail.dmarc.enforcement-readiness',
                 riskPosture: 'medium',
                 blastRadius: 'single-domain',
                 reviewOnly: true,
@@ -579,9 +583,9 @@ export const dkimRule: Rule = {
         },
         suggestions: [
           {
-            title: 'Configure DKIM',
+            title: 'Review DKIM setup',
             description: `DKIM provides cryptographic email authentication and is recommended.`,
-            action: `Configure DKIM with your mail provider and add the public key as a TXT record at selector._domainkey.${context.domainName}`,
+            action: 'Playbook: mail.dkim.selector-evidence',
             riskPosture: 'low',
             blastRadius: 'single-domain',
             reviewOnly: true,
@@ -703,7 +707,7 @@ export const mtaStsRule: Rule = {
           {
             title: 'Consider MTA-STS',
             description: `MTA-STS enforces TLS for email and prevents downgrade attacks.`,
-            action: `Deploy MTA-STS: (1) Add TXT record _mta-sts.${context.domainName} with "v=STSv1; id=YYYYMMDD", (2) Host policy at https://mta-sts.${context.domainName}/.well-known/mta-sts.txt`,
+            action: 'Playbook: mail.mta-sts.readiness',
             riskPosture: 'low',
             blastRadius: 'single-domain',
             reviewOnly: true,
@@ -778,7 +782,7 @@ export const tlsRptRule: Rule = {
           {
             title: 'Consider TLS-RPT',
             description: `TLS-RPT provides reports on TLS connectivity issues for inbound mail.`,
-            action: `Add TXT record at _smtp._tls.${context.domainName}: "v=TLSRPTv1; rua=mailto:tls-rpt@${context.domainName}"`,
+            action: 'Playbook: mail.tls-rpt.reporting-readiness',
             riskPosture: 'low',
             blastRadius: 'single-domain',
             reviewOnly: true,

--- a/packages/rules/src/mail/rules.ts
+++ b/packages/rules/src/mail/rules.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Observation } from '@dns-ops/db';
-import { parseDMARC, parseSPF } from '@dns-ops/parsing';
+import { assessFirstLevelSpf, parseDMARC, parseSPF } from '@dns-ops/parsing';
 import type { Rule, RuleContext, RuleResult } from '../engine/index.js';
 
 // =============================================================================
@@ -278,26 +278,13 @@ export const spfRule: Rule = {
       };
     }
 
-    // Validate SPF mechanisms - check for unknown/invalid mechanisms
-    const validMechanisms = [
-      'all',
-      'include',
-      'a',
-      'mx',
-      'ptr',
-      'ip4',
-      'ip6',
-      'exists',
-      'redirect',
-    ];
-    const invalidMechanisms = parsed.mechanisms.filter((m) => !validMechanisms.includes(m.type));
-
-    if (invalidMechanisms.length > 0) {
+    const assessment = assessFirstLevelSpf(parsed);
+    if (assessment.status === 'DIRECT_SYNTAX_INVALID') {
       return {
         finding: {
           type: 'mail.spf-malformed',
-          title: `Malformed SPF record for ${context.domainName}`,
-          description: `${context.domainName} has an SPF record with invalid mechanisms: ${invalidMechanisms.map((m) => m.type).join(', ')}. Raw: "${spfRecord}". Valid mechanisms are: ${validMechanisms.join(', ')}.`,
+          title: `Malformed directly published SPF record for ${context.domainName}`,
+          description: `${context.domainName} has directly visible SPF syntax that cannot be assessed safely. ${assessment.limitation}`,
           severity: 'critical',
           confidence: 'certain',
           riskPosture: 'critical',
@@ -307,27 +294,17 @@ export const spfRule: Rule = {
             ? [
                 {
                   observationId: spfObservation.id,
-                  description: `Invalid SPF mechanisms found`,
+                  description: `First-level SPF assessment: ${JSON.stringify(assessment)}`,
                 },
               ]
             : [],
           ruleId: this.id,
           ruleVersion: this.version,
         },
-        suggestions: [
-          {
-            title: 'Fix SPF mechanism syntax',
-            description: `The SPF record contains unknown mechanisms that may cause mail delivery issues.`,
-            action: `Remove or correct invalid mechanisms: ${invalidMechanisms.map((m) => m.type).join(', ')}`,
-            riskPosture: 'high',
-            blastRadius: 'single-domain',
-            reviewOnly: true,
-          },
-        ],
       };
     }
 
-    // Valid SPF - analyze configuration
+    // Analyze only directly visible configuration. Dependencies remain unresolved.
     const issues: string[] = [];
 
     // Check for ~all (softfail) vs -all (hardfail)
@@ -363,7 +340,7 @@ export const spfRule: Rule = {
       finding: {
         type: 'mail.spf-present',
         title: `SPF record present for ${context.domainName}`,
-        description: `${context.domainName} has a valid SPF record. Raw: "${spfRecord}". ${issues.length > 0 ? `Issues: ${issues.join('; ')}` : 'Configuration looks good with proper all mechanism.'}`,
+        description: `${context.domainName} has directly valid published SPF syntax within a FIRST_LEVEL_ONLY assessment. completeEvaluation=false. ${issues.length > 0 ? `Direct issues: ${issues.join('; ')}. ` : ''}${assessment.limitation}`,
         severity,
         confidence: 'certain',
         riskPosture:
@@ -374,7 +351,7 @@ export const spfRule: Rule = {
           ? [
               {
                 observationId: spfObservation.id,
-                description: `Parsed SPF: ${JSON.stringify(parsed)}`,
+                description: `First-level SPF assessment: ${JSON.stringify(assessment)}`,
               },
             ]
           : [],

--- a/packages/rules/src/mail/shadow.ts
+++ b/packages/rules/src/mail/shadow.ts
@@ -111,7 +111,7 @@ export class ShadowComparator {
     // Compare SPF presence
     comparisons.push(this.compareSpfPresence(newSpfFinding, legacyOutput.spf));
 
-    // Compare SPF validity
+    // Compare directly published SPF syntax only; recursive validity is unavailable.
     comparisons.push(this.compareSpfValidity(newSpfFinding, legacyOutput.spf));
 
     // Compare DKIM presence
@@ -283,7 +283,7 @@ export class ShadowComparator {
         newValue: newValid,
         status: 'match',
         severity: 'info',
-        explanation: `Both agree: SPF is ${newValid ? 'valid' : 'invalid'}`,
+        explanation: `Both agree on directly published SPF syntax: ${newValid ? 'valid' : 'invalid'}. Nested dependencies were not evaluated.`,
       };
     }
 
@@ -293,7 +293,7 @@ export class ShadowComparator {
       newValue: newValid,
       status: 'mismatch',
       severity: 'high',
-      explanation: `MISMATCH: Legacy says ${legacyValid ? 'valid' : 'invalid'}, new says ${newValid ? 'valid' : 'invalid'}`,
+      explanation: `MISMATCH: Legacy reports ${legacyValid ? 'valid' : 'invalid'}, while the new first-level-only syntax check reports ${newValid ? 'valid' : 'invalid'}. Nested dependencies were not evaluated.`,
     };
   }
 

--- a/packages/rules/src/simulation/index.ts
+++ b/packages/rules/src/simulation/index.ts
@@ -1,17 +1,19 @@
 /**
  * DNS Change Simulation Engine
  *
- * Inverts findings into proposed DNS record mutations, then dry-runs them
- * through the rules engine to predict which findings resolve, remain, or appear.
- *
- * Deterministic only — no AI/LLM, no guessing.
+ * Generic findings are intentionally downgraded to non-executable guidance.
+ * Concrete local simulation is allowed only after a future caller supplies
+ * complete, provider-confirmed values; this module currently exposes no such
+ * generic-to-mutation path.
  */
 
-import type { NewFinding, Observation, RecordSet } from '@dns-ops/db';
+import type { GuidanceOnlySuggestion } from '@dns-ops/contracts';
+import type { NewFinding, Observation } from '@dns-ops/db';
 
-// Result-based error handling
 export {
   getActionableFindingTypes,
+  getGuidanceSupportedFindingTypes,
+  hasGuidanceForFindingType,
   isActionableFindingType,
   isSimulationError,
   SimulationError,
@@ -22,59 +24,30 @@ export {
 
 import type { RuleContext, Ruleset } from '../engine/index.js';
 import { RulesEngine } from '../engine/index.js';
-import {
-  detectProviderFromDns,
-  type KnownProvider,
-  PROVIDER_TEMPLATES,
-} from '../mail/templates.js';
-
-// =============================================================================
-// Types
-// =============================================================================
+import type { KnownProvider } from '../mail/templates.js';
 
 export interface ProposedChange {
-  /** What kind of mutation */
   action: 'add' | 'modify' | 'remove';
-  /** DNS record name (e.g. "example.com", "_dmarc.example.com") */
   name: string;
-  /** DNS record type (e.g. "TXT", "MX") */
   type: string;
-  /** Current value(s) — empty for 'add' */
   currentValues: string[];
-  /** Proposed value(s) — empty for 'remove' */
   proposedValues: string[];
-  /** Human-readable rationale */
   rationale: string;
-  /** Which finding this change addresses */
   findingType: string;
-  /** Risk level of making this change */
   risk: 'low' | 'medium' | 'high';
 }
 
 export interface SimulationResult {
-  /** Domain being simulated */
+  mode: 'GUIDANCE_ONLY';
   domain: string;
-  /** Detected provider (if any) */
   detectedProvider: KnownProvider;
-  /** Proposed DNS changes */
-  proposedChanges: ProposedChange[];
-  /** Findings BEFORE the proposed changes */
+  proposedChanges: [];
+  guidanceOnlySuggestions: GuidanceOnlySuggestion[];
   currentFindings: SimulationFinding[];
-  /** Findings AFTER the proposed changes (dry-run) */
-  projectedFindings: SimulationFinding[];
-  /** Findings that would be resolved */
-  resolvedFindings: SimulationFinding[];
-  /** Findings that would remain */
-  remainingFindings: SimulationFinding[];
-  /** New findings introduced by the changes */
-  newFindings: SimulationFinding[];
-  /** Summary stats */
   summary: {
-    changesProposed: number;
-    findingsBefore: number;
-    findingsAfter: number;
-    findingsResolved: number;
-    findingsNew: number;
+    changesProposed: 0;
+    guidanceProvided: number;
+    currentFindings: number;
   };
 }
 
@@ -85,468 +58,119 @@ export interface SimulationFinding {
   ruleId: string;
 }
 
-// =============================================================================
-// Simulation Engine
-// =============================================================================
+const GUIDANCE_BY_FINDING: Record<
+  string,
+  Omit<GuidanceOnlySuggestion, 'kind' | 'executableMutation'>
+> = {
+  'mail.no-spf-record': {
+    title: 'Confirm authorized senders with the mail provider',
+    explanation:
+      'Inventory every authorized sender, obtain the provider-specific SPF instructions, and review the directly published SPF terms before planning a change.',
+    playbookId: 'mail.spf.provider-confirmation',
+    requiresProviderConfirmation: true,
+  },
+  'mail.spf-malformed': {
+    title: 'Review SPF syntax and sender dependencies',
+    explanation:
+      'Correct only after the current sender inventory and provider instructions are confirmed. Phase 0–1 does not recursively validate include or redirect dependencies.',
+    playbookId: 'mail.spf.syntax-review',
+    requiresProviderConfirmation: true,
+  },
+  'mail.no-dmarc-record': {
+    title: 'Plan DMARC monitoring with a verified report destination',
+    explanation:
+      'Confirm the domain mail purpose, aligned senders, and a monitored aggregate-report destination before choosing any DMARC policy.',
+    playbookId: 'mail.dmarc.monitoring-readiness',
+    requiresProviderConfirmation: true,
+  },
+  'mail.no-mx-record': {
+    title: 'Declare the domain mail-receiving purpose',
+    explanation:
+      'Decide whether the domain receives mail, then obtain exact MX targets from the confirmed provider or follow the non-mail-domain playbook.',
+    playbookId: 'mail.mx.purpose-and-provider',
+    requiresProviderConfirmation: true,
+  },
+  'mail.no-dkim-queried': {
+    title: 'Supply provider-issued DKIM selector evidence',
+    explanation:
+      'Retrieve selectors and public-key records from the confirmed provider. DNS Ops does not invent selectors or key material.',
+    playbookId: 'mail.dkim.selector-evidence',
+    requiresProviderConfirmation: true,
+  },
+  'mail.no-mta-sts': {
+    title: 'Assess MTA-STS deployment prerequisites',
+    explanation:
+      'Confirm inbound-mail ownership, policy-host availability, certificate operations, and rollback monitoring before planning deployment.',
+    playbookId: 'mail.mta-sts.readiness',
+    requiresProviderConfirmation: true,
+  },
+  'mail.no-tls-rpt': {
+    title: 'Confirm TLS reporting ownership',
+    explanation:
+      'Choose and verify an operated reporting destination before planning a TLS-RPT record.',
+    playbookId: 'mail.tls-rpt.reporting-readiness',
+    requiresProviderConfirmation: true,
+  },
+  'dns.cname-coexistence-conflict': {
+    title: 'Choose the intended owner of the DNS name',
+    explanation:
+      'Review service ownership and dependencies before deciding whether the CNAME or other data should remain. No record is selected for removal automatically.',
+    playbookId: 'dns.cname.conflict-review',
+    requiresProviderConfirmation: false,
+  },
+};
+
+export function guidanceForFindingType(findingType: string): GuidanceOnlySuggestion | undefined {
+  const guidance = GUIDANCE_BY_FINDING[findingType];
+  return guidance ? { kind: 'GUIDANCE_ONLY', ...guidance, executableMutation: null } : undefined;
+}
 
 export class SimulationEngine {
-  private ruleset: Ruleset;
+  constructor(private ruleset: Ruleset) {}
 
-  constructor(ruleset: Ruleset) {
-    this.ruleset = ruleset;
-  }
-
-  /**
-   * Given current findings and DNS state, generate proposed fixes and dry-run them.
-   */
   simulate(
     context: RuleContext,
     findings: Array<{ type: string; title: string; severity: string; ruleId: string }>,
     findingTypes?: string[]
   ): SimulationResult {
-    // Detect provider from current records
-    const mxRecordSet = context.recordSets.find(
-      (rs) => rs.type === 'MX' && rs.name.toLowerCase() === context.domainName.toLowerCase()
-    );
-    const spfRecordSet = context.recordSets.find(
-      (rs) =>
-        rs.type === 'TXT' &&
-        rs.name.toLowerCase() === context.domainName.toLowerCase() &&
-        rs.values.some((v) => v.includes('v=spf1'))
-    );
-    const detection = detectProviderFromDns(
-      mxRecordSet?.values || [],
-      spfRecordSet?.values.find((v) => v.includes('v=spf1'))
-    );
-
-    // Filter findings to simulate
     const targetFindings = findingTypes
-      ? findings.filter((f) => findingTypes.includes(f.type))
-      : findings.filter((f) => this.isActionable(f.type));
+      ? findings.filter((finding) => findingTypes.includes(finding.type))
+      : findings.filter((finding) => finding.type in GUIDANCE_BY_FINDING);
+    const guidanceOnlySuggestions = targetFindings
+      .map((finding) => guidanceForFindingType(finding.type))
+      .filter((guidance): guidance is GuidanceOnlySuggestion => guidance !== undefined);
 
-    // Generate proposed changes for each target finding
-    const proposedChanges: ProposedChange[] = [];
-    for (const finding of targetFindings) {
-      const changes = this.invertFinding(
-        finding.type,
-        context.domainName,
-        context.recordSets,
-        detection.provider
-      );
-      proposedChanges.push(...changes);
-    }
-
-    // Deduplicate changes (same name+type)
-    const deduped = this.deduplicateChanges(proposedChanges);
-
-    // Build projected record sets by applying changes
-    const projectedRecordSets = this.applyChanges(context.recordSets, deduped, context.snapshotId);
-
-    // Build projected observations by synthesizing for new records
-    const projectedObservations = synthesizeObservations(
-      context.observations,
-      deduped,
-      context.domainName,
-      context.snapshotId
-    );
-
-    // Dry-run rules engine with projected state
-    const projectedContext: RuleContext = {
-      ...context,
-      recordSets: projectedRecordSets,
-      observations: projectedObservations,
-    };
-
-    const engine = new RulesEngine(this.ruleset);
-    const currentResult = engine.evaluate(context);
-    const projectedResult = engine.evaluate(projectedContext);
-
-    const currentSimFindings = this.toSimFindings(currentResult.findings);
-    const projectedSimFindings = this.toSimFindings(projectedResult.findings);
-
-    // Diff findings
-    const currentTypes = new Set(currentSimFindings.map((f) => f.type));
-    const projectedTypes = new Set(projectedSimFindings.map((f) => f.type));
-
-    const resolved = currentSimFindings.filter((f) => !projectedTypes.has(f.type));
-    const remaining = currentSimFindings.filter((f) => projectedTypes.has(f.type));
-    const newFindings = projectedSimFindings.filter((f) => !currentTypes.has(f.type));
+    const currentResult = new RulesEngine(this.ruleset).evaluate(context);
+    const currentFindings = this.toSimFindings(currentResult.findings);
 
     return {
+      mode: 'GUIDANCE_ONLY',
       domain: context.domainName,
-      detectedProvider: detection.provider,
-      proposedChanges: deduped,
-      currentFindings: currentSimFindings,
-      projectedFindings: projectedSimFindings,
-      resolvedFindings: resolved,
-      remainingFindings: remaining,
-      newFindings,
+      detectedProvider: 'unknown',
+      proposedChanges: [],
+      guidanceOnlySuggestions,
+      currentFindings,
       summary: {
-        changesProposed: deduped.length,
-        findingsBefore: currentSimFindings.length,
-        findingsAfter: projectedSimFindings.length,
-        findingsResolved: resolved.length,
-        findingsNew: newFindings.length,
+        changesProposed: 0,
+        guidanceProvided: guidanceOnlySuggestions.length,
+        currentFindings: currentFindings.length,
       },
     };
-  }
-
-  // ===========================================================================
-  // Finding inversion — maps finding type → proposed DNS changes
-  // ===========================================================================
-
-  invertFinding(
-    findingType: string,
-    domainName: string,
-    currentRecordSets: RecordSet[],
-    provider: KnownProvider
-  ): ProposedChange[] {
-    const template = PROVIDER_TEMPLATES[provider] || PROVIDER_TEMPLATES.other;
-
-    switch (findingType) {
-      case 'mail.no-spf-record':
-        return this.proposeSPF(domainName, template, provider);
-
-      case 'mail.no-dmarc-record':
-        return this.proposeDMARC(domainName);
-
-      case 'mail.no-mx-record':
-        return this.proposeMX(domainName, template, provider);
-
-      case 'mail.no-mta-sts':
-        return this.proposeMtaSts(domainName);
-
-      case 'mail.no-tls-rpt':
-        return this.proposeTlsRpt(domainName);
-
-      case 'mail.no-dkim-queried':
-        return this.proposeDKIM(domainName, template, provider);
-
-      case 'mail.spf-malformed':
-        return this.proposeFixSPF(domainName, currentRecordSets, template, provider);
-
-      case 'dns.cname-coexistence-conflict':
-        return this.proposeCnameResolution(domainName, currentRecordSets);
-
-      default:
-        return [];
-    }
-  }
-
-  // ===========================================================================
-  // Individual fix generators
-  // ===========================================================================
-
-  private proposeSPF(
-    domain: string,
-    template: (typeof PROVIDER_TEMPLATES)[KnownProvider],
-    provider: KnownProvider
-  ): ProposedChange[] {
-    const include = template.expected.spf?.include;
-    const spfValue = include ? `"v=spf1 include:${include} ~all"` : '"v=spf1 ~all"';
-
-    return [
-      {
-        action: 'add',
-        name: domain,
-        type: 'TXT',
-        currentValues: [],
-        proposedValues: [spfValue],
-        rationale: include
-          ? `Add SPF record with ${provider} include directive`
-          : 'Add baseline SPF record (customize includes for your mail provider)',
-        findingType: 'mail.no-spf-record',
-        risk: 'low',
-      },
-    ];
-  }
-
-  private proposeDMARC(domain: string): ProposedChange[] {
-    return [
-      {
-        action: 'add',
-        name: `_dmarc.${domain}`,
-        type: 'TXT',
-        currentValues: [],
-        proposedValues: [`"v=DMARC1; p=none; rua=mailto:dmarc-reports@${domain}"`],
-        rationale:
-          'Add DMARC record in monitoring mode (p=none). Upgrade to quarantine/reject after reviewing reports.',
-        findingType: 'mail.no-dmarc-record',
-        risk: 'low',
-      },
-    ];
-  }
-
-  private proposeMX(
-    domain: string,
-    template: (typeof PROVIDER_TEMPLATES)[KnownProvider],
-    provider: KnownProvider
-  ): ProposedChange[] {
-    if (template.expected.mx && template.expected.mx.length > 0) {
-      return [
-        {
-          action: 'add',
-          name: domain,
-          type: 'MX',
-          currentValues: [],
-          proposedValues: template.expected.mx.map((mx) => `${mx.priority} ${mx.description}`),
-          rationale: `Add MX records for ${provider}`,
-          findingType: 'mail.no-mx-record',
-          risk: 'medium',
-        },
-      ];
-    }
-
-    // No provider-specific MX — suggest null MX if domain shouldn't receive mail
-    return [
-      {
-        action: 'add',
-        name: domain,
-        type: 'MX',
-        currentValues: [],
-        proposedValues: ['0 .'],
-        rationale:
-          'Add Null MX to explicitly declare this domain does not receive email, OR add your mail server MX records',
-        findingType: 'mail.no-mx-record',
-        risk: 'medium',
-      },
-    ];
-  }
-
-  private proposeMtaSts(domain: string): ProposedChange[] {
-    const dateId = new Date().toISOString().slice(0, 10).replace(/-/g, '');
-    return [
-      {
-        action: 'add',
-        name: `_mta-sts.${domain}`,
-        type: 'TXT',
-        currentValues: [],
-        proposedValues: [`"v=STSv1; id=${dateId}"`],
-        rationale:
-          'Add MTA-STS TXT record to enable TLS enforcement for inbound mail. Also requires hosting a policy file at https://mta-sts.{domain}/.well-known/mta-sts.txt',
-        findingType: 'mail.no-mta-sts',
-        risk: 'low',
-      },
-    ];
-  }
-
-  private proposeTlsRpt(domain: string): ProposedChange[] {
-    return [
-      {
-        action: 'add',
-        name: `_smtp._tls.${domain}`,
-        type: 'TXT',
-        currentValues: [],
-        proposedValues: [`"v=TLSRPTv1; rua=mailto:tls-reports@${domain}"`],
-        rationale: 'Add TLS-RPT record to receive TLS connectivity reports for inbound mail',
-        findingType: 'mail.no-tls-rpt',
-        risk: 'low',
-      },
-    ];
-  }
-
-  private proposeDKIM(
-    domain: string,
-    template: (typeof PROVIDER_TEMPLATES)[KnownProvider],
-    provider: KnownProvider
-  ): ProposedChange[] {
-    const selectors = template.expected.dkim?.selectors || [];
-    if (selectors.length === 0) {
-      return [
-        {
-          action: 'add',
-          name: `default._domainkey.${domain}`,
-          type: 'TXT',
-          currentValues: [],
-          proposedValues: ['"v=DKIM1; k=rsa; p=YOUR_PUBLIC_KEY"'],
-          rationale:
-            'Add DKIM public key record. Replace YOUR_PUBLIC_KEY with the key from your mail provider.',
-          findingType: 'mail.no-dkim-queried',
-          risk: 'low',
-        },
-      ];
-    }
-
-    return selectors.map((selector) => ({
-      action: 'add' as const,
-      name: `${selector}._domainkey.${domain}`,
-      type: 'TXT',
-      currentValues: [],
-      proposedValues: ['"v=DKIM1; k=rsa; p=YOUR_PUBLIC_KEY"'],
-      rationale: `Add DKIM public key for ${provider} selector "${selector}". Get the actual key value from your ${provider} admin console.`,
-      findingType: 'mail.no-dkim-queried',
-      risk: 'low',
-    }));
-  }
-
-  private proposeFixSPF(
-    domain: string,
-    currentRecordSets: RecordSet[],
-    template: (typeof PROVIDER_TEMPLATES)[KnownProvider],
-    provider: KnownProvider
-  ): ProposedChange[] {
-    const currentSpf = currentRecordSets.find(
-      (rs) =>
-        rs.type === 'TXT' &&
-        rs.name.toLowerCase() === domain.toLowerCase() &&
-        rs.values.some((v) => v.includes('v=spf1'))
-    );
-
-    const include = template.expected.spf?.include;
-    const newSpf = include ? `"v=spf1 include:${include} ~all"` : '"v=spf1 ~all"';
-
-    return [
-      {
-        action: 'modify',
-        name: domain,
-        type: 'TXT',
-        currentValues: currentSpf?.values.filter((v) => v.includes('v=spf1')) || [],
-        proposedValues: [newSpf],
-        rationale: `Replace malformed SPF record with valid ${provider} configuration`,
-        findingType: 'mail.spf-malformed',
-        risk: 'medium',
-      },
-    ];
-  }
-
-  private proposeCnameResolution(domain: string, currentRecordSets: RecordSet[]): ProposedChange[] {
-    // Find the CNAME and conflicting records
-    const cnameRecords = currentRecordSets.filter(
-      (rs) => rs.type === 'CNAME' && rs.name.toLowerCase() === domain.toLowerCase()
-    );
-
-    if (cnameRecords.length === 0) return [];
-
-    const conflicting = currentRecordSets.filter(
-      (rs) =>
-        rs.name.toLowerCase() === domain.toLowerCase() &&
-        rs.type !== 'CNAME' &&
-        !['RRSIG', 'NSEC', 'NSEC3', 'DNSKEY'].includes(rs.type)
-    );
-
-    // Suggest removing the conflicting non-CNAME records (safer default)
-    return conflicting.map((rs) => ({
-      action: 'remove' as const,
-      name: rs.name,
-      type: rs.type,
-      currentValues: rs.values,
-      proposedValues: [],
-      rationale: `Remove ${rs.type} record that conflicts with CNAME at ${rs.name} (RFC 1034/2181 violation)`,
-      findingType: 'dns.cname-coexistence-conflict',
-      risk: 'high',
-    }));
-  }
-
-  // ===========================================================================
-  // Helpers
-  // ===========================================================================
-
-  /** Check if a finding type has a known fix */
-  private isActionable(findingType: string): boolean {
-    const actionableTypes = [
-      'mail.no-spf-record',
-      'mail.no-dmarc-record',
-      'mail.no-mx-record',
-      'mail.no-mta-sts',
-      'mail.no-tls-rpt',
-      'mail.no-dkim-queried',
-      'mail.spf-malformed',
-      'dns.cname-coexistence-conflict',
-    ];
-    return actionableTypes.includes(findingType);
-  }
-
-  /** Deduplicate changes targeting the same name+type */
-  private deduplicateChanges(changes: ProposedChange[]): ProposedChange[] {
-    const seen = new Map<string, ProposedChange>();
-    for (const change of changes) {
-      const key = `${change.action}:${change.name.toLowerCase()}:${change.type}`;
-      if (!seen.has(key)) {
-        seen.set(key, change);
-      }
-    }
-    return [...seen.values()];
-  }
-
-  /** Apply proposed changes to record sets, returning a new projected set */
-  private applyChanges(
-    current: RecordSet[],
-    changes: ProposedChange[],
-    snapshotId: string
-  ): RecordSet[] {
-    const result = [...current];
-
-    for (const change of changes) {
-      if (change.action === 'add') {
-        result.push({
-          id: crypto.randomUUID(),
-          snapshotId,
-          name: change.name,
-          type: change.type,
-          ttl: 300,
-          values: change.proposedValues,
-          sourceObservationIds: [],
-          sourceVantages: ['simulation'],
-          isConsistent: true,
-          consolidationNotes: 'Simulated record',
-          createdAt: new Date(),
-        });
-      } else if (change.action === 'modify') {
-        // For modify, try to match by current values first (more precise),
-        // then fall back to name+type match
-        let idx = result.findIndex(
-          (rs) =>
-            rs.name.toLowerCase() === change.name.toLowerCase() &&
-            rs.type === change.type &&
-            change.currentValues.some((cv) =>
-              rs.values.some((v) => v.includes(cv) || cv.includes(v))
-            )
-        );
-        if (idx < 0) {
-          idx = result.findIndex(
-            (rs) => rs.name.toLowerCase() === change.name.toLowerCase() && rs.type === change.type
-          );
-        }
-        if (idx >= 0) {
-          result[idx] = {
-            ...result[idx],
-            values: change.proposedValues,
-            consolidationNotes: 'Simulated modification',
-          };
-        }
-      } else if (change.action === 'remove') {
-        const idx = result.findIndex(
-          (rs) => rs.name.toLowerCase() === change.name.toLowerCase() && rs.type === change.type
-        );
-        if (idx >= 0) {
-          result.splice(idx, 1);
-        }
-      }
-    }
-
-    return result;
   }
 
   private toSimFindings(findings: NewFinding[]): SimulationFinding[] {
-    return findings.map((f) => ({
-      type: f.type,
-      title: f.title,
-      severity: f.severity,
-      ruleId: f.ruleId,
+    return findings.map((finding) => ({
+      type: finding.type,
+      title: finding.title,
+      severity: finding.severity,
+      ruleId: finding.ruleId,
     }));
   }
 }
 
 /**
- * Synthesize successful DNS observations for newly added/modified records so the
- * rules engine can evaluate projected DNS state. Pure function — no engine state.
- *
- * The synthesized observation mirrors the canonical `observations` row shape
- * (`@dns-ops/db`) exactly — `vantageType`/`vantageIdentifier` (not a made-up
- * `vantage`/`vantageId`), `queriedAt` (not `timestamp`/`createdAt`),
- * `responseTimeMs` (not `queryDurationMs`), and `answerSection`/
- * `authoritySection`/`additionalSection` (not `answers`/`authority`/`additional`).
- * No cast is required because the field names match the Drizzle-inferred type.
+ * Apply already-complete, explicitly supplied local changes to observation
+ * fixtures. This helper does not generate values and performs no external I/O.
  */
 export function synthesizeObservations(
   current: Observation[],
@@ -559,29 +183,22 @@ export function synthesizeObservations(
   for (const change of changes) {
     if (change.action === 'remove') continue;
 
-    // For 'add': if a successful observation already exists with answers, skip.
-    // For 'modify': always replace the existing observation with the simulated one.
     const existingIdx = result.findIndex(
-      (obs) =>
-        obs.queryName.toLowerCase() === change.name.toLowerCase() &&
-        obs.queryType === change.type &&
-        obs.status === 'success'
+      (observation) =>
+        observation.queryName.toLowerCase() === change.name.toLowerCase() &&
+        observation.queryType === change.type &&
+        observation.status === 'success'
     );
-    if (change.action === 'add') {
-      if (
-        existingIdx >= 0 &&
-        result[existingIdx].answerSection &&
-        (result[existingIdx].answerSection?.length ?? 0) > 0
-      ) {
-        continue;
-      }
+    if (
+      change.action === 'add' &&
+      existingIdx >= 0 &&
+      result[existingIdx].answerSection &&
+      (result[existingIdx].answerSection?.length ?? 0) > 0
+    ) {
+      continue;
     }
-    // Remove existing observation so the simulated one takes over
-    if (existingIdx >= 0) {
-      result.splice(existingIdx, 1);
-    }
+    if (existingIdx >= 0) result.splice(existingIdx, 1);
 
-    // Synthesize a successful observation using canonical schema field names.
     result.push({
       id: crypto.randomUUID(),
       snapshotId,
@@ -594,11 +211,11 @@ export function synthesizeObservations(
       responseTimeMs: 0,
       responseCode: 0,
       flags: null,
-      answerSection: change.proposedValues.map((v) => ({
+      answerSection: change.proposedValues.map((value) => ({
         name: change.name,
         type: change.type,
         ttl: 300,
-        data: v,
+        data: value,
       })),
       authoritySection: null,
       additionalSection: null,

--- a/packages/rules/src/simulation/result.ts
+++ b/packages/rules/src/simulation/result.ts
@@ -79,10 +79,8 @@ export function simulationResult<T>(fn: () => T): ResultOrError<T, SimulationErr
   }
 }
 
-/**
- * Get actionable finding types that can be simulated
- */
-export function getActionableFindingTypes(): string[] {
+/** Finding types with a non-executable guidance playbook. */
+export function getGuidanceSupportedFindingTypes(): string[] {
   return [
     'mail.no-spf-record',
     'mail.no-dmarc-record',
@@ -95,12 +93,15 @@ export function getActionableFindingTypes(): string[] {
   ];
 }
 
-/**
- * Check if a finding type can be simulated
- */
-export function isActionableFindingType(findingType: string): boolean {
-  return getActionableFindingTypes().includes(findingType);
+/** Check whether a finding type has non-executable guidance. */
+export function hasGuidanceForFindingType(findingType: string): boolean {
+  return getGuidanceSupportedFindingTypes().includes(findingType);
 }
+
+/** @deprecated Use getGuidanceSupportedFindingTypes. */
+export const getActionableFindingTypes = getGuidanceSupportedFindingTypes;
+/** @deprecated Use hasGuidanceForFindingType. */
+export const isActionableFindingType = hasGuidanceForFindingType;
 
 /**
  * Field type validators for simulation context

--- a/packages/testkit/src/benchmark-corpus/index.ts
+++ b/packages/testkit/src/benchmark-corpus/index.ts
@@ -177,7 +177,7 @@ export const knownGoodUnmanaged: BenchmarkCase[] = [
 export const historicalIncidents: BenchmarkCase[] = [
   {
     id: 'incident-001',
-    description: 'SPF record too many lookups (caused mail delivery issues)',
+    description: 'SPF record with nested dependencies requiring first-level-only disclosure',
     domain: 'spf-lookup-incident.test',
     zoneManagement: 'managed',
     expectedResult: 'complete',
@@ -185,13 +185,14 @@ export const historicalIncidents: BenchmarkCase[] = [
     characteristics: ['has-mx', 'has-spf', 'has-dmarc'],
     expectedFindings: [
       {
-        type: 'spf-too-many-lookups',
-        severity: 'high',
+        type: 'mail.spf-present',
+        severity: 'medium',
         confidence: 'certain',
         reviewOnly: true,
       },
     ],
-    notes: 'SPF record exceeded 10 DNS lookup limit',
+    notes:
+      'The published record contains unresolved dependencies. Phase 0–1 does not evaluate or claim compliance with the recursive ten-term lookup budget.',
   },
   {
     id: 'incident-002',

--- a/tools/controlled-live-fixture/Dockerfile
+++ b/tools/controlled-live-fixture/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+
+WORKDIR /app
+COPY server.mjs ./server.mjs
+
+EXPOSE 3000
+CMD ["node", "server.mjs"]

--- a/tools/controlled-live-fixture/server.mjs
+++ b/tools/controlled-live-fixture/server.mjs
@@ -1,0 +1,109 @@
+import { createServer } from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const modes = new Set(['healthy', 'redirect_fault', 'noindex_fault']);
+const controlPath = '/__dnsops/live-mode';
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function parseHostname(host) {
+  return host?.split(':', 1)[0]?.toLowerCase();
+}
+
+function bearerMatches(request, expected) {
+  const supplied = request.headers.authorization?.match(/^Bearer (.+)$/)?.[1];
+  if (!supplied) return false;
+  const suppliedBytes = Buffer.from(supplied);
+  const expectedBytes = Buffer.from(expected);
+  return suppliedBytes.length === expectedBytes.length && timingSafeEqual(suppliedBytes, expectedBytes);
+}
+
+async function readControlRequest(request) {
+  let body = '';
+  for await (const chunk of request) {
+    body += chunk;
+    if (body.length > 512) throw new Error('control request is too large');
+  }
+  const parsed = JSON.parse(body);
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    Array.isArray(parsed) ||
+    Object.keys(parsed).length !== 1 ||
+    !modes.has(parsed.mode)
+  ) {
+    throw new Error('control request must contain one permitted mode');
+  }
+  return parsed.mode;
+}
+
+function html({ noindex, canonicalUrl }) {
+  const robots = noindex ? '<meta name="robots" content="noindex">' : '';
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">${robots}<link rel="canonical" href="${canonicalUrl}"><title>DNS Ops live fixture</title></head><body>DNS Ops live fixture</body></html>`;
+}
+
+export function createFixtureServer({ apexHost, wwwHost, controlToken }) {
+  let mode = 'healthy';
+  const canonicalUrl = `https://${apexHost}/`;
+
+  return createServer(async (request, response) => {
+    const hostname = parseHostname(request.headers.host);
+    if (hostname !== apexHost && hostname !== wwwHost) {
+      response.writeHead(421).end();
+      return;
+    }
+
+    if (request.url === controlPath) {
+      if (request.method !== 'POST' || !bearerMatches(request, controlToken)) {
+        response.writeHead(404).end();
+        return;
+      }
+      try {
+        mode = await readControlRequest(request);
+        response.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
+        response.end(JSON.stringify({ mode }));
+      } catch {
+        response.writeHead(400).end();
+      }
+      return;
+    }
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      response.writeHead(405, { allow: 'GET, HEAD, POST' }).end();
+      return;
+    }
+
+    if (request.headers['x-forwarded-proto'] === 'http') {
+      response.writeHead(308, { location: canonicalUrl, 'cache-control': 'no-store' }).end();
+      return;
+    }
+
+    if (hostname === wwwHost && mode !== 'redirect_fault') {
+      response.writeHead(308, { location: canonicalUrl, 'cache-control': 'no-store' }).end();
+      return;
+    }
+
+    const noindex = mode === 'noindex_fault';
+    response.writeHead(200, {
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'no-store',
+      ...(noindex ? { 'x-robots-tag': 'noindex' } : {}),
+    });
+    if (request.method === 'HEAD') response.end();
+    else response.end(html({ noindex, canonicalUrl }));
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const apexHost = requiredEnvironment('DNSOPS_FIXTURE_APEX_HOST');
+  const wwwHost = requiredEnvironment('DNSOPS_FIXTURE_WWW_HOST');
+  const controlToken = requiredEnvironment('DNSOPS_FIXTURE_CONTROL_TOKEN');
+  const port = Number(process.env.PORT ?? 3000);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('PORT must be a valid port');
+  createFixtureServer({ apexHost, wwwHost, controlToken }).listen(port);
+}

--- a/tools/controlled-live-fixture/server.test.mjs
+++ b/tools/controlled-live-fixture/server.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { randomBytes } from 'node:crypto';
+import { request as httpRequest } from 'node:http';
+import test from 'node:test';
+import { createFixtureServer } from './server.mjs';
+
+const apexHost = 'asorin.ai';
+const wwwHost = 'www.asorin.ai';
+const controlToken = randomBytes(32).toString('hex');
+
+async function withFixture(run) {
+  const server = createFixtureServer({ apexHost, wwwHost, controlToken });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+}
+
+function request(baseUrl, path, { method = 'GET', headers = {}, body } = {}) {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(`${baseUrl}${path}`, { method, headers }, (response) => {
+      let responseBody = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        responseBody += chunk;
+      });
+      response.on('end', () => {
+        resolve({
+          status: response.statusCode,
+          headers: response.headers,
+          text: () => responseBody,
+        });
+      });
+    });
+    request.on('error', reject);
+    if (body) request.write(body);
+    request.end();
+  });
+}
+
+test('healthy fixture redirects www and serves an indexable canonical apex page', async () => {
+  await withFixture(async (baseUrl) => {
+    const redirect = await request(baseUrl, '/', { headers: { host: wwwHost } });
+    assert.equal(redirect.status, 308);
+    assert.equal(redirect.headers.location, `https://${apexHost}/`);
+
+    const page = await request(baseUrl, '/', { headers: { host: apexHost } });
+    assert.equal(page.status, 200);
+    assert.equal(page.headers['x-robots-tag'], undefined);
+    assert.match(page.text(), /rel="canonical" href="https:\/\/asorin.ai\/"/);
+  });
+});
+
+test('control endpoint admits only an authenticated fixed mode and changes the expected surface', async () => {
+  await withFixture(async (baseUrl) => {
+    const denied = await request(baseUrl, '/__dnsops/live-mode', {
+      method: 'POST',
+      headers: { host: apexHost },
+      body: JSON.stringify({ mode: 'redirect_fault' }),
+    });
+    assert.equal(denied.status, 404);
+
+    const invalid = await request(baseUrl, '/__dnsops/live-mode', {
+      method: 'POST',
+      headers: { host: apexHost, authorization: `Bearer ${controlToken}` },
+      body: JSON.stringify({ mode: 'arbitrary-content' }),
+    });
+    assert.equal(invalid.status, 400);
+
+    const setRedirectFault = await request(baseUrl, '/__dnsops/live-mode', {
+      method: 'POST',
+      headers: { host: apexHost, authorization: `Bearer ${controlToken}` },
+      body: JSON.stringify({ mode: 'redirect_fault' }),
+    });
+    assert.equal(setRedirectFault.status, 200);
+    assert.equal((await request(baseUrl, '/', { headers: { host: wwwHost } })).status, 200);
+
+    const setNoindexFault = await request(baseUrl, '/__dnsops/live-mode', {
+      method: 'POST',
+      headers: { host: apexHost, authorization: `Bearer ${controlToken}` },
+      body: JSON.stringify({ mode: 'noindex_fault' }),
+    });
+    assert.equal(setNoindexFault.status, 200);
+    const page = await request(baseUrl, '/', { headers: { host: apexHost } });
+    assert.equal(page.headers['x-robots-tag'], 'noindex');
+    assert.match(page.text(), /<meta name="robots" content="noindex">/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     include: [
       'packages/*/src/**/*.test.ts',
       'apps/*/src/**/*.test.ts',
+      'apps/web/app/**/*.test.ts',
       'apps/web/hono/**/*.test.ts',
       'scripts/**/*.test.ts',
     ],


### PR DESCRIPTION
## Scope

Ports the validated Phase 0–1 implementation from `c3b3cca` onto `master` via merge commit `e743433`.

## Validation

- `bun install --frozen-lockfile`
- `bunx vitest run packages/contracts/src/live-fault-harness.test.ts` — 9 passed
- `node --test tools/controlled-live-fixture/server.test.mjs` — 2 passed
- `bun run lint` — 8/8
- `bun run typecheck` — 14/14
- `RUN_LIVE_DNS_TESTS=0 bun run test` — 2,730 passed / 41 skipped
- `bun run build` — 8/8
- `bun run --filter @dns-ops/db check-drift` — clean

## Safety

No provider mutation, live DNS test, deployment, or merge to `master` was performed. Controlled-live provider execution remains deliberately gated pending a complete manifest-derived harness, baseline, and restoration evidence.

## Review

Independent GLM review found no BLOCKER/HIGH findings and confirmed no provider-write capability entered DNS Ops/MCP.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the validated Phase 0–1 DNS Ops work to `master`. Preserves authoritative DNS evidence, adds domain evidence collection and canonical signal/case flow, introduces MCP transport, and updates the app to surface evaluation coverage with guidance-only suggestions.

- **New Features**
  - DNS: uniform wire resolver for all types with real TTLs; preserves AA/flags and authoritative recursion policy; persists evaluation coverage via `@dns-ops/db`.
  - Mail: RFC 9989 DMARC policy discovery and first‑level SPF assessment; safer domain‑existence checks; scoring aligned to effective DMARC policy.
  - External evidence: RDAP expiration, TLS certificate, and HTTP web probes; SSRF guard hardened; evidence persisted as probe observations and collected after DNS by domain profile purpose.
  - Canonical signals: baselines, evaluation, and alert finalization; SPF absence migrated to canonical signals; legacy alert path gated by a condition registry.
  - Monitoring: authenticated, tenant‑scoped collection via internal `/api/collect/domain`; canonical finalization runs after collection.
  - MCP: static principal auth (`MCP_PRINCIPALS_JSON`), closed toolset, idempotent command replay, per‑tenant scan rate limit; server‑only `/mcp` endpoint; tenant‑scoped domain profile and case APIs; UI shows evaluation coverage and guidance‑only playbooks, replaces executable suggestions and simulation.

- **Migration**
  - Run database migrations.
  - Configure `INTERNAL_SECRET` and `COLLECTOR_URL` for monitoring-triggered collections.
  - Provision MCP principals by setting `MCP_PRINCIPALS_JSON` with SHA‑256 token hashes and scopes.

<sup>Written for commit e74343315ac4555e28dc421ef14accd90fff8ad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

