### PR TITLE
Preserve redacted LIVE-01/02 execution artifacts

### DIFF
--- a/docs/domain-operations/evidence/gate-3/asorin-live-01-02-web-bootstrap.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-01-02-web-bootstrap.json
@@ -1,0 +1,24 @@
+{
+  "kind": "CLOUDFLARE_LIVE01_02_WEB_BOOTSTRAP",
+  "manifestId": "ASORIN-AI-CONTROLLED-LIVE-01-03",
+  "zoneId": "7391960081e72b26c9c5066133013ab2",
+  "providerCredentialFingerprint": "sha256:17fe70271d1013db5ef7fffa31f6ea68e98a2a0040300a3acb3ee96e4b9bfd8f",
+  "targetNames": [
+    "asorin.ai",
+    "www.asorin.ai",
+    "_railway-verify.asorin.ai",
+    "_railway-verify.www.asorin.ai"
+  ],
+  "baselineHash": "sha256:74c75dc9ac48d95293fcc8333ae3ed135f33148da227fed498c6e0f7cafdfc3f",
+  "providerResponses": [
+    "cloudflare.web_zone_bootstrap: 200",
+    "cloudflare.web_dns_bootstrap_read: 200",
+    "cloudflare.web_dns_bootstrap_create: 200",
+    "cloudflare.web_dns_bootstrap_read: 200",
+    "cloudflare.web_dns_bootstrap_create: 200",
+    "cloudflare.web_dns_bootstrap_read: 200",
+    "cloudflare.web_dns_bootstrap_create: 200",
+    "cloudflare.web_dns_bootstrap_read: 200",
+    "cloudflare.web_dns_bootstrap_create: 200"
+  ]
+}

--- a/docs/domain-operations/evidence/gate-3/asorin-live-01-fixture-apply.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-01-fixture-apply.json
@@ -1,0 +1,19 @@
+{
+  "kind": "FIXTURE_LIVE01_02_FAULT",
+  "runId": "67aeefd1-5af9-4bc9-bf5f-afe448d6e6f8",
+  "manifestId": "ASORIN-AI-CONTROLLED-LIVE-01-03",
+  "fixtureEndpoint": "https://asorin.ai/__dnsops/live-mode",
+  "mutationId": "LIVE-01",
+  "targetNames": [
+    "www.asorin.ai"
+  ],
+  "baselineHash": "sha256:6260efb46b74d4d25d21e01c57ee8b02789adf31139a5eed2c6ff7d5de5f7a6e",
+  "fixtureControlCredentialFingerprint": "sha256:759c8178cc299ccbcad760bf5cbbad9fab2d7f4c1792a2025a6a5f1e2ad198a7",
+  "appliedAt": "2026-08-05T17:18:16.140Z",
+  "fixtureResponses": [
+    "fixture.mode_apply_before_readback: 200",
+    "fixture.mode_apply: 200",
+    "fixture.mode_apply_after_readback: 200"
+  ],
+  "result": "RECOVERY_REQUIRED"
+}

--- a/docs/domain-operations/evidence/gate-3/asorin-live-01-fixture-restored.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-01-fixture-restored.json
@@ -1,0 +1,23 @@
+{
+  "kind": "FIXTURE_LIVE01_02_FAULT",
+  "runId": "67aeefd1-5af9-4bc9-bf5f-afe448d6e6f8",
+  "manifestId": "ASORIN-AI-CONTROLLED-LIVE-01-03",
+  "fixtureEndpoint": "https://asorin.ai/__dnsops/live-mode",
+  "mutationId": "LIVE-01",
+  "targetNames": [
+    "www.asorin.ai"
+  ],
+  "baselineHash": "sha256:6260efb46b74d4d25d21e01c57ee8b02789adf31139a5eed2c6ff7d5de5f7a6e",
+  "fixtureControlCredentialFingerprint": "sha256:759c8178cc299ccbcad760bf5cbbad9fab2d7f4c1792a2025a6a5f1e2ad198a7",
+  "appliedAt": "2026-08-05T17:18:16.140Z",
+  "fixtureResponses": [
+    "fixture.mode_apply_before_readback: 200",
+    "fixture.mode_apply: 200",
+    "fixture.mode_apply_after_readback: 200",
+    "fixture.mode_restore_before_readback: 200",
+    "fixture.mode_restore: 200",
+    "fixture.mode_restore_after_readback: 200"
+  ],
+  "result": "RESTORED",
+  "restoredAt": "2026-08-05T17:18:16.928Z"
+}

--- a/docs/domain-operations/evidence/gate-3/asorin-live-02-fixture-apply.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-02-fixture-apply.json
@@ -1,0 +1,19 @@
+{
+  "kind": "FIXTURE_LIVE01_02_FAULT",
+  "runId": "06d7b033-dc8d-4c6e-9f5a-8186cf51e282",
+  "manifestId": "ASORIN-AI-CONTROLLED-LIVE-01-03",
+  "fixtureEndpoint": "https://asorin.ai/__dnsops/live-mode",
+  "mutationId": "LIVE-02",
+  "targetNames": [
+    "asorin.ai"
+  ],
+  "baselineHash": "sha256:6260efb46b74d4d25d21e01c57ee8b02789adf31139a5eed2c6ff7d5de5f7a6e",
+  "fixtureControlCredentialFingerprint": "sha256:759c8178cc299ccbcad760bf5cbbad9fab2d7f4c1792a2025a6a5f1e2ad198a7",
+  "appliedAt": "2026-08-05T17:18:27.373Z",
+  "fixtureResponses": [
+    "fixture.mode_apply_before_readback: 200",
+    "fixture.mode_apply: 200",
+    "fixture.mode_apply_after_readback: 200"
+  ],
+  "result": "RECOVERY_REQUIRED"
+}

--- a/docs/domain-operations/evidence/gate-3/asorin-live-02-fixture-restored.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-02-fixture-restored.json
@@ -1,0 +1,23 @@
+{
+  "kind": "FIXTURE_LIVE01_02_FAULT",
+  "runId": "06d7b033-dc8d-4c6e-9f5a-8186cf51e282",
+  "manifestId": "ASORIN-AI-CONTROLLED-LIVE-01-03",
+  "fixtureEndpoint": "https://asorin.ai/__dnsops/live-mode",
+  "mutationId": "LIVE-02",
+  "targetNames": [
+    "asorin.ai"
+  ],
+  "baselineHash": "sha256:6260efb46b74d4d25d21e01c57ee8b02789adf31139a5eed2c6ff7d5de5f7a6e",
+  "fixtureControlCredentialFingerprint": "sha256:759c8178cc299ccbcad760bf5cbbad9fab2d7f4c1792a2025a6a5f1e2ad198a7",
+  "appliedAt": "2026-08-05T17:18:27.373Z",
+  "fixtureResponses": [
+    "fixture.mode_apply_before_readback: 200",
+    "fixture.mode_apply: 200",
+    "fixture.mode_apply_after_readback: 200",
+    "fixture.mode_restore_before_readback: 200",
+    "fixture.mode_restore: 200",
+    "fixture.mode_restore_after_readback: 200"
+  ],
+  "result": "RESTORED",
+  "restoredAt": "2026-08-05T17:18:28.103Z"
+}


### PR DESCRIPTION
Adds redacted, non-secret Cloudflare bootstrap and fixture apply/restore artifacts for the completed LIVE-01/02 harness runs. These prove harness recovery only; independent DNS Ops scan/signal/case/audit evidence remains required for PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves redacted, non-secret evidence from LIVE-01 and LIVE-02 harness runs. Adds JSON artifacts for Cloudflare web bootstrap and fixture apply/restore under docs/domain-operations/evidence/gate-3; these prove harness recovery only, and DNS Ops scan/signal/case/audit evidence is still required for PASS.

<sup>Written for commit 7eb07d7decec25eebde5eaf1630e0850a7b0eccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

