### PR TITLE
Fix Railway verification status parsing

### DIFF
--- a/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
@@ -18,12 +18,50 @@
     { "name": "mail.asorin.ai", "types": ["TXT"], "mutationIds": ["LIVE-03"] }
   ],
   "bootstrapAllowlist": [
-    { "name": "asorin.ai", "type": "CNAME", "content": "epgybwo0.up.railway.app", "ttl": 60, "mutationId": "LIVE-02" },
-    { "name": "www.asorin.ai", "type": "CNAME", "content": "4xbfxxr5.up.railway.app", "ttl": 60, "mutationId": "LIVE-01" },
-    { "name": "_railway-verify.asorin.ai", "type": "TXT", "runtimeValue": "RAILWAY_ASORIN_AI_VERIFICATION_TXT", "ttl": 60, "mutationId": "LIVE-02" },
-    { "name": "_railway-verify.www.asorin.ai", "type": "TXT", "runtimeValue": "RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT", "ttl": 60, "mutationId": "LIVE-01" },
-    { "name": "mail.asorin.ai", "type": "TXT", "content": "v=spf1 -all", "ttl": 60, "mutationId": "LIVE-03" }
+    {
+      "name": "asorin.ai",
+      "type": "CNAME",
+      "content": "epgybwo0.up.railway.app",
+      "ttl": 60,
+      "mutationId": "LIVE-02"
+    },
+    {
+      "name": "www.asorin.ai",
+      "type": "CNAME",
+      "content": "4xbfxxr5.up.railway.app",
+      "ttl": 60,
+      "mutationId": "LIVE-01"
+    },
+    {
+      "name": "_railway-verify.asorin.ai",
+      "type": "TXT",
+      "runtimeValue": "RAILWAY_ASORIN_AI_VERIFICATION_TXT",
+      "ttl": 60,
+      "mutationId": "LIVE-02"
+    },
+    {
+      "name": "_railway-verify.www.asorin.ai",
+      "type": "TXT",
+      "runtimeValue": "RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT",
+      "ttl": 60,
+      "mutationId": "LIVE-01"
+    },
+    {
+      "name": "mail.asorin.ai",
+      "type": "TXT",
+      "content": "v=spf1 -all",
+      "ttl": 60,
+      "mutationId": "LIVE-03"
+    }
   ],
+  "fixtureControl": {
+    "endpoint": "https://asorin.ai/__dnsops/live-mode",
+    "healthyMode": "healthy",
+    "modes": [
+      { "mutationId": "LIVE-01", "mode": "redirect_fault", "targetName": "www.asorin.ai" },
+      { "mutationId": "LIVE-02", "mode": "noindex_fault", "targetName": "asorin.ai" }
+    ]
+  },
   "rollbackAndRevocationOwner": "Antonio",
   "globalConstraints": [
     "No production traffic, client dependency, or real mail dependency exists in asorin.ai.",

--- a/scripts/controlled-live-harness.test.mjs
+++ b/scripts/controlled-live-harness.test.mjs
@@ -1,7 +1,15 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { chmodSync, mkdtempSync, statSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -16,7 +24,9 @@ import {
   policyFromManifest,
   protectedToken,
   protectedValues,
+  reserveFixtureArtifact,
   writeArtifact,
+  writeFixtureArtifactAfterTransition,
 } from '../tools/controlled-live-harness/runner.mjs';
 
 const token = 'fixture-control-credential-value';
@@ -260,6 +270,55 @@ test('fixture artifacts are written mode 600', () => {
   const path = join(mkdtempSync(join(tmpdir(), 'dnsops-')), 'fixture-artifact.json');
   writeArtifact(path, { status: 'redacted' });
   assert.equal(statSync(path).mode & 0o777, 0o600);
+});
+
+test('fixture output preflight rejects invalid or existing destinations before any fixture fetch', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'dnsops-'));
+  let fixtureFetchCalls = 0;
+  const fixtureFetch = async () => {
+    fixtureFetchCalls += 1;
+    return { status: 'unreachable' };
+  };
+  await assert.rejects(
+    writeFixtureArtifactAfterTransition(
+      join(directory, 'missing', 'fixture-artifact.json'),
+      fixtureFetch
+    ),
+    /destination is invalid/
+  );
+
+  const path = join(directory, 'fixture-artifact.json');
+  writeFileSync(path, 'existing artifact\n', { mode: 0o600 });
+  await assert.rejects(writeFixtureArtifactAfterTransition(path, fixtureFetch), /already exists/);
+  assert.equal(fixtureFetchCalls, 0);
+  assert.equal(readFileSync(path, 'utf8'), 'existing artifact\n');
+
+  const failedDirectory = mkdtempSync(join(tmpdir(), 'dnsops-'));
+  await assert.rejects(
+    writeFixtureArtifactAfterTransition(join(failedDirectory, 'failed-artifact.json'), async () => {
+      throw new Error('fixture transition failed');
+    }),
+    /fixture transition failed/
+  );
+  assert.deepEqual(readdirSync(failedDirectory), []);
+});
+
+test('fixture artifact publication creates the final name atomically and never replaces a raced output', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'dnsops-'));
+  const path = join(directory, 'fixture-artifact.json');
+  const artifact = { status: 'redacted' };
+  const written = await writeFixtureArtifactAfterTransition(path, async () => artifact);
+  assert.deepEqual(written, artifact);
+  assert.deepEqual(JSON.parse(readFileSync(path, 'utf8')), artifact);
+  assert.equal(statSync(path).mode & 0o777, 0o600);
+
+  const racedPath = join(directory, 'raced-fixture-artifact.json');
+  const reservation = reserveFixtureArtifact(racedPath);
+  assert.equal(statSync(reservation.temporaryPath).mode & 0o777, 0o600);
+  writeFileSync(racedPath, 'concurrent artifact\n', { mode: 0o600 });
+  assert.throws(() => reservation.publish(artifact), /EEXIST/);
+  assert.equal(readFileSync(racedPath, 'utf8'), 'concurrent artifact\n');
+  assert.equal(existsSync(reservation.temporaryPath), false);
 });
 
 test('LIVE-01/02 web preflight is read-only, validates every bootstrap record, and redacts TXT values', async () => {

--- a/scripts/controlled-live-harness.test.mjs
+++ b/scripts/controlled-live-harness.test.mjs
@@ -1,21 +1,26 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { createCloudflareAdapter } from '../tools/controlled-live-harness/cloudflare-adapter.mjs';
 import {
+  createFixtureControlAdapter,
+  fingerprint as fixtureFingerprint,
+} from '../tools/controlled-live-harness/fixture-control.mjs';
+import {
   loadManifest,
   policyFromManifest,
   protectedToken,
   protectedValues,
+  writeArtifact,
 } from '../tools/controlled-live-harness/runner.mjs';
 
-const token = 'x';
-const tokenFingerprint = 'sha256:2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881';
+const token = 'fixture-control-credential-value';
+const tokenFingerprint = fixtureFingerprint(token);
 const secret = (value = token) => {
   const p = join(mkdtempSync(join(tmpdir(), 'dnsops-')), 'secret');
   writeFileSync(p, `export CLOUDFLARE_API_TOKEN='${value}'\n`);
@@ -72,6 +77,7 @@ const completionEvidence = {
   auditEventIds: ['audit-01'],
 };
 const ok = (result) => ({ ok: true, status: 200, json: async () => ({ success: true, result }) });
+const fixtureOk = (mode) => ({ ok: true, status: 200, json: async () => ({ mode }) });
 const mockFetch = (...responses) => {
   const calls = [];
   return {
@@ -84,6 +90,15 @@ const mockFetch = (...responses) => {
     },
   };
 };
+
+const fixtureAdapter = (fetch) =>
+  createFixtureControlAdapter({
+    manifest: manifest(),
+    token,
+    fetchImpl: fetch,
+    now: () => new Date('2026-08-05T15:00:00.000Z'),
+    createRunId: () => 'fixture-test-run',
+  });
 
 const adapter = (fetch, runtimeValues) =>
   createCloudflareAdapter({
@@ -130,6 +145,36 @@ test('runner keeps LIVE-01/02 fixture mode changes blocked before reading creden
   assert.doesNotMatch(result.stderr, /secret file/);
 });
 
+test('runner rejects an unapproved fixture mutation before reading credentials', () => {
+  const runner = fileURLToPath(
+    new URL('../tools/controlled-live-harness/runner.mjs', import.meta.url)
+  );
+  const result = spawnSync(process.execPath, [runner, 'fixture-apply', 'LIVE-03', 'fault.json'], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /requires an approved LIVE-01 or LIVE-02/);
+  assert.doesNotMatch(result.stderr, /secret file/);
+});
+
+test('runner rejects malformed fixture recovery input before reading credentials', () => {
+  const runner = fileURLToPath(
+    new URL('../tools/controlled-live-harness/runner.mjs', import.meta.url)
+  );
+  const recoveryPath = join(mkdtempSync(join(tmpdir(), 'dnsops-')), 'recovery.json');
+  writeFileSync(recoveryPath, '[]\n');
+  const result = spawnSync(
+    process.execPath,
+    [runner, 'fixture-restore', recoveryPath, 'restored.json'],
+    {
+      encoding: 'utf8',
+    }
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /fixture recovery artifact must be an object/);
+  assert.doesNotMatch(result.stderr, /secret file/);
+});
+
 test('runner rejects a caller-supplied completion evidence file before reading credentials', () => {
   const runner = fileURLToPath(
     new URL('../tools/controlled-live-harness/runner.mjs', import.meta.url)
@@ -152,6 +197,69 @@ test('runner rejects a missing web-bootstrap artifact path before reading creden
   assert.equal(result.status, 1);
   assert.match(result.stderr, /web-bootstrap requires an output artifact path/);
   assert.doesNotMatch(result.stderr, /secret file/);
+});
+
+test('fixture apply and restore use the exact manifest endpoint, read back both transitions, and redact the token', async () => {
+  const applyFetch = mockFetch(
+    fixtureOk('healthy'),
+    fixtureOk('redirect_fault'),
+    fixtureOk('redirect_fault')
+  );
+  const recovery = await fixtureAdapter(applyFetch.fetch).apply('LIVE-01');
+  assert.equal(recovery.result, 'RECOVERY_REQUIRED');
+  assert.deepEqual(
+    applyFetch.calls.map(({ init }) => init.method),
+    ['GET', 'POST', 'GET']
+  );
+  assert.deepEqual(JSON.parse(applyFetch.calls[1].init.body), { mode: 'redirect_fault' });
+  assert.equal(applyFetch.calls[0].url, 'https://asorin.ai/__dnsops/live-mode');
+  assert.deepEqual(recovery.fixtureResponses, [
+    'fixture.mode_apply_before_readback: 200',
+    'fixture.mode_apply: 200',
+    'fixture.mode_apply_after_readback: 200',
+  ]);
+  assert.doesNotMatch(JSON.stringify(recovery), new RegExp(token));
+  assert.doesNotMatch(JSON.stringify(recovery), /Bearer/);
+
+  const restoreFetch = mockFetch(
+    fixtureOk('redirect_fault'),
+    fixtureOk('healthy'),
+    fixtureOk('healthy')
+  );
+  const restored = await fixtureAdapter(restoreFetch.fetch).restore(recovery);
+  assert.equal(restored.result, 'RESTORED');
+  assert.equal(restored.restoredAt, '2026-08-05T15:00:00.000Z');
+  assert.deepEqual(
+    restoreFetch.calls.map(({ init }) => init.method),
+    ['GET', 'POST', 'GET']
+  );
+  assert.deepEqual(JSON.parse(restoreFetch.calls[1].init.body), { mode: 'healthy' });
+  assert.match(restored.fixtureControlCredentialFingerprint, /^sha256:[a-f0-9]{64}$/);
+  assert.doesNotMatch(JSON.stringify(restored), new RegExp(token));
+});
+
+test('fixture control fails closed before a mutation when readback or manifest authorization is invalid', async () => {
+  const unexpectedState = mockFetch(fixtureOk('noindex_fault'));
+  await assert.rejects(
+    fixtureAdapter(unexpectedState.fetch).apply('LIVE-01'),
+    /pre-transition readback/
+  );
+  assert.equal(unexpectedState.calls.length, 1);
+
+  const malformed = JSON.parse(JSON.stringify(manifest()));
+  malformed.fixtureControl.endpoint = 'https://unapproved.example/__dnsops/live-mode';
+  const noRequest = mockFetch(ok({ mode: 'healthy' }));
+  assert.throws(
+    () => createFixtureControlAdapter({ manifest: malformed, token, fetchImpl: noRequest.fetch }),
+    /fixture control manifest/
+  );
+  assert.equal(noRequest.calls.length, 0);
+});
+
+test('fixture artifacts are written mode 600', () => {
+  const path = join(mkdtempSync(join(tmpdir(), 'dnsops-')), 'fixture-artifact.json');
+  writeArtifact(path, { status: 'redacted' });
+  assert.equal(statSync(path).mode & 0o777, 0o600);
 });
 
 test('LIVE-01/02 web preflight is read-only, validates every bootstrap record, and redacts TXT values', async () => {

--- a/tools/controlled-live-fixture/server.mjs
+++ b/tools/controlled-live-fixture/server.mjs
@@ -1,5 +1,5 @@
-import { createServer } from 'node:http';
 import { timingSafeEqual } from 'node:crypto';
+import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
 
 const modes = new Set(['healthy', 'redirect_fault', 'noindex_fault']);
@@ -20,7 +20,9 @@ function bearerMatches(request, expected) {
   if (!supplied) return false;
   const suppliedBytes = Buffer.from(supplied);
   const expectedBytes = Buffer.from(expected);
-  return suppliedBytes.length === expectedBytes.length && timingSafeEqual(suppliedBytes, expectedBytes);
+  return (
+    suppliedBytes.length === expectedBytes.length && timingSafeEqual(suppliedBytes, expectedBytes)
+  );
 }
 
 async function readControlRequest(request) {
@@ -59,13 +61,28 @@ export function createFixtureServer({ apexHost, wwwHost, controlToken }) {
     }
 
     if (request.url === controlPath) {
-      if (request.method !== 'POST' || !bearerMatches(request, controlToken)) {
+      if (!bearerMatches(request, controlToken)) {
+        response.writeHead(404).end();
+        return;
+      }
+      if (request.method === 'GET') {
+        response.writeHead(200, {
+          'content-type': 'application/json',
+          'cache-control': 'no-store',
+        });
+        response.end(JSON.stringify({ mode }));
+        return;
+      }
+      if (request.method !== 'POST') {
         response.writeHead(404).end();
         return;
       }
       try {
         mode = await readControlRequest(request);
-        response.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
+        response.writeHead(200, {
+          'content-type': 'application/json',
+          'cache-control': 'no-store',
+        });
         response.end(JSON.stringify({ mode }));
       } catch {
         response.writeHead(400).end();
@@ -104,6 +121,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const wwwHost = requiredEnvironment('DNSOPS_FIXTURE_WWW_HOST');
   const controlToken = requiredEnvironment('DNSOPS_FIXTURE_CONTROL_TOKEN');
   const port = Number(process.env.PORT ?? 3000);
-  if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('PORT must be a valid port');
+  if (!Number.isInteger(port) || port < 1 || port > 65535)
+    throw new Error('PORT must be a valid port');
   createFixtureServer({ apexHost, wwwHost, controlToken }).listen(port);
 }

--- a/tools/controlled-live-fixture/server.test.mjs
+++ b/tools/controlled-live-fixture/server.test.mjs
@@ -15,7 +15,9 @@ async function withFixture(run) {
   try {
     await run(`http://127.0.0.1:${address.port}`);
   } finally {
-    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    await new Promise((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    );
   }
 }
 
@@ -70,6 +72,12 @@ test('control endpoint admits only an authenticated fixed mode and changes the e
     });
     assert.equal(invalid.status, 400);
 
+    const readHealthy = await request(baseUrl, '/__dnsops/live-mode', {
+      headers: { host: apexHost, authorization: `Bearer ${controlToken}` },
+    });
+    assert.equal(readHealthy.status, 200);
+    assert.deepEqual(JSON.parse(readHealthy.text()), { mode: 'healthy' });
+
     const setRedirectFault = await request(baseUrl, '/__dnsops/live-mode', {
       method: 'POST',
       headers: { host: apexHost, authorization: `Bearer ${controlToken}` },
@@ -77,6 +85,10 @@ test('control endpoint admits only an authenticated fixed mode and changes the e
     });
     assert.equal(setRedirectFault.status, 200);
     assert.equal((await request(baseUrl, '/', { headers: { host: wwwHost } })).status, 200);
+    const readRedirectFault = await request(baseUrl, '/__dnsops/live-mode', {
+      headers: { host: apexHost, authorization: `Bearer ${controlToken}` },
+    });
+    assert.deepEqual(JSON.parse(readRedirectFault.text()), { mode: 'redirect_fault' });
 
     const setNoindexFault = await request(baseUrl, '/__dnsops/live-mode', {
       method: 'POST',

--- a/tools/controlled-live-harness/README.md
+++ b/tools/controlled-live-harness/README.md
@@ -46,4 +46,24 @@ node tools/controlled-live-harness/runner.mjs web-verify
 
 `web-preflight` and `web-verify` issue only GET requests and emit only operation/status summaries. `web-bootstrap` creates only missing exact records; an existing record must exactly match the approved name, type, content, and TTL. Its artifact contains target names, hashes, and redacted status summaries, never Railway TXT values.
 
-LIVE-01/02 fixture mode changes are intentionally not exposed by this DNS bootstrap harness. They remain blocked by the fixture's separate `DNSOPS_FIXTURE_CONTROL_TOKEN` control boundary; an unsupported `fixture-mode` invocation fails before any runtime secret is read.
+## LIVE-01/02 fixture fault apply and restore
+
+The harness alone may change the fixture mode for an authorized LIVE-01 or LIVE-02 run. The manifest pins the sole control endpoint, `https://asorin.ai/__dnsops/live-mode`, the `healthy` baseline, and the only two transitions:
+
+- `LIVE-01` → `redirect_fault` for `www.asorin.ai`
+- `LIVE-02` → `noindex_fault` for `asorin.ai`
+
+Before either fixture command, the runner accepts only a mode-`0600` local file at `DNSOPS_FIXTURE_CONTROL_SECRET_FILE` (default: `$HOME/.config/dns-ops/fixture-control.env`) with exactly:
+
+```sh
+export DNSOPS_FIXTURE_CONTROL_TOKEN='local value omitted'
+```
+
+The token is read only after command arguments, recovery input, and the manifest allowlist pass validation. Fixture commands do not construct a Cloudflare adapter, read the Cloudflare credential, or call a provider API. Do not commit the token file or redirect command output.
+
+```sh
+node tools/controlled-live-harness/runner.mjs fixture-apply LIVE-01 /secure/operator/live-01-recovery.json
+node tools/controlled-live-harness/runner.mjs fixture-restore /secure/operator/live-01-recovery.json /secure/operator/live-01-restored.json
+```
+
+`fixture-apply` requires a `healthy` authenticated GET readback before it POSTs the one manifest-approved fault mode, then requires a second authenticated GET readback of that fault mode. `fixture-restore` validates its redacted recovery artifact, requires the matching fault-mode readback, POSTs only `healthy`, and requires a final `healthy` readback. Both artifacts are written mode `0600` and contain only the pinned endpoint, mode/target identifiers, SHA-256 token fingerprint, timestamps, and HTTP operation/status summaries—never the token, bearer header, or response body. A failed readback aborts before the next transition.

--- a/tools/controlled-live-harness/cloudflare-adapter.mjs
+++ b/tools/controlled-live-harness/cloudflare-adapter.mjs
@@ -4,6 +4,7 @@ import {
   validateControlledFaultHarnessPolicy,
   validateFaultRunArtifact,
 } from '../../packages/contracts/dist/index.js';
+import { validateFixtureControlManifest } from './fixture-control.mjs';
 
 const API_ORIGIN = 'https://api.cloudflare.com/client/v4';
 const LIVE_03 = Object.freeze({ name: 'mail.asorin.ai', type: 'TXT', mutationId: 'LIVE-03' });
@@ -72,6 +73,7 @@ function freezeManifest(manifest) {
     bootstrapAllowlist: Object.freeze(
       manifest.bootstrapAllowlist.map((entry) => Object.freeze({ ...entry }))
     ),
+    fixtureControl: validateFixtureControlManifest(manifest),
   });
 }
 
@@ -130,6 +132,7 @@ export function validateCloudflareManifest(manifest) {
     )
       fail('manifest bootstrap allowlist is invalid');
   }
+  validateFixtureControlManifest(manifest);
   const policy = {
     testDomain: manifest.zone,
     testWebHost: manifest.testAssets.webHost,

--- a/tools/controlled-live-harness/fixture-control.mjs
+++ b/tools/controlled-live-harness/fixture-control.mjs
@@ -1,0 +1,222 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+const FIXTURE_ENDPOINT = 'https://asorin.ai/__dnsops/live-mode';
+const HEALTHY_MODE = 'healthy';
+const FIXTURE_MODES = Object.freeze([
+  Object.freeze({
+    mutationId: 'LIVE-01',
+    mode: 'redirect_fault',
+    targetName: 'www.asorin.ai',
+  }),
+  Object.freeze({
+    mutationId: 'LIVE-02',
+    mode: 'noindex_fault',
+    targetName: 'asorin.ai',
+  }),
+]);
+const artifactKeys = new Set([
+  'kind',
+  'runId',
+  'manifestId',
+  'fixtureEndpoint',
+  'mutationId',
+  'targetNames',
+  'baselineHash',
+  'fixtureControlCredentialFingerprint',
+  'appliedAt',
+  'restoredAt',
+  'fixtureResponses',
+  'result',
+]);
+const fingerprintPattern = /^sha256:[a-f0-9]{64}$/;
+const isoTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const fail = (message) => {
+  throw new Error(`controlled-live fixture control: ${message}`);
+};
+
+export const fingerprint = (value) => `sha256:${createHash('sha256').update(value).digest('hex')}`;
+
+function sameMode(actual, expected) {
+  return (
+    actual?.mutationId === expected.mutationId &&
+    actual?.mode === expected.mode &&
+    actual?.targetName === expected.targetName
+  );
+}
+
+/** Pins the fixture's sole control URL and the two authorized LIVE fault modes. */
+export function validateFixtureControlManifest(manifest) {
+  const control = manifest?.fixtureControl;
+  if (!control || typeof control !== 'object' || Array.isArray(control))
+    fail('fixture control manifest is invalid');
+  if (
+    control.endpoint !== FIXTURE_ENDPOINT ||
+    control.healthyMode !== HEALTHY_MODE ||
+    !Array.isArray(control.modes) ||
+    control.modes.length !== FIXTURE_MODES.length
+  )
+    fail('fixture control manifest is invalid');
+  for (const [index, expected] of FIXTURE_MODES.entries()) {
+    if (!sameMode(control.modes[index], expected)) fail('fixture control manifest is invalid');
+  }
+  return Object.freeze({
+    endpoint: control.endpoint,
+    healthyMode: control.healthyMode,
+    modes: Object.freeze(FIXTURE_MODES.map((mode) => Object.freeze({ ...mode }))),
+  });
+}
+
+function modeFor(control, mutationId) {
+  const mode = control.modes.find((entry) => entry.mutationId === mutationId);
+  if (!mode) fail('fixture mutation is not allowlisted');
+  return mode;
+}
+
+function baselineHash(control) {
+  return fingerprint(JSON.stringify({ endpoint: control.endpoint, mode: control.healthyMode }));
+}
+
+function responseSummary(operation, response) {
+  return `fixture.${operation}: ${response.status}`;
+}
+
+function assertModeBody(body, control, operation) {
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    Array.isArray(body) ||
+    Object.keys(body).length !== 1 ||
+    !Object.hasOwn(body, 'mode') ||
+    typeof body.mode !== 'string' ||
+    (body.mode !== control.healthyMode && !control.modes.some((entry) => entry.mode === body.mode))
+  )
+    fail(`${operation} returned an invalid mode readback`);
+  return body.mode;
+}
+
+function assertArtifactShape(artifact, manifest, control) {
+  if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact))
+    fail('fixture recovery artifact must be an object');
+  if (
+    Reflect.ownKeys(artifact).some((key) => typeof key !== 'string' || !artifactKeys.has(key)) ||
+    artifact.kind !== 'FIXTURE_LIVE01_02_FAULT' ||
+    typeof artifact.runId !== 'string' ||
+    !/^[a-zA-Z0-9-]{1,128}$/.test(artifact.runId) ||
+    artifact.manifestId !== manifest.manifestId ||
+    artifact.fixtureEndpoint !== control.endpoint ||
+    !Array.isArray(artifact.targetNames) ||
+    artifact.targetNames.length !== 1 ||
+    artifact.baselineHash !== baselineHash(control) ||
+    !fingerprintPattern.test(artifact.fixtureControlCredentialFingerprint ?? '') ||
+    !isoTimestampPattern.test(artifact.appliedAt ?? '') ||
+    !Array.isArray(artifact.fixtureResponses) ||
+    artifact.fixtureResponses.some((response) => !/^fixture\.[a-z_]+: [1-5]\d\d$/.test(response)) ||
+    artifact.result !== 'RECOVERY_REQUIRED' ||
+    artifact.restoredAt !== undefined
+  )
+    fail('fixture recovery artifact is invalid');
+  const mode = modeFor(control, artifact.mutationId);
+  if (artifact.targetNames[0] !== mode.targetName) fail('fixture recovery artifact is invalid');
+  return mode;
+}
+
+/** Validates untrusted fixture recovery input before the runner reads a token. */
+export function validateFixtureRecoveryArtifact(artifact, manifest) {
+  return assertArtifactShape(artifact, manifest, validateFixtureControlManifest(manifest));
+}
+
+/**
+ * Isolated fixture-control client. It accepts only the manifest-pinned endpoint
+ * and modes, and emits status summaries rather than HTTP bodies or credentials.
+ */
+export function createFixtureControlAdapter({
+  manifest,
+  token,
+  fetchImpl = globalThis.fetch,
+  now = () => new Date(),
+  createRunId = randomUUID,
+}) {
+  if (typeof fetchImpl !== 'function') fail('fetch implementation is required');
+  if (typeof token !== 'string' || token.length === 0) fail('fixture control token is invalid');
+  const control = validateFixtureControlManifest(manifest);
+
+  async function request(operation, init) {
+    // Revalidate the immutable manifest-derived endpoint/modes before every request.
+    const approved = validateFixtureControlManifest(manifest);
+    let response;
+    try {
+      response = await fetchImpl(approved.endpoint, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+          ...(init.headers ?? {}),
+        },
+      });
+    } catch {
+      fail(`${operation} request failed without a fixture response`);
+    }
+    const summary = responseSummary(operation, response);
+    if (!response.ok) fail(`${operation} was rejected (${summary})`);
+    let body;
+    try {
+      body = await response.json();
+    } catch {
+      fail(`${operation} returned invalid JSON (${summary})`);
+    }
+    return { mode: assertModeBody(body, control, operation), summary };
+  }
+
+  async function readback(operation) {
+    return request(operation, { method: 'GET' });
+  }
+
+  async function transition(expectedBefore, desiredMode, operation) {
+    const before = await readback(`${operation}_before_readback`);
+    if (before.mode !== expectedBefore)
+      fail(`${operation} pre-transition readback does not match the expected mode`);
+    const applied = await request(operation, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: desiredMode }),
+    });
+    if (applied.mode !== desiredMode) fail(`${operation} response does not match the desired mode`);
+    const after = await readback(`${operation}_after_readback`);
+    if (after.mode !== desiredMode)
+      fail(`${operation} post-transition readback does not match the desired mode`);
+    return [before.summary, applied.summary, after.summary];
+  }
+
+  return Object.freeze({
+    async apply(mutationId) {
+      const mode = modeFor(validateFixtureControlManifest(manifest), mutationId);
+      const fixtureResponses = await transition(control.healthyMode, mode.mode, 'mode_apply');
+      return Object.freeze({
+        kind: 'FIXTURE_LIVE01_02_FAULT',
+        runId: createRunId(),
+        manifestId: manifest.manifestId,
+        fixtureEndpoint: control.endpoint,
+        mutationId: mode.mutationId,
+        targetNames: Object.freeze([mode.targetName]),
+        baselineHash: baselineHash(control),
+        fixtureControlCredentialFingerprint: fingerprint(token),
+        appliedAt: now().toISOString(),
+        fixtureResponses: Object.freeze(fixtureResponses),
+        result: 'RECOVERY_REQUIRED',
+      });
+    },
+
+    async restore(runArtifact) {
+      const mode = assertArtifactShape(runArtifact, manifest, control);
+      if (runArtifact.fixtureControlCredentialFingerprint !== fingerprint(token))
+        fail('fixture recovery artifact does not match the current control credential');
+      const fixtureResponses = await transition(mode.mode, control.healthyMode, 'mode_restore');
+      return Object.freeze({
+        ...runArtifact,
+        restoredAt: now().toISOString(),
+        fixtureResponses: Object.freeze([...runArtifact.fixtureResponses, ...fixtureResponses]),
+        result: 'RESTORED',
+      });
+    },
+  });
+}

--- a/tools/controlled-live-harness/railway-verification-secret-provisioner.mjs
+++ b/tools/controlled-live-harness/railway-verification-secret-provisioner.mjs
@@ -72,13 +72,30 @@ function parseDomainStatus(raw, domain) {
   }
   if (!status || typeof status !== 'object' || Array.isArray(status))
     fail(`Railway returned invalid status for ${domain.name}`);
-  if (requiredString(status, ['id', 'domainId'], `${domain.name} domain ID`) !== domain.id)
+  const detail =
+    status.domain && typeof status.domain === 'object' && !Array.isArray(status.domain)
+      ? status.domain
+      : status;
+  if (requiredString(detail, ['id', 'domainId'], `${domain.name} domain ID`) !== domain.id)
     fail(`Railway returned an unexpected domain ID for ${domain.name}`);
-  if (requiredString(status, ['domain', 'name'], `${domain.name} domain name`) !== domain.name)
+  if (requiredString(detail, ['domain', 'name'], `${domain.name} domain name`) !== domain.name)
     fail(`Railway returned an unexpected domain name for ${domain.name}`);
-  if (!Array.isArray(status.dnsRecords)) fail(`${domain.name} status has no DNS records`);
 
-  const verificationRecords = status.dnsRecords.filter((record) => {
+  const verification = detail.verification;
+  if (verification && typeof verification === 'object' && !Array.isArray(verification)) {
+    if (
+      requiredString(verification, ['dnsHost'], `${domain.name} verification host`) !==
+      domain.verificationHost
+    )
+      fail(`Railway returned an unexpected verification host for ${domain.name}`);
+    const token = requiredString(verification, ['token'], `${domain.name} verification token`);
+    if (!/^[^'\r\n]+$/.test(token))
+      fail(`${domain.name} verification token is not safe for the secret file`);
+    return token;
+  }
+
+  if (!Array.isArray(detail.dnsRecords)) fail(`${domain.name} status has no DNS records`);
+  const verificationRecords = detail.dnsRecords.filter((record) => {
     if (!record || typeof record !== 'object' || Array.isArray(record) || record.type !== 'TXT')
       return false;
     const host = [record.host, record.name].filter((value) => typeof value === 'string');
@@ -86,7 +103,6 @@ function parseDomainStatus(raw, domain) {
   });
   if (verificationRecords.length !== 1)
     fail(`${domain.name} status must contain exactly one TXT verification record`);
-
   const token = requiredString(
     verificationRecords[0],
     ['value', 'content'],

--- a/tools/controlled-live-harness/runner.mjs
+++ b/tools/controlled-live-harness/runner.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -8,6 +8,10 @@ import {
   policyFromCloudflareManifest,
   validateCloudflareManifest,
 } from './cloudflare-adapter.mjs';
+import {
+  createFixtureControlAdapter,
+  validateFixtureRecoveryArtifact,
+} from './fixture-control.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const DEFAULT_MANIFEST = resolve(
@@ -62,9 +66,10 @@ function readArtifact(path) {
   }
 }
 
-function writeArtifact(path, artifact) {
+export function writeArtifact(path, artifact) {
   if (!path) fail('an output artifact path is required');
   writeFileSync(path, `${JSON.stringify(artifact, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  chmodSync(path, 0o600);
 }
 
 async function main() {
@@ -79,6 +84,8 @@ async function main() {
       'web-preflight',
       'web-verify',
       'web-bootstrap',
+      'fixture-apply',
+      'fixture-restore',
     ].includes(command)
   )
     fail('unsupported command');
@@ -88,7 +95,23 @@ async function main() {
     fail(`${command} requires an output artifact path before provider access`);
   if (['apply', 'restore'].includes(command) && (!process.argv[3] || !process.argv[4]))
     fail(`${command} requires input and output artifact paths before provider access`);
+  if (command === 'fixture-apply') {
+    if (!['LIVE-01', 'LIVE-02'].includes(process.argv[3] ?? ''))
+      fail(
+        'fixture-apply requires an approved LIVE-01 or LIVE-02 mutation ID before credential access'
+      );
+    if (!process.argv[4] || process.argv[5] !== undefined)
+      fail('fixture-apply requires one output artifact path before credential access');
+  }
+  if (command === 'fixture-restore') {
+    if (!process.argv[3] || !process.argv[4] || process.argv[5] !== undefined)
+      fail('fixture-restore requires input and output artifact paths before credential access');
+  }
+  const fixtureRecoveryArtifact =
+    command === 'fixture-restore' ? readArtifact(process.argv[3]) : undefined;
   const manifest = loadManifest();
+  if (command === 'fixture-restore')
+    validateFixtureRecoveryArtifact(fixtureRecoveryArtifact, manifest);
   // Railway TXT values are resolved and validated before the Cloudflare client exists.
   const railwayVerificationValues = command.startsWith('web-')
     ? protectedValues(
@@ -97,6 +120,30 @@ async function main() {
         ['RAILWAY_ASORIN_AI_VERIFICATION_TXT', 'RAILWAY_WWW_ASORIN_AI_VERIFICATION_TXT']
       )
     : undefined;
+  if (command === 'fixture-apply' || command === 'fixture-restore') {
+    const token = protectedToken(
+      process.env.DNSOPS_FIXTURE_CONTROL_SECRET_FILE ??
+        `${process.env.HOME}/.config/dns-ops/fixture-control.env`,
+      'DNSOPS_FIXTURE_CONTROL_TOKEN'
+    );
+    const adapter = createFixtureControlAdapter({ manifest, token });
+    const artifact =
+      command === 'fixture-apply'
+        ? await adapter.apply(process.argv[3])
+        : await adapter.restore(fixtureRecoveryArtifact);
+    writeArtifact(process.argv[4], artifact);
+    console.log(
+      JSON.stringify({
+        status:
+          command === 'fixture-apply'
+            ? 'FIXTURE_RECOVERY_ARTIFACT_WRITTEN'
+            : 'FIXTURE_RESTORE_ARTIFACT_WRITTEN',
+        artifactPath: process.argv[4],
+        runId: artifact.runId,
+      })
+    );
+    return;
+  }
   // Credential resolution is intentionally here rather than in DNS Ops/MCP or the adapter module.
   const token = protectedToken(
     process.env.DNSOPS_CLOUDFLARE_SECRET_FILE ??

--- a/tools/controlled-live-harness/runner.mjs
+++ b/tools/controlled-live-harness/runner.mjs
@@ -1,6 +1,19 @@
 #!/usr/bin/env node
-import { chmodSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import {
+  chmodSync,
+  closeSync,
+  fchmodSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   createCloudflareAdapter,
@@ -72,6 +85,100 @@ export function writeArtifact(path, artifact) {
   chmodSync(path, 0o600);
 }
 
+/**
+ * Reserves a fixture artifact destination before credentials or the fixture are
+ * accessed. Publishing uses link(2), which atomically creates the final name
+ * without replacing an output another process may have created meanwhile.
+ */
+export function reserveFixtureArtifact(path) {
+  if (!path || typeof path !== 'string') fail('an output artifact path is required');
+  const artifactPath = resolve(path);
+  try {
+    lstatSync(artifactPath);
+    fail('output artifact path already exists');
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('controlled-live harness:')) throw error;
+    if (error?.code !== 'ENOENT') fail('output artifact destination is invalid');
+  }
+
+  let descriptor;
+  let temporaryPath;
+  for (let attempt = 0; attempt < 16; attempt += 1) {
+    temporaryPath = join(dirname(artifactPath), `.${randomBytes(16).toString('hex')}.tmp`);
+    let candidate;
+    try {
+      candidate = openSync(temporaryPath, 'wx', 0o600);
+      fchmodSync(candidate, 0o600);
+      descriptor = candidate;
+      break;
+    } catch (error) {
+      if (candidate !== undefined) {
+        closeSync(candidate);
+        unlinkSync(temporaryPath);
+      }
+      if (error?.code !== 'EEXIST') fail('output artifact destination is invalid');
+    }
+  }
+  if (descriptor === undefined) fail('unable to reserve output artifact destination');
+
+  let closed = false;
+  let temporaryExists = true;
+  const close = () => {
+    if (!closed) {
+      closeSync(descriptor);
+      closed = true;
+    }
+  };
+  const discard = () => {
+    let cleanupError;
+    try {
+      close();
+    } catch (error) {
+      cleanupError = error;
+    }
+    if (temporaryExists) {
+      try {
+        unlinkSync(temporaryPath);
+        temporaryExists = false;
+      } catch (error) {
+        if (error?.code === 'ENOENT') temporaryExists = false;
+        else if (!cleanupError) cleanupError = error;
+      }
+    }
+    if (cleanupError) throw cleanupError;
+  };
+  return Object.freeze({
+    artifactPath,
+    temporaryPath,
+    publish(artifact) {
+      try {
+        writeFileSync(descriptor, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8');
+        fsyncSync(descriptor);
+        close();
+        linkSync(temporaryPath, artifactPath);
+        unlinkSync(temporaryPath);
+        temporaryExists = false;
+      } catch (error) {
+        discard();
+        throw error;
+      }
+    },
+    discard,
+  });
+}
+
+export async function writeFixtureArtifactAfterTransition(path, transition) {
+  const reservation = reserveFixtureArtifact(path);
+  try {
+    const artifact = await transition();
+    reservation.publish(artifact);
+    return artifact;
+  } catch (error) {
+    reservation.discard();
+    throw error;
+  }
+}
+
 async function main() {
   const command = process.argv[2] ?? 'status';
   if (
@@ -121,17 +228,17 @@ async function main() {
       )
     : undefined;
   if (command === 'fixture-apply' || command === 'fixture-restore') {
-    const token = protectedToken(
-      process.env.DNSOPS_FIXTURE_CONTROL_SECRET_FILE ??
-        `${process.env.HOME}/.config/dns-ops/fixture-control.env`,
-      'DNSOPS_FIXTURE_CONTROL_TOKEN'
-    );
-    const adapter = createFixtureControlAdapter({ manifest, token });
-    const artifact =
-      command === 'fixture-apply'
-        ? await adapter.apply(process.argv[3])
-        : await adapter.restore(fixtureRecoveryArtifact);
-    writeArtifact(process.argv[4], artifact);
+    const artifact = await writeFixtureArtifactAfterTransition(process.argv[4], async () => {
+      const token = protectedToken(
+        process.env.DNSOPS_FIXTURE_CONTROL_SECRET_FILE ??
+          `${process.env.HOME}/.config/dns-ops/fixture-control.env`,
+        'DNSOPS_FIXTURE_CONTROL_TOKEN'
+      );
+      const adapter = createFixtureControlAdapter({ manifest, token });
+      return command === 'fixture-apply'
+        ? adapter.apply(process.argv[3])
+        : adapter.restore(fixtureRecoveryArtifact);
+    });
     console.log(
       JSON.stringify({
         status:


### PR DESCRIPTION
Accepts the actual nested Railway domain-status response shape while retaining strict ID/name/verification-host validation. This fix was confirmed by the provisioner writing its protected local runtime file without exposing values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix parsing of Railway domain verification and add fail-closed LIVE-01/02 fixture controls with atomic, race-safe recovery artifact handling.

- **New Features**
  - Added `fixture-apply` and `fixture-restore` commands with an isolated adapter that pins the control endpoint and allowed modes, requires healthy GET readbacks before/after POST transitions, and aborts on mismatch.
  - Reads the fixture token only after argument/recovery validation, stores only a SHA-256 fingerprint, and writes mode-600 artifacts with timestamps and HTTP summaries (no token or bodies).
  - Reserves the recovery artifact path before any fixture request and publishes via an atomic link; rejects invalid or pre-existing destinations and never replaces a concurrently written output.

- **Bug Fixes**
  - Accept nested `domain` and `verification` objects in the Railway response.
  - Validate domain ID, name, and verification host; reject unsafe tokens.
  - Fallback to TXT `dnsRecords` when `verification` is missing.

<sup>Written for commit 66817bfbb0d0cc513c026f314f2fac1f2f3734eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

