### PR TITLE
Redact historical production credential

### DIFF
--- a/sessions/2026-05-04_session-web-deployment-rollercoaster.md
+++ b/sessions/2026-05-04_session-web-deployment-rollercoaster.md
@@ -138,6 +138,6 @@
 - **Current repo state:** `master` branch, `aaa2ccd3` is HEAD. Dockerfile + railway.toml exist. `.output/` is NOT in git.
 - **Collector is healthy:** `https://dns-ops-production.up.railway.app` — use it for `COLLECTOR_URL`.
 - **Postgres is healthy:** service ID `edec61ed-1585-4210-a6d8-86d27f72f5dc`.
-- **Previous login credentials:** `antonio.correa@gmail.com` / `sW0uK44xoGdYm@56GNXDZP%g` (seeded in production DB).
+- Historical production credentials were removed. Use approved runtime-only secret management and rotate any previously exposed value.
 - **Avoid:** Railpack builder, committing `.output/`, root `railway.toml`, `railpack.json`.
 - **Prefer:** Dockerfile builder, dashboard for service creation, API tokens for headless ops.


### PR DESCRIPTION
Removes an obsolete plaintext credential from a tracked historical deployment note. The value is not reproduced. Any previously exposed value must be rotated through approved secret management.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacted an obsolete plaintext production credential from a historical deployment note to remove sensitive data from the repo. Added guidance to use runtime-only secret management and rotate any previously exposed value.

<sup>Written for commit a8547d851590681e9599fdf508661d36517f1828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

