### PR TITLE
Link operational PASS manifest in checkpoint

### DIFF
--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -115,7 +115,8 @@
       "docs/domain-operations/evidence/gate-3/asorin-live-01-02-authoritative-web.json",
       "docs/domain-operations/evidence/gate-3/asorin-live-03-authoritative-restoration.json",
       "docs/domain-operations/evidence/gate-3/asorin-live-03-restored-pending-evidence.json",
-      "docs/domain-operations/evidence/gate-3/dns-ops-evidence-source-probe.json"
+      "docs/domain-operations/evidence/gate-3/dns-ops-evidence-source-probe.json",
+      "docs/domain-operations/evidence/gate-3/asorin-operational-pass-evidence-manifest.json"
     ],
     "missingForPass": [
       "Timestamp-correlated MCP scan task/result IDs for every LIVE fault and restoration",


### PR DESCRIPTION
Links the merged scenario-by-scenario operational PASS evidence manifest from the checkpoint durable-evidence inventory. No scenario status changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linked the merged scenario-by-scenario operational PASS evidence manifest in the Gate 3 checkpoint so it references the complete durable-evidence inventory. No scenario status changes.

<sup>Written for commit 6fc7d875cb6e7daf5f12e3d307887e2dafc1f3f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

