### PR TITLE
Add fail-closed Railway DNS bootstrap harness

### DIFF
--- a/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
@@ -7,11 +7,22 @@
   "providerCredentialFingerprint": "sha256:17fe70271d1013db5ef7fffa31f6ea68e98a2a0040300a3acb3ee96e4b9bfd8f",
   "testAssets": {
     "webHost": "asorin.ai",
+    "wwwHost": "www.asorin.ai",
     "mailSubdomain": "mail.asorin.ai"
   },
-  "allowlist": [{ "name": "mail.asorin.ai", "types": ["TXT"], "mutationIds": ["LIVE-03"] }],
+  "allowlist": [
+    { "name": "asorin.ai", "types": ["CNAME"], "mutationIds": ["LIVE-02"] },
+    { "name": "www.asorin.ai", "types": ["CNAME"], "mutationIds": ["LIVE-01"] },
+    { "name": "_railway-verify.asorin.ai", "types": ["TXT"], "mutationIds": ["LIVE-02"] },
+    { "name": "_railway-verify.www.asorin.ai", "types": ["TXT"], "mutationIds": ["LIVE-01"] },
+    { "name": "mail.asorin.ai", "types": ["TXT"], "mutationIds": ["LIVE-03"] }
+  ],
   "bootstrapAllowlist": [
-    { "name": "mail.asorin.ai", "type": "TXT", "content": "v=spf1 -all", "ttl": 60 }
+    { "name": "asorin.ai", "type": "CNAME", "content": "epgybwo0.up.railway.app", "ttl": 60, "mutationId": "LIVE-02" },
+    { "name": "www.asorin.ai", "type": "CNAME", "content": "4xbfxxr5.up.railway.app", "ttl": 60, "mutationId": "LIVE-01" },
+    { "name": "_railway-verify.asorin.ai", "type": "TXT", "runtimeValue": "RAILWAY_ASORIN_AI_VERIFICATION_TXT", "ttl": 60, "mutationId": "LIVE-02" },
+    { "name": "_railway-verify.www.asorin.ai", "type": "TXT", "runtimeValue": "RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT", "ttl": 60, "mutationId": "LIVE-01" },
+    { "name": "mail.asorin.ai", "type": "TXT", "content": "v=spf1 -all", "ttl": 60, "mutationId": "LIVE-03" }
   ],
   "rollbackAndRevocationOwner": "Antonio",
   "globalConstraints": [

--- a/scripts/controlled-live-harness.test.mjs
+++ b/scripts/controlled-live-harness.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -10,6 +11,7 @@ import {
   loadManifest,
   policyFromManifest,
   protectedToken,
+  protectedValues,
 } from '../tools/controlled-live-harness/runner.mjs';
 
 const token = 'x';
@@ -28,6 +30,40 @@ const record = {
   content: 'v=spf1 -all',
   ttl: 60,
 };
+const railwayVerificationValues = Object.freeze({
+  RAILWAY_ASORIN_AI_VERIFICATION_TXT: randomBytes(24).toString('hex'),
+  RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT: randomBytes(24).toString('hex'),
+});
+const webRecords = Object.freeze([
+  {
+    id: 'c'.repeat(32),
+    name: 'asorin.ai',
+    type: 'CNAME',
+    content: 'epgybwo0.up.railway.app',
+    ttl: 60,
+  },
+  {
+    id: 'd'.repeat(32),
+    name: 'www.asorin.ai',
+    type: 'CNAME',
+    content: '4xbfxxr5.up.railway.app',
+    ttl: 60,
+  },
+  {
+    id: 'e'.repeat(32),
+    name: '_railway-verify.asorin.ai',
+    type: 'TXT',
+    content: railwayVerificationValues.RAILWAY_ASORIN_AI_VERIFICATION_TXT,
+    ttl: 60,
+  },
+  {
+    id: 'f'.repeat(32),
+    name: '_railway-verify.www.asorin.ai',
+    type: 'TXT',
+    content: railwayVerificationValues.RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT,
+    ttl: 60,
+  },
+]);
 const completionEvidence = {
   authoritativeEvidenceIds: ['authoritative-01'],
   scanTaskIds: ['scan-01'],
@@ -49,10 +85,11 @@ const mockFetch = (...responses) => {
   };
 };
 
-const adapter = (fetch) =>
+const adapter = (fetch, runtimeValues) =>
   createCloudflareAdapter({
     manifest: manifest(),
     token,
+    railwayVerificationValues: runtimeValues,
     fetchImpl: fetch,
     now: () => new Date('2026-08-05T15:00:00.000Z'),
     createRunId: () => 'live-03-test-run',
@@ -64,6 +101,35 @@ test('derives LIVE-03 authorization from the manifest and pins token fingerprint
   const m = manifest();
   assert.throws(() => policyFromManifest(m, 'wrong'), /fingerprint/);
 });
+test('requires an exact mode-600 Railway verification secret file', () => {
+  const path = join(mkdtempSync(join(tmpdir(), 'dnsops-')), 'railway-verification');
+  writeFileSync(
+    path,
+    `export RAILWAY_ASORIN_AI_VERIFICATION_TXT='${railwayVerificationValues.RAILWAY_ASORIN_AI_VERIFICATION_TXT}'\nexport RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT='${railwayVerificationValues.RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT}'\n`
+  );
+  chmodSync(path, 0o600);
+  assert.deepEqual(
+    protectedValues(path, [
+      'RAILWAY_ASORIN_AI_VERIFICATION_TXT',
+      'RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT',
+    ]),
+    railwayVerificationValues
+  );
+  chmodSync(path, 0o644);
+  assert.throws(() => protectedValues(path, ['RAILWAY_ASORIN_AI_VERIFICATION_TXT']), /mode 600/);
+});
+test('runner keeps LIVE-01/02 fixture mode changes blocked before reading credentials', () => {
+  const runner = fileURLToPath(
+    new URL('../tools/controlled-live-harness/runner.mjs', import.meta.url)
+  );
+  const result = spawnSync(process.execPath, [runner, 'fixture-mode', 'redirect_fault'], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unsupported command/);
+  assert.doesNotMatch(result.stderr, /secret file/);
+});
+
 test('runner rejects a caller-supplied completion evidence file before reading credentials', () => {
   const runner = fileURLToPath(
     new URL('../tools/controlled-live-harness/runner.mjs', import.meta.url)
@@ -76,6 +142,104 @@ test('runner rejects a caller-supplied completion evidence file before reading c
   assert.equal(result.status, 1);
   assert.match(result.stderr, /does not accept a caller-supplied completion evidence file/);
   assert.doesNotMatch(result.stderr, /secret file/);
+});
+
+test('runner rejects a missing web-bootstrap artifact path before reading credentials', () => {
+  const runner = fileURLToPath(
+    new URL('../tools/controlled-live-harness/runner.mjs', import.meta.url)
+  );
+  const result = spawnSync(process.execPath, [runner, 'web-bootstrap'], { encoding: 'utf8' });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /web-bootstrap requires an output artifact path/);
+  assert.doesNotMatch(result.stderr, /secret file/);
+});
+
+test('LIVE-01/02 web preflight is read-only, validates every bootstrap record, and redacts TXT values', async () => {
+  const mocked = mockFetch(
+    ok({ id: manifest().zoneId, name: 'asorin.ai' }),
+    ...webRecords.map((entry) => ok([entry]))
+  );
+  const result = await adapter(mocked.fetch, railwayVerificationValues).webPreflight();
+  assert.equal(result.status, 'WEB_PREFLIGHT_OK');
+  assert.equal(mocked.calls.length, 5);
+  assert.deepEqual(
+    mocked.calls.map(({ init }) => init.method),
+    ['GET', 'GET', 'GET', 'GET', 'GET']
+  );
+  assert.deepEqual(result.providerResponses, [
+    'cloudflare.web_zone_preflight: 200',
+    'cloudflare.web_dns_verify: 200',
+    'cloudflare.web_dns_verify: 200',
+    'cloudflare.web_dns_verify: 200',
+    'cloudflare.web_dns_verify: 200',
+  ]);
+  const emitted = JSON.stringify(result);
+  assert.doesNotMatch(
+    emitted,
+    new RegExp(railwayVerificationValues.RAILWAY_ASORIN_AI_VERIFICATION_TXT)
+  );
+  assert.doesNotMatch(
+    emitted,
+    new RegExp(railwayVerificationValues.RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT)
+  );
+  const verificationFetch = mockFetch(
+    ok({ id: manifest().zoneId, name: 'asorin.ai' }),
+    ...webRecords.map((entry) => ok([entry]))
+  );
+  const verification = await adapter(
+    verificationFetch.fetch,
+    railwayVerificationValues
+  ).webVerify();
+  assert.equal(verification.status, 'WEB_BOOTSTRAP_VERIFIED');
+  assert.equal(verificationFetch.calls.length, 5);
+});
+
+test('LIVE-01/02 web bootstrap fails before provider access without exact runtime values', async () => {
+  const mocked = mockFetch(ok({}));
+  await assert.rejects(
+    adapter(mocked.fetch, {
+      RAILWAY_ASORIN_AI_VERIFICATION_TXT: 'valid-but-incomplete',
+    }).webBootstrap(),
+    /runtime values are invalid/
+  );
+  assert.equal(mocked.calls.length, 0);
+});
+
+test('LIVE-01/02 web bootstrap creates only exact missing CNAME/TXT records and emits no TXT values', async () => {
+  const created = webRecords.map((entry) => ok(entry));
+  const mocked = mockFetch(
+    ok({ id: manifest().zoneId, name: 'asorin.ai' }),
+    ok([]),
+    created[0],
+    ok([]),
+    created[1],
+    ok([]),
+    created[2],
+    ok([]),
+    created[3]
+  );
+  const artifact = await adapter(mocked.fetch, railwayVerificationValues).webBootstrap();
+  assert.equal(artifact.kind, 'CLOUDFLARE_LIVE01_02_WEB_BOOTSTRAP');
+  assert.equal(mocked.calls.length, 9);
+  assert.deepEqual(
+    mocked.calls.map(({ init }) => init.method),
+    ['GET', 'GET', 'POST', 'GET', 'POST', 'GET', 'POST', 'GET', 'POST']
+  );
+  assert.deepEqual(JSON.parse(mocked.calls[4].init.body), {
+    type: 'CNAME',
+    name: 'www.asorin.ai',
+    content: '4xbfxxr5.up.railway.app',
+    ttl: 60,
+  });
+  const emitted = JSON.stringify(artifact);
+  assert.doesNotMatch(
+    emitted,
+    new RegExp(railwayVerificationValues.RAILWAY_ASORIN_AI_VERIFICATION_TXT)
+  );
+  assert.doesNotMatch(
+    emitted,
+    new RegExp(railwayVerificationValues.RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT)
+  );
 });
 
 test('preflight is read-only, verifies zone and exact approved record, and emits redacted summaries', async () => {
@@ -243,6 +407,13 @@ test('manifest fingerprint and exact allowlist are rechecked before an injected 
       createCloudflareAdapter({ manifest: manifest(), token: 'wrong', fetchImpl: mocked.fetch }),
     /fingerprint/
   );
+  const wrongTarget = JSON.parse(JSON.stringify(manifest()));
+  wrongTarget.bootstrapAllowlist[0].content = 'unapproved.example';
+  assert.throws(
+    () => createCloudflareAdapter({ manifest: wrongTarget, token, fetchImpl: mocked.fetch }),
+    /bootstrap allowlist/
+  );
+  assert.equal(mocked.calls.length, 0);
 });
 
 test('provider errors are fail-closed and redact provider bodies', async () => {

--- a/tools/controlled-live-harness/README.md
+++ b/tools/controlled-live-harness/README.md
@@ -1,0 +1,31 @@
+# Controlled live harness
+
+This directory is the only repository component that may call Cloudflare for controlled live DNS work. Operators run it directly; DNS Ops application code and MCP never receive provider or fixture credentials.
+
+## LIVE-01/02 Railway DNS bootstrap
+
+The committed manifest pins the only permitted web records:
+
+- `asorin.ai` CNAME → `epgybwo0.up.railway.app`
+- `www.asorin.ai` CNAME → `4xbfxxr5.up.railway.app`
+- `_railway-verify.asorin.ai` TXT
+- `_railway-verify.www.asorin.ai` TXT
+
+The two verification TXT values are deliberately absent from the manifest and all emitted artifacts. Before a `web-*` command, the runner requires a separate mode-`0600` file at `DNSOPS_RAILWAY_VERIFICATION_SECRET_FILE` (default: `$HOME/.config/dns-ops/railway-verification.env`) with exactly:
+
+```sh
+export RAILWAY_ASORIN_AI_VERIFICATION_TXT='runtime value omitted'
+export RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT='runtime value omitted'
+```
+
+The literal example values above are placeholders for local operator documentation only; do not commit real values. The runner validates that file and both printable DNS TXT values before constructing a provider request. Every provider request revalidates the full manifest, zone, all exact CNAME/TXT tuples, credential fingerprint, and the runtime TXT values.
+
+```sh
+node tools/controlled-live-harness/runner.mjs web-preflight
+node tools/controlled-live-harness/runner.mjs web-bootstrap /secure/operator/web-bootstrap.json
+node tools/controlled-live-harness/runner.mjs web-verify
+```
+
+`web-preflight` and `web-verify` issue only GET requests and emit only operation/status summaries. `web-bootstrap` creates only missing exact records; an existing record must exactly match the approved name, type, content, and TTL. Its artifact contains target names, hashes, and redacted status summaries, never Railway TXT values.
+
+LIVE-01/02 fixture mode changes are intentionally not exposed by this DNS bootstrap harness. They remain blocked by the fixture's separate `DNSOPS_FIXTURE_CONTROL_TOKEN` control boundary; an unsupported `fixture-mode` invocation fails before any runtime secret is read.

--- a/tools/controlled-live-harness/cloudflare-adapter.mjs
+++ b/tools/controlled-live-harness/cloudflare-adapter.mjs
@@ -7,6 +7,48 @@ import {
 
 const API_ORIGIN = 'https://api.cloudflare.com/client/v4';
 const LIVE_03 = Object.freeze({ name: 'mail.asorin.ai', type: 'TXT', mutationId: 'LIVE-03' });
+const WEB_BOOTSTRAP = Object.freeze([
+  Object.freeze({
+    name: 'asorin.ai',
+    type: 'CNAME',
+    content: 'epgybwo0.up.railway.app',
+    ttl: 60,
+    mutationId: 'LIVE-02',
+  }),
+  Object.freeze({
+    name: 'www.asorin.ai',
+    type: 'CNAME',
+    content: '4xbfxxr5.up.railway.app',
+    ttl: 60,
+    mutationId: 'LIVE-01',
+  }),
+  Object.freeze({
+    name: '_railway-verify.asorin.ai',
+    type: 'TXT',
+    runtimeValue: 'RAILWAY_ASORIN_AI_VERIFICATION_TXT',
+    ttl: 60,
+    mutationId: 'LIVE-02',
+  }),
+  Object.freeze({
+    name: '_railway-verify.www.asorin.ai',
+    type: 'TXT',
+    runtimeValue: 'RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT',
+    ttl: 60,
+    mutationId: 'LIVE-01',
+  }),
+]);
+const LIVE_03_BOOTSTRAP = Object.freeze({
+  name: LIVE_03.name,
+  type: LIVE_03.type,
+  content: 'v=spf1 -all',
+  ttl: 60,
+  mutationId: LIVE_03.mutationId,
+});
+const EXPECTED_ALLOWLIST = Object.freeze([
+  ...WEB_BOOTSTRAP.map(({ name, type, mutationId }) => ({ name, type, mutationId })),
+  { name: LIVE_03.name, type: LIVE_03.type, mutationId: LIVE_03.mutationId },
+]);
+const runtimeTxtPattern = /^[\x21-\x7e]{1,255}$/;
 const recordIdPattern = /^[a-f0-9]{32}$/;
 const fingerprintPattern = /^sha256:[a-f0-9]{64}$/;
 const fail = (message) => {
@@ -50,33 +92,44 @@ export function validateCloudflareManifest(manifest) {
     fail('manifest identity is invalid');
   if (
     manifest.testAssets?.webHost !== 'asorin.ai' ||
+    manifest.testAssets?.wwwHost !== 'www.asorin.ai' ||
     manifest.testAssets?.mailSubdomain !== LIVE_03.name
   )
     fail('manifest test assets are invalid');
-  if (!Array.isArray(manifest.allowlist) || manifest.allowlist.length !== 1)
+  if (!Array.isArray(manifest.allowlist) || manifest.allowlist.length !== EXPECTED_ALLOWLIST.length)
     fail('manifest allowlist is invalid');
-  const [entry] = manifest.allowlist;
-  if (
-    !entry ||
-    entry.name !== LIVE_03.name ||
-    !Array.isArray(entry.types) ||
-    entry.types.length !== 1 ||
-    entry.types[0] !== LIVE_03.type ||
-    !Array.isArray(entry.mutationIds) ||
-    entry.mutationIds.length !== 1 ||
-    entry.mutationIds[0] !== LIVE_03.mutationId
-  )
-    fail('manifest allowlist is invalid');
+  for (const [index, expected] of EXPECTED_ALLOWLIST.entries()) {
+    const entry = manifest.allowlist[index];
+    if (
+      !entry ||
+      entry.name !== expected.name ||
+      !Array.isArray(entry.types) ||
+      entry.types.length !== 1 ||
+      entry.types[0] !== expected.type ||
+      !Array.isArray(entry.mutationIds) ||
+      entry.mutationIds.length !== 1 ||
+      entry.mutationIds[0] !== expected.mutationId
+    )
+      fail('manifest allowlist is invalid');
+  }
+  const expectedBootstrap = [...WEB_BOOTSTRAP, LIVE_03_BOOTSTRAP];
   const bootstrap = manifest.bootstrapAllowlist;
-  if (
-    !Array.isArray(bootstrap) ||
-    bootstrap.length !== 1 ||
-    bootstrap[0]?.name !== LIVE_03.name ||
-    bootstrap[0]?.type !== LIVE_03.type ||
-    bootstrap[0]?.content !== 'v=spf1 -all' ||
-    bootstrap[0]?.ttl !== 60
-  )
+  if (!Array.isArray(bootstrap) || bootstrap.length !== expectedBootstrap.length)
     fail('manifest bootstrap allowlist is invalid');
+  for (const [index, expected] of expectedBootstrap.entries()) {
+    const entry = bootstrap[index];
+    if (
+      !entry ||
+      entry.name !== expected.name ||
+      entry.type !== expected.type ||
+      entry.ttl !== expected.ttl ||
+      entry.mutationId !== expected.mutationId ||
+      (expected.content !== undefined
+        ? entry.content !== expected.content || entry.runtimeValue !== undefined
+        : entry.runtimeValue !== expected.runtimeValue || entry.content !== undefined)
+    )
+      fail('manifest bootstrap allowlist is invalid');
+  }
   const policy = {
     testDomain: manifest.zone,
     testWebHost: manifest.testAssets.webHost,
@@ -142,6 +195,66 @@ function validateRecord(record) {
   });
 }
 
+/** Runtime TXT verification values are never placed in manifests or artifacts. */
+function webBootstrapRecords(runtimeValues) {
+  if (
+    !runtimeValues ||
+    typeof runtimeValues !== 'object' ||
+    Array.isArray(runtimeValues) ||
+    Object.getPrototypeOf(runtimeValues) !== Object.prototype ||
+    Object.keys(runtimeValues).length !== 2
+  )
+    fail('Railway verification runtime values are invalid');
+  const values = {};
+  for (const key of [
+    'RAILWAY_ASORIN_AI_VERIFICATION_TXT',
+    'RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT',
+  ]) {
+    const value = runtimeValues[key];
+    if (typeof value !== 'string' || !runtimeTxtPattern.test(value))
+      fail('Railway verification runtime values are invalid');
+    values[key] = value;
+  }
+  return WEB_BOOTSTRAP.map((record) =>
+    Object.freeze({
+      ...record,
+      content: record.runtimeValue === undefined ? record.content : values[record.runtimeValue],
+    })
+  );
+}
+
+function validateWebRecord(record, expected) {
+  if (
+    !record ||
+    typeof record !== 'object' ||
+    Array.isArray(record) ||
+    !recordIdPattern.test(record.id ?? '') ||
+    record.name !== expected.name ||
+    record.type !== expected.type ||
+    record.content !== expected.content ||
+    record.ttl !== expected.ttl
+  )
+    fail('provider record does not match the approved LIVE-01/02 bootstrap baseline');
+  return Object.freeze({
+    id: record.id,
+    name: record.name,
+    type: record.type,
+    content: record.content,
+    ttl: record.ttl,
+  });
+}
+
+function canonicalWebBaseline(records) {
+  return JSON.stringify(
+    records.map((record) => ({
+      name: record.name,
+      type: record.type,
+      content: record.content,
+      ttl: record.ttl,
+    }))
+  );
+}
+
 function assertBootstrapArtifact(value, manifest) {
   if (!value || typeof value !== 'object' || Array.isArray(value))
     fail('bootstrap artifact must be an object');
@@ -186,6 +299,7 @@ function redactedStatus(operation, response) {
 export function createCloudflareAdapter({
   manifest,
   token,
+  railwayVerificationValues,
   fetchImpl = globalThis.fetch,
   now = () => new Date(),
   createRunId = randomUUID,
@@ -200,8 +314,22 @@ export function createCloudflareAdapter({
     return current;
   }
 
-  async function request(operation, path, init) {
-    const { manifest: approved } = authorize(operation);
+  function authorizeWebBootstrap(_operation) {
+    // Revalidate the zone and every exact CNAME/TXT tuple before every HTTP operation.
+    const current = policyFor(initial.manifest, token);
+    for (const record of webBootstrapRecords(railwayVerificationValues)) {
+      authorizeControlledFaultMutation(current.policy, {
+        zoneId: current.policy.zoneId,
+        name: record.name,
+        type: record.type,
+        mutationId: record.mutationId,
+      });
+    }
+    return current;
+  }
+
+  async function request(operation, path, init, authorizeRequest = authorize) {
+    const { manifest: approved } = authorizeRequest(operation);
     let response;
     try {
       response = await fetchImpl(`${API_ORIGIN}/zones/${approved.zoneId}${path}`, {
@@ -236,7 +364,115 @@ export function createCloudflareAdapter({
     return { record: validateRecord(body.result[0]), summary };
   }
 
+  async function readWebRecord(operation, expected) {
+    const query = `?name=${encodeURIComponent(expected.name)}&type=${expected.type}`;
+    const { body, summary } = await request(
+      operation,
+      `/dns_records${query}`,
+      { method: 'GET' },
+      authorizeWebBootstrap
+    );
+    if (!Array.isArray(body.result) || body.result.length !== 1)
+      fail('provider must return exactly one approved LIVE-01/02 bootstrap record');
+    return { record: validateWebRecord(body.result[0], expected), summary };
+  }
+
+  async function verifyWebBootstrap(status) {
+    // Resolve and validate both TXT values before the first provider request.
+    const records = webBootstrapRecords(railwayVerificationValues);
+    const zone = await request('web_zone_preflight', '', { method: 'GET' }, authorizeWebBootstrap);
+    if (
+      zone.body.result?.id !== initial.manifest.zoneId ||
+      zone.body.result?.name !== initial.manifest.zone
+    )
+      fail('provider zone does not match the validated manifest');
+    const providerResponses = [zone.summary];
+    for (const expected of records) {
+      const verified = await readWebRecord('web_dns_verify', expected);
+      providerResponses.push(verified.summary);
+    }
+    return Object.freeze({
+      status,
+      manifestId: initial.manifest.manifestId,
+      zoneId: initial.manifest.zoneId,
+      targetNames: records.map(({ name }) => name),
+      providerResponses: Object.freeze(providerResponses),
+    });
+  }
+
   return Object.freeze({
+    /** Read-only LIVE-01/02 DNS preflight with status-only provider evidence. */
+    async webPreflight() {
+      return verifyWebBootstrap('WEB_PREFLIGHT_OK');
+    },
+
+    /** Read-only post-bootstrap verification; never emits TXT verification values. */
+    async webVerify() {
+      return verifyWebBootstrap('WEB_BOOTSTRAP_VERIFIED');
+    },
+
+    async webBootstrap() {
+      // Resolve and validate both TXT values before the first provider request.
+      const expectedRecords = webBootstrapRecords(railwayVerificationValues);
+      const zone = await request(
+        'web_zone_bootstrap',
+        '',
+        { method: 'GET' },
+        authorizeWebBootstrap
+      );
+      if (
+        zone.body.result?.id !== initial.manifest.zoneId ||
+        zone.body.result?.name !== initial.manifest.zone
+      )
+        fail('provider zone does not match the validated manifest');
+      const providerResponses = [zone.summary];
+      const baselineRecords = [];
+      for (const expected of expectedRecords) {
+        const query = `?name=${encodeURIComponent(expected.name)}&type=${expected.type}`;
+        const listed = await request(
+          'web_dns_bootstrap_read',
+          `/dns_records${query}`,
+          { method: 'GET' },
+          authorizeWebBootstrap
+        );
+        providerResponses.push(listed.summary);
+        if (!Array.isArray(listed.body.result))
+          fail('provider returned an invalid DNS record list');
+        if (listed.body.result.length === 0) {
+          const created = await request(
+            'web_dns_bootstrap_create',
+            '/dns_records',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                type: expected.type,
+                name: expected.name,
+                content: expected.content,
+                ttl: expected.ttl,
+              }),
+            },
+            authorizeWebBootstrap
+          );
+          providerResponses.push(created.summary);
+          baselineRecords.push(validateWebRecord(created.body.result, expected));
+        } else if (listed.body.result.length === 1) {
+          baselineRecords.push(validateWebRecord(listed.body.result[0], expected));
+        } else {
+          fail('provider must return at most one approved LIVE-01/02 bootstrap record');
+        }
+      }
+      return Object.freeze({
+        kind: 'CLOUDFLARE_LIVE01_02_WEB_BOOTSTRAP',
+        manifestId: initial.manifest.manifestId,
+        zoneId: initial.manifest.zoneId,
+        providerCredentialFingerprint: initial.manifest.providerCredentialFingerprint,
+        targetNames: Object.freeze(expectedRecords.map(({ name }) => name)),
+        baselineHash: fingerprint(canonicalWebBaseline(baselineRecords)),
+        providerResponses: Object.freeze(providerResponses),
+      });
+    },
+
     async preflight() {
       const zone = await request('zone_preflight', '', { method: 'GET' });
       if (

--- a/tools/controlled-live-harness/runner.mjs
+++ b/tools/controlled-live-harness/runner.mjs
@@ -26,6 +26,26 @@ export function protectedToken(path, name) {
   return match[1];
 }
 
+export function protectedValues(path, names) {
+  if (!Array.isArray(names) || names.length === 0 || new Set(names).size !== names.length)
+    fail('protected runtime value names are invalid');
+  if ((statSync(path).mode & 0o777) !== 0o600) fail('runtime secret file must be mode 600');
+  const lines = readFileSync(path, 'utf8').split('\n');
+  if (lines.at(-1) !== '') fail('runtime secret file has invalid format');
+  lines.pop();
+  if (lines.length !== names.length) fail('runtime secret file has invalid format');
+  const expected = new Set(names);
+  const values = {};
+  for (const line of lines) {
+    const match = line.match(/^export ([A-Z][A-Z0-9_]*)='([^'\r\n]+)'$/);
+    if (!match || !expected.has(match[1]) || Object.hasOwn(values, match[1]))
+      fail('runtime secret file has invalid format');
+    values[match[1]] = match[2];
+  }
+  if (Object.keys(values).length !== names.length) fail('runtime secret file has invalid format');
+  return Object.freeze(values);
+}
+
 export function loadManifest(path = DEFAULT_MANIFEST) {
   return validateCloudflareManifest(JSON.parse(readFileSync(path, 'utf8')));
 }
@@ -49,17 +69,40 @@ function writeArtifact(path, artifact) {
 
 async function main() {
   const command = process.argv[2] ?? 'status';
-  if (!['status', 'preflight', 'bootstrap', 'apply', 'restore'].includes(command))
+  if (
+    ![
+      'status',
+      'preflight',
+      'bootstrap',
+      'apply',
+      'restore',
+      'web-preflight',
+      'web-verify',
+      'web-bootstrap',
+    ].includes(command)
+  )
     fail('unsupported command');
   if (command === 'restore' && process.argv[5] !== undefined)
     fail('restore does not accept a caller-supplied completion evidence file');
+  if (['bootstrap', 'web-bootstrap'].includes(command) && !process.argv[3])
+    fail(`${command} requires an output artifact path before provider access`);
+  if (['apply', 'restore'].includes(command) && (!process.argv[3] || !process.argv[4]))
+    fail(`${command} requires input and output artifact paths before provider access`);
+  const manifest = loadManifest();
+  // Railway TXT values are resolved and validated before the Cloudflare client exists.
+  const railwayVerificationValues = command.startsWith('web-')
+    ? protectedValues(
+        process.env.DNSOPS_RAILWAY_VERIFICATION_SECRET_FILE ??
+          `${process.env.HOME}/.config/dns-ops/railway-verification.env`,
+        ['RAILWAY_ASORIN_AI_VERIFICATION_TXT', 'RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT']
+      )
+    : undefined;
   // Credential resolution is intentionally here rather than in DNS Ops/MCP or the adapter module.
   const token = protectedToken(
     process.env.DNSOPS_CLOUDFLARE_SECRET_FILE ??
       `${process.env.HOME}/.config/dns-ops/cloudflare-test.env`,
     'CLOUDFLARE_API_TOKEN'
   );
-  const manifest = loadManifest();
   if (command === 'status') {
     policyFromManifest(manifest, token);
     console.log(
@@ -73,7 +116,27 @@ async function main() {
     );
     return;
   }
-  const adapter = createCloudflareAdapter({ manifest, token });
+  const adapter = createCloudflareAdapter({ manifest, token, railwayVerificationValues });
+  if (command === 'web-preflight') {
+    console.log(JSON.stringify(await adapter.webPreflight()));
+    return;
+  }
+  if (command === 'web-verify') {
+    console.log(JSON.stringify(await adapter.webVerify()));
+    return;
+  }
+  if (command === 'web-bootstrap') {
+    const artifact = await adapter.webBootstrap();
+    writeArtifact(process.argv[3], artifact);
+    console.log(
+      JSON.stringify({
+        status: 'WEB_BOOTSTRAP_ARTIFACT_WRITTEN',
+        artifactPath: process.argv[3],
+        baselineHash: artifact.baselineHash,
+      })
+    );
+    return;
+  }
   if (command === 'preflight') {
     console.log(JSON.stringify(await adapter.preflight()));
     return;


### PR DESCRIPTION
Adds an isolated, exact-allowlist LIVE-01/02 Railway DNS bootstrap and read-only verification path. Verification TXT values are loaded only from a protected runtime file; no secret is committed or logged. Fixture mode remains explicitly blocked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-closed Railway DNS bootstrap harness for LIVE-01/02 that only creates exact `CNAME`/`TXT` records and redacts verification TXT values. Includes read-only preflight/verify, strict runtime secret handling, and manifest pinning to protect Cloudflare changes.

- **New Features**
  - New `web-preflight`, `web-bootstrap`, and `web-verify` commands in the controlled-live harness.
  - Manifest pins exact LIVE-01/02 records: `asorin.ai` and `www.asorin.ai` `CNAME`s, and `_railway-verify.*` `TXT`s; LIVE-03 mail SPF unchanged.
  - Runtime TXT values are read from a mode-0600 secret file, validated, and never emitted; all outputs redact them.
  - Cloudflare adapter revalidates the manifest, zone, exact tuples, credential fingerprint, and runtime TXT values before every request; preflight/verify are GET-only; bootstrap creates only missing exact records and emits a baseline hash.
  - Runner blocks fixture-mode for LIVE-01/02, requires artifact paths up front, and fails early on unsupported inputs; README documents usage; tests cover secret-file validation, redaction, and fail-closed paths.

- **Migration**
  - Create the secret file (default: `$HOME/.config/dns-ops/railway-verification.env`, mode `0600`) with:
    - `export RAILWAY_ASORIN_AI_VERIFICATION_TXT='...'`
    - `export RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT='...'`
  - Run:
    - `node tools/controlled-live-harness/runner.mjs web-preflight`
    - `node tools/controlled-live-harness/runner.mjs web-bootstrap <artifact.json>`
    - `node tools/controlled-live-harness/runner.mjs web-verify`

<sup>Written for commit 8ffc8f6d19037597b351e2c18a63c0c12b2b192d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

