### PR TITLE
Add fail-closed controlled-live harness guards

### DIFF
--- a/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
@@ -2,7 +2,16 @@
   "manifestId": "ASORIN-AI-CONTROLLED-LIVE-01-03",
   "status": "FOUNDER_AUTHORIZED_PENDING_HARNESS_IMPLEMENTATION",
   "zone": "asorin.ai",
+  "zoneId": "7391960081e72b26c9c5066133013ab2",
   "provider": "cloudflare",
+  "providerCredentialFingerprint": "sha256:17fe70271d1013db5ef7fffa31f6ea68e98a2a0040300a3acb3ee96e4b9bfd8f",
+  "testAssets": {
+    "webHost": "asorin.ai",
+    "mailSubdomain": "mail.asorin.ai"
+  },
+  "allowlist": [
+    {"name": "mail.asorin.ai", "types": ["TXT"], "mutationIds": ["LIVE-03"]}
+  ],
   "rollbackAndRevocationOwner": "Antonio",
   "globalConstraints": [
     "No production traffic, client dependency, or real mail dependency exists in asorin.ai.",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
     "dev": "turbo run dev",
-    "test": "vitest run",
+    "test": "vitest run && bun run test:controlled-live-harness",
+    "test:controlled-live-harness": "bun run --filter @dns-ops/contracts build && node --test scripts/controlled-live-harness.test.mjs",
     "test:live-dns": "bun run --filter @dns-ops/collector test:live-dns",
     "smoke-test": "npx tsx scripts/deploy/smoke-test.ts",
     "start": "node apps/web/.output/server/index.mjs"

--- a/scripts/controlled-live-harness.test.mjs
+++ b/scripts/controlled-live-harness.test.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { protectedToken, loadManifest, policyFromManifest, requireLive03Preconditions } from '../tools/controlled-live-harness/runner.mjs';
+const secret = (value = 'x') => { const p = join(mkdtempSync(join(tmpdir(), 'dnsops-')), 'secret'); writeFileSync(p, `export CLOUDFLARE_API_TOKEN='${value}'\n`); chmodSync(p, 0o600); return p; };
+const manifest = () => loadManifest();
+test('requires a protected secret file', () => assert.equal(protectedToken(secret(), 'CLOUDFLARE_API_TOKEN'), 'x'));
+test('derives LIVE-03 authorization from the manifest and pins token fingerprint', () => { const m = manifest(); assert.throws(() => policyFromManifest(m, 'x'), /fingerprint/); });
+test('LIVE-03 rejects missing evidence even after policy authorization', () => { const m = { ...manifest(), providerCredentialFingerprint: 'sha256:2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881' }; assert.throws(() => requireLive03Preconditions({ manifest: m, token: 'x', evidence: { spfRecords: 1, ttl: 60, mxRecords: 0 } }), /missing required/); });

--- a/tools/controlled-live-harness/runner.mjs
+++ b/tools/controlled-live-harness/runner.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto';
 import { readFileSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { validateControlledFaultHarnessPolicy, authorizeControlledFaultMutation } from '../../packages/contracts/dist/index.js';
 
-const ROOT = resolve(import.meta.dirname, '../..');
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const DEFAULT_MANIFEST = resolve(ROOT, 'docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json');
 const fail = (message) => { throw new Error(`controlled-live harness: ${message}`); };
 const fingerprint = (token) => `sha256:${createHash('sha256').update(token).digest('hex')}`;
@@ -32,14 +33,13 @@ export function requireLive03Preconditions({ manifest, token, evidence }) {
   const policy = policyFromManifest(manifest, token);
   authorizeControlledFaultMutation(policy, { zoneId: policy.zoneId, name: 'mail.asorin.ai', type: 'TXT', mutationId: 'LIVE-03' });
   if (!evidence || evidence.spfRecords !== 1 || evidence.ttl !== 60 || evidence.mxRecords !== 0) fail('LIVE-03 authoritative baseline rejected');
-  for (const id of ['scanTaskIds', 'signalIds', 'caseIds', 'auditEventIds']) if (!Array.isArray(evidence[id]) || evidence[id].length === 0) fail(`missing required ${id}`);
+  for (const id of ['authoritativeEvidenceIds', 'scanTaskIds', 'signalIds', 'caseIds', 'auditEventIds']) if (!Array.isArray(evidence[id]) || evidence[id].length === 0) fail(`missing required ${id}`);
 }
 function main() {
   const command = process.argv[2] ?? 'status';
-  if (!['status', 'prepare', 'apply', 'verify', 'restore', 'run', 'recover'].includes(command)) fail('unsupported command');
+  if (command !== 'status') fail('unsupported command until a provider-specific adapter is implemented');
   const token = protectedToken(process.env.DNSOPS_CLOUDFLARE_SECRET_FILE ?? `${process.env.HOME}/.config/dns-ops/cloudflare-test.env`, 'CLOUDFLARE_API_TOKEN');
   const manifest = loadManifest(); policyFromManifest(manifest, token);
-  if (command === 'status') return console.log(JSON.stringify({ status: 'READY_FOR_PREFLIGHT_ONLY', manifestId: manifest.manifestId, zoneId: manifest.zoneId }));
-  fail(`${command} requires a provider-specific adapter; no provider request was made`);
+  return console.log(JSON.stringify({ status: 'READY_FOR_PREFLIGHT_ONLY', manifestId: manifest.manifestId, zoneId: manifest.zoneId, providerCredentialFingerprint: manifest.providerCredentialFingerprint, allowlist: manifest.allowlist }));
 }
 if (process.argv[1] === new URL(import.meta.url).pathname) { try { main(); } catch (error) { console.error(error.message); process.exitCode = 1; } }

--- a/tools/controlled-live-harness/runner.mjs
+++ b/tools/controlled-live-harness/runner.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { validateControlledFaultHarnessPolicy, authorizeControlledFaultMutation } from '../../packages/contracts/dist/index.js';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const DEFAULT_MANIFEST = resolve(ROOT, 'docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json');
+const fail = (message) => { throw new Error(`controlled-live harness: ${message}`); };
+const fingerprint = (token) => `sha256:${createHash('sha256').update(token).digest('hex')}`;
+
+export function protectedToken(path, name) {
+  if ((statSync(path).mode & 0o777) !== 0o600) fail(`${name} secret file must be mode 600`);
+  const match = readFileSync(path, 'utf8').match(new RegExp(`^export ${name}='([^'\\n]+)'\\n?$`));
+  if (!match) fail(`${name} secret file has invalid format`);
+  return match[1];
+}
+export function loadManifest(path = DEFAULT_MANIFEST) {
+  const m = JSON.parse(readFileSync(path, 'utf8'));
+  if (m.manifestId !== 'ASORIN-AI-CONTROLLED-LIVE-01-03' || m.zone !== 'asorin.ai' || m.provider !== 'cloudflare') fail('unrecognized manifest');
+  if (!/^[a-f0-9]{32}$/.test(m.zoneId) || !/^sha256:[a-f0-9]{64}$/.test(m.providerCredentialFingerprint)) fail('manifest identity is invalid');
+  if (m.testAssets?.webHost !== 'asorin.ai' || m.testAssets?.mailSubdomain !== 'mail.asorin.ai') fail('manifest test assets are invalid');
+  if (!Array.isArray(m.allowlist) || m.allowlist.length !== 1 || m.allowlist[0]?.name !== 'mail.asorin.ai' || m.allowlist[0]?.types?.join() !== 'TXT' || m.allowlist[0]?.mutationIds?.join() !== 'LIVE-03') fail('manifest allowlist is invalid');
+  return Object.freeze(m);
+}
+export function policyFromManifest(manifest, token) {
+  if (fingerprint(token) !== manifest.providerCredentialFingerprint) fail('provider credential fingerprint does not match manifest');
+  const policy = { testDomain: manifest.zone, testWebHost: manifest.testAssets.webHost, testMailSubdomain: manifest.testAssets.mailSubdomain, providerKind: manifest.provider, zoneId: manifest.zoneId, providerCredentialFingerprint: manifest.providerCredentialFingerprint, allowlist: manifest.allowlist };
+  validateControlledFaultHarnessPolicy(policy); return policy;
+}
+export function requireLive03Preconditions({ manifest, token, evidence }) {
+  const policy = policyFromManifest(manifest, token);
+  authorizeControlledFaultMutation(policy, { zoneId: policy.zoneId, name: 'mail.asorin.ai', type: 'TXT', mutationId: 'LIVE-03' });
+  if (!evidence || evidence.spfRecords !== 1 || evidence.ttl !== 60 || evidence.mxRecords !== 0) fail('LIVE-03 authoritative baseline rejected');
+  for (const id of ['scanTaskIds', 'signalIds', 'caseIds', 'auditEventIds']) if (!Array.isArray(evidence[id]) || evidence[id].length === 0) fail(`missing required ${id}`);
+}
+function main() {
+  const command = process.argv[2] ?? 'status';
+  if (!['status', 'prepare', 'apply', 'verify', 'restore', 'run', 'recover'].includes(command)) fail('unsupported command');
+  const token = protectedToken(process.env.DNSOPS_CLOUDFLARE_SECRET_FILE ?? `${process.env.HOME}/.config/dns-ops/cloudflare-test.env`, 'CLOUDFLARE_API_TOKEN');
+  const manifest = loadManifest(); policyFromManifest(manifest, token);
+  if (command === 'status') return console.log(JSON.stringify({ status: 'READY_FOR_PREFLIGHT_ONLY', manifestId: manifest.manifestId, zoneId: manifest.zoneId }));
+  fail(`${command} requires a provider-specific adapter; no provider request was made`);
+}
+if (process.argv[1] === new URL(import.meta.url).pathname) { try { main(); } catch (error) { console.error(error.message); process.exitCode = 1; } }


### PR DESCRIPTION
Adds manifest-derived, non-mutating harness guards and runs them through the existing test command used by CI. Validated with `bun run test:controlled-live-harness` (3 passed). No provider, DNS, Railway, or network mutation path exists. Independent review: no BLOCKER/HIGH findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-closed, non-mutating controlled-live harness for LIVE-03 that validates the Cloudflare token, manifest, and evidence preflight. Guard tests run in CI to prevent accidental provider calls.

- **New Features**
  - Added `tools/controlled-live-harness/runner.mjs` to enforce secret file mode 600, token export format, fingerprint pinning, and strict manifest identity/test-asset/allowlist checks; validates policy and LIVE-03 authorization via `@dns-ops/contracts`; exposes a read-only `status` command, all others fail closed.
  - Added `scripts/controlled-live-harness.test.mjs` to cover secret guarding, fingerprint mismatches, and preflight requirements (SPF=1, TTL=60, MX=0, plus non-empty evidence ID arrays).
  - Wired the harness into `package.json` tests: added `test:controlled-live-harness` (builds `@dns-ops/contracts` then runs Node tests) and chained it to `test`.
  - Extended the manifest with `zoneId`, `providerCredentialFingerprint`, test assets, and an allowlist entry for `mail.asorin.ai` TXT `LIVE-03`.

<sup>Written for commit eb1c53f5199541248fe6e29f2dc6fd1a53b1964d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

