### PR TITLE
Add Railway verification secret provisioner

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "turbo run lint",
     "dev": "turbo run dev",
     "test": "vitest run && bun run test:controlled-live-harness && bun run test:migrations",
-    "test:controlled-live-harness": "bun run --filter @dns-ops/contracts build && node --test scripts/controlled-live-harness.test.mjs",
+    "test:controlled-live-harness": "bun run --filter @dns-ops/contracts build && node --test scripts/controlled-live-harness.test.mjs scripts/railway-verification-secret-provisioner.test.mjs",
     "test:migrations": "node --test scripts/run-migrations.test.mjs",
     "test:live-dns": "bun run --filter @dns-ops/collector test:live-dns",
     "smoke-test": "npx tsx scripts/deploy/smoke-test.ts",

--- a/scripts/railway-verification-secret-provisioner.test.mjs
+++ b/scripts/railway-verification-secret-provisioner.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  provisionRailwayVerificationSecret,
+  RAILWAY_SCOPE,
+} from '../tools/controlled-live-harness/railway-verification-secret-provisioner.mjs';
+
+const outputPath = '/home/operator/.config/dns-ops/railway-verification.env';
+const token = Object.freeze({
+  'asorin.ai': 'apex-verification-token',
+  'www.asorin.ai': 'www-verification-token',
+});
+
+function railwayStatus(domain) {
+  return JSON.stringify({
+    id: domain.id,
+    domain: domain.name,
+    dnsRecords: [
+      { host: domain.verificationHost, type: 'TXT', value: token[domain.name] },
+      { host: '@', type: 'CNAME', value: 'ignored-by-provisioner.example' },
+    ],
+  });
+}
+
+function memoryFilesystem(initialFiles = {}) {
+  const files = new Map(Object.entries(initialFiles));
+  const calls = [];
+  return {
+    calls,
+    files,
+    mkdirSync(path, options) {
+      calls.push({ operation: 'mkdir', path, options });
+    },
+    existsSync(path) {
+      calls.push({ operation: 'exists', path });
+      return files.has(path);
+    },
+    writeFileSync(path, content, options) {
+      calls.push({ operation: 'write', path, content, options });
+      if (options.flag === 'wx' && files.has(path)) {
+        const error = new Error('exists');
+        error.code = 'EEXIST';
+        throw error;
+      }
+      files.set(path, content);
+    },
+    chmodSync(path, mode) {
+      calls.push({ operation: 'chmod', path, mode });
+    },
+    linkSync(source, destination) {
+      calls.push({ operation: 'link', source, destination });
+      if (files.has(destination)) {
+        const error = new Error('exists');
+        error.code = 'EEXIST';
+        throw error;
+      }
+      files.set(destination, files.get(source));
+    },
+    renameSync(source, destination) {
+      calls.push({ operation: 'rename', source, destination });
+      files.set(destination, files.get(source));
+      files.delete(source);
+    },
+    unlinkSync(path) {
+      calls.push({ operation: 'unlink', path });
+      if (!files.delete(path)) {
+        const error = new Error('missing');
+        error.code = 'ENOENT';
+        throw error;
+      }
+    },
+  };
+}
+
+function mockedExecute(calls, statuses = RAILWAY_SCOPE.domains.map(railwayStatus)) {
+  return (command, args) => {
+    calls.push({ command, args });
+    return statuses.shift();
+  };
+}
+
+test('queries only the pinned Railway domain IDs with full scope and writes a mode-600 secret', () => {
+  const cliCalls = [];
+  const fs = memoryFilesystem();
+  const result = provisionRailwayVerificationSecret({
+    outputPath,
+    execute: mockedExecute(cliCalls),
+    fs,
+    temporaryName: (path) => `${path}.test-tmp`,
+  });
+
+  assert.deepEqual(result, {
+    status: 'RAILWAY_VERIFICATION_SECRET_WRITTEN',
+    outputPath,
+  });
+  assert.deepEqual(
+    cliCalls,
+    RAILWAY_SCOPE.domains.map((domain) => ({
+      command: 'railway',
+      args: [
+        'domain',
+        'status',
+        domain.id,
+        '--project',
+        RAILWAY_SCOPE.projectId,
+        '--environment',
+        RAILWAY_SCOPE.environmentId,
+        '--service',
+        RAILWAY_SCOPE.serviceId,
+        '--json',
+      ],
+    }))
+  );
+  assert.equal(
+    fs.files.get(outputPath),
+    "export RAILWAY_ASORIN_AI_VERIFICATION_TXT='apex-verification-token'\nexport RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT='www-verification-token'\n"
+  );
+  assert.deepEqual(
+    fs.calls.filter((call) => call.operation === 'chmod').map((call) => call.mode),
+    [0o600]
+  );
+  assert.equal(
+    fs.calls.some((call) => call.operation === 'rename'),
+    false
+  );
+  assert.equal(
+    fs.calls.some((call) => call.operation === 'link'),
+    true
+  );
+  assert.doesNotMatch(JSON.stringify(result), /apex-verification-token|www-verification-token/);
+});
+
+test('refuses an existing secret without querying Railway and permits an explicit atomic replacement', () => {
+  const fs = memoryFilesystem({ [outputPath]: 'old secret' });
+  const cliCalls = [];
+  assert.throws(
+    () =>
+      provisionRailwayVerificationSecret({
+        outputPath,
+        execute: mockedExecute(cliCalls),
+        fs,
+        temporaryName: (path) => `${path}.test-tmp`,
+      }),
+    /refusing to overwrite.*--replace/
+  );
+  assert.equal(cliCalls.length, 0);
+
+  provisionRailwayVerificationSecret({
+    replace: true,
+    outputPath,
+    execute: mockedExecute(cliCalls),
+    fs,
+    temporaryName: (path) => `${path}.test-tmp`,
+  });
+  assert.equal(
+    fs.calls.some((call) => call.operation === 'rename'),
+    true
+  );
+  assert.match(fs.files.get(outputPath), /RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT/);
+});
+
+test('rejects malformed or mismatched Railway status without writing a secret', () => {
+  const fs = memoryFilesystem();
+  const mismatched = railwayStatus(RAILWAY_SCOPE.domains[0]);
+  const malformed = JSON.stringify({
+    id: RAILWAY_SCOPE.domains[1].id,
+    domain: RAILWAY_SCOPE.domains[1].name,
+    dnsRecords: [
+      { host: '_railway-verify.www', type: 'TXT', value: 'first' },
+      { host: '_railway-verify.www', type: 'TXT', value: 'second' },
+    ],
+  });
+  assert.throws(
+    () =>
+      provisionRailwayVerificationSecret({
+        outputPath,
+        execute: mockedExecute([], [mismatched, malformed]),
+        fs,
+        temporaryName: (path) => `${path}.test-tmp`,
+      }),
+    /must contain exactly one TXT verification record/
+  );
+  assert.equal(fs.files.has(outputPath), false);
+});

--- a/tools/controlled-live-harness/README.md
+++ b/tools/controlled-live-harness/README.md
@@ -20,6 +20,24 @@ export RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT='runtime value omitted'
 
 The literal example values above are placeholders for local operator documentation only; do not commit real values. The runner validates that file and both printable DNS TXT values before constructing a provider request. Every provider request revalidates the full manifest, zone, all exact CNAME/TXT tuples, credential fingerprint, and the runtime TXT values.
 
+### Provision the local Railway secret
+
+An authorized operator can obtain the two values without copying them through a terminal or an artifact:
+
+```sh
+node tools/controlled-live-harness/railway-verification-secret-provisioner.mjs
+```
+
+The provisioner runs exactly two `railway domain status <pinned-domain-id> --project <pinned-project-id> --environment <pinned-environment-id> --service <pinned-service-id> --json` queries. It verifies the returned pinned domain ID/name and exact `_railway-verify` TXT record before atomically creating `$HOME/.config/dns-ops/railway-verification.env` at mode `0600`. It prints only a success status and file path, never a verification value. It does not call Cloudflare and has no Railway mutation command.
+
+It refuses to replace an existing secret file (and performs no Railway query in that case). Use this only when intentionally refreshing both Railway values:
+
+```sh
+node tools/controlled-live-harness/railway-verification-secret-provisioner.mjs --replace
+```
+
+Do not redirect output, use shell tracing, commit the generated file, or run the provisioner without authorization to read the pinned Railway project. It is deliberately separate from the `web-*` commands, which may contact Cloudflare.
+
 ```sh
 node tools/controlled-live-harness/runner.mjs web-preflight
 node tools/controlled-live-harness/runner.mjs web-bootstrap /secure/operator/web-bootstrap.json

--- a/tools/controlled-live-harness/railway-verification-secret-provisioner.mjs
+++ b/tools/controlled-live-harness/railway-verification-secret-provisioner.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+export const RAILWAY_SCOPE = Object.freeze({
+  projectId: '0e240f31-311a-4140-9dbf-c18c485d9820',
+  environmentId: 'e6c3a4d7-2cce-4e2a-8d81-9b7e433dcd1d',
+  serviceId: '4197eca1-a820-4f2f-8706-46cba7a0740d',
+  domains: Object.freeze([
+    Object.freeze({
+      id: '110e3e42-141b-4f3a-9328-3a6dff4b9851',
+      name: 'asorin.ai',
+      verificationHost: '_railway-verify',
+      environmentVariable: 'RAILWAY_ASORIN_AI_VERIFICATION_TXT',
+    }),
+    Object.freeze({
+      id: 'efe59266-2b4a-476b-b189-f5e660ac8da8',
+      name: 'www.asorin.ai',
+      verificationHost: '_railway-verify.www',
+      environmentVariable: 'RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT',
+    }),
+  ]),
+});
+
+const fail = (message) => {
+  throw new Error(`Railway verification-secret provisioner: ${message}`);
+};
+
+function scopedDomainStatusArgs(domain) {
+  return [
+    'domain',
+    'status',
+    domain.id,
+    '--project',
+    RAILWAY_SCOPE.projectId,
+    '--environment',
+    RAILWAY_SCOPE.environmentId,
+    '--service',
+    RAILWAY_SCOPE.serviceId,
+    '--json',
+  ];
+}
+
+function requiredString(object, fields, label) {
+  const values = fields
+    .filter((field) => Object.hasOwn(object, field))
+    .map((field) => object[field]);
+  if (
+    values.length === 0 ||
+    values.some((value) => typeof value !== 'string' || value.length === 0)
+  )
+    fail(`${label} is missing or invalid`);
+  if (new Set(values).size !== 1) fail(`${label} is ambiguous`);
+  return values[0];
+}
+
+function parseDomainStatus(raw, domain) {
+  let status;
+  try {
+    status = JSON.parse(raw);
+  } catch {
+    fail(`Railway returned invalid JSON for ${domain.name}`);
+  }
+  if (!status || typeof status !== 'object' || Array.isArray(status))
+    fail(`Railway returned invalid status for ${domain.name}`);
+  if (requiredString(status, ['id', 'domainId'], `${domain.name} domain ID`) !== domain.id)
+    fail(`Railway returned an unexpected domain ID for ${domain.name}`);
+  if (requiredString(status, ['domain', 'name'], `${domain.name} domain name`) !== domain.name)
+    fail(`Railway returned an unexpected domain name for ${domain.name}`);
+  if (!Array.isArray(status.dnsRecords)) fail(`${domain.name} status has no DNS records`);
+
+  const verificationRecords = status.dnsRecords.filter((record) => {
+    if (!record || typeof record !== 'object' || Array.isArray(record) || record.type !== 'TXT')
+      return false;
+    const host = [record.host, record.name].filter((value) => typeof value === 'string');
+    return host.length > 0 && host.every((value) => value === domain.verificationHost);
+  });
+  if (verificationRecords.length !== 1)
+    fail(`${domain.name} status must contain exactly one TXT verification record`);
+
+  const token = requiredString(
+    verificationRecords[0],
+    ['value', 'content'],
+    `${domain.name} verification token`
+  );
+  if (!/^[^'\r\n]+$/.test(token))
+    fail(`${domain.name} verification token is not safe for the secret file`);
+  return token;
+}
+
+function envFileContents(tokens) {
+  return `${RAILWAY_SCOPE.domains
+    .map((domain) => `export ${domain.environmentVariable}='${tokens[domain.environmentVariable]}'`)
+    .join('\n')}\n`;
+}
+
+function defaultExecute(command, args) {
+  try {
+    return execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch {
+    fail('scoped Railway domain-status query failed');
+  }
+}
+
+function isAlreadyExists(error) {
+  return error && typeof error === 'object' && error.code === 'EEXIST';
+}
+
+/**
+ * Queries only the two pinned Railway domain IDs and writes the harness's local secret file.
+ * The injected seams keep tests offline; production uses Railway CLI and the Node filesystem.
+ */
+export function provisionRailwayVerificationSecret({
+  replace = false,
+  outputPath = resolve(process.env.HOME ?? '', '.config/dns-ops/railway-verification.env'),
+  execute = defaultExecute,
+  fs = { mkdirSync, writeFileSync, chmodSync, existsSync, linkSync, renameSync, unlinkSync },
+  temporaryName = (path) => `${path}.${process.pid}.tmp`,
+} = {}) {
+  if (typeof replace !== 'boolean') fail('replace must be a boolean');
+  if (typeof outputPath !== 'string' || outputPath.length === 0) fail('output path is invalid');
+  const path = resolve(outputPath);
+  const temporaryPath = temporaryName(path);
+  if (typeof temporaryPath !== 'string' || resolve(temporaryPath) === path)
+    fail('temporary path is invalid');
+
+  if (!replace && fs.existsSync(path))
+    fail('refusing to overwrite existing secret file without --replace');
+
+  const tokens = {};
+  for (const domain of RAILWAY_SCOPE.domains) {
+    const output = execute('railway', scopedDomainStatusArgs(domain));
+    if (typeof output !== 'string') fail(`Railway returned invalid output for ${domain.name}`);
+    tokens[domain.environmentVariable] = parseDomainStatus(output, domain);
+  }
+
+  fs.mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  try {
+    fs.writeFileSync(temporaryPath, envFileContents(tokens), {
+      encoding: 'utf8',
+      mode: 0o600,
+      flag: 'wx',
+    });
+    fs.chmodSync(temporaryPath, 0o600);
+    if (replace) fs.renameSync(temporaryPath, path);
+    else {
+      try {
+        fs.linkSync(temporaryPath, path);
+      } catch (error) {
+        if (isAlreadyExists(error))
+          fail('refusing to overwrite existing secret file without --replace');
+        throw error;
+      }
+      fs.unlinkSync(temporaryPath);
+    }
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch (cleanupError) {
+      if (!isAlreadyExists(cleanupError) && cleanupError?.code !== 'ENOENT') throw cleanupError;
+    }
+    throw error;
+  }
+  return Object.freeze({ status: 'RAILWAY_VERIFICATION_SECRET_WRITTEN', outputPath: path });
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.some((arg) => arg !== '--replace'))
+    fail('usage: railway-verification-secret-provisioner.mjs [--replace]');
+  if (args.filter((arg) => arg === '--replace').length > 1)
+    fail('usage: railway-verification-secret-provisioner.mjs [--replace]');
+  const result = provisionRailwayVerificationSecret({ replace: args.includes('--replace') });
+  console.log(JSON.stringify(result));
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
Adds a user-invoked, scoped read-only Railway provisioner that atomically writes the mode-600 verification runtime file without printing values. No Cloudflare or infrastructure mutation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user-invoked Railway verification secret provisioner that fetches TXT tokens from pinned domains and atomically writes a mode-600 env file without exposing values. Improves operator safety by avoiding terminal copy/paste and preventing accidental overwrites.

- New Features
  - `tools/controlled-live-harness/railway-verification-secret-provisioner.mjs` runs two scoped `railway domain status ... --json` calls against pinned project/environment/service and domain IDs.
  - Verifies domain ID/name and requires exactly one TXT record at the `_railway-verify` host; rejects malformed or mismatched data.
  - Writes `$HOME/.config/dns-ops/railway-verification.env` atomically at mode `0600`; refuses overwrite unless `--replace`.
  - Prints only a JSON success status and path; never prints tokens; no Cloudflare calls or Railway mutations.
  - Added tests (`scripts/railway-verification-secret-provisioner.test.mjs`) and updated README; wired into `test:controlled-live-harness` in `package.json`.

<sup>Written for commit f845bb8af6aee0f8c42e3b38f65a9224c34ae14b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

