### PR TITLE
Link DNS Ops source probe in checkpoint

### DIFF
--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -78,7 +78,7 @@
     },
     {
       "command": "bun run --filter @dns-ops/db check-drift",
-      "result": "No schema drift after migrations 0015–0020 operational baselines, case versioning, MCP command idempotency, and schema-exported session tables"
+      "result": "No schema drift after migrations 0015\u20130020 operational baselines, case versioning, MCP command idempotency, and schema-exported session tables"
     },
     {
       "command": "DATABASE_URL=<isolated> bun run --filter @dns-ops/db verify-migrations",
@@ -114,7 +114,8 @@
       "docs/domain-operations/evidence/gate-3/asorin-live-02-fixture-restored.json",
       "docs/domain-operations/evidence/gate-3/asorin-live-01-02-authoritative-web.json",
       "docs/domain-operations/evidence/gate-3/asorin-live-03-authoritative-restoration.json",
-      "docs/domain-operations/evidence/gate-3/asorin-live-03-restored-pending-evidence.json"
+      "docs/domain-operations/evidence/gate-3/asorin-live-03-restored-pending-evidence.json",
+      "docs/domain-operations/evidence/gate-3/dns-ops-evidence-source-probe.json"
     ],
     "missingForPass": [
       "Timestamp-correlated MCP scan task/result IDs for every LIVE fault and restoration",


### PR DESCRIPTION
Adds the merged redacted evidence-source probe to the checkpoint durable-evidence inventory. PASS remains explicitly pending independent DNS Ops evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linked the redacted DNS Ops evidence-source probe to the checkpoint’s durable-evidence inventory by adding docs/domain-operations/evidence/gate-3/dns-ops-evidence-source-probe.json. PASS remains pending until independent DNS Ops evidence is provided.

<sup>Written for commit 5fe2d29b764c261d00601994f7786d879ccf7512. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

