### PR TITLE
docs: clarify LIVE-01 alert evidence access

### DIFF
--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -125,7 +125,7 @@
       "Canonical case IDs, dispositions, versions, and LIVE-01 reopen proof",
       "Audit IDs for scan, signal, case, and restoration lifecycle",
       "An approved tenant-scoped audit evidence path, or an explicit decision that case_get lifecycle events satisfy the audit-ID requirement",
-      "An approved tenant-scoped alert evidence path for LIVE-01 reopen deduplication, or an explicit PASS-contract revision",
+      "An authorized tenant-scoped web-session read path for GET /api/alerts to verify LIVE-01 reopen alert deduplication",
       "An authorized DNS Ops MCP endpoint and principal with required scopes"
     ]
   },
@@ -134,7 +134,7 @@
     "Founder-verified portfolio selection, purpose, criticality, and observation-only classifications",
     "Authorized DNS Ops MCP endpoint and runtime-only principal with DOMAIN_READ, SIGNAL_READ, CASE_READ, CASE_WRITE, and SCAN_REQUEST scopes",
     "Timestamp-correlated DNS Ops scan, signal, case, audit, restoration, and LIVE-01 reopen evidence",
-    "Approved tenant-scoped audit and LIVE-01 alert-deduplication evidence access, or explicit PASS-contract decisions documented in asorin-mcp-operational-evidence-access-gap.json",
+    "Approved tenant-scoped audit evidence access (or explicit audit-ID decision) and authorized web-session access to GET /api/alerts for LIVE-01 alert deduplication, as documented in asorin-mcp-operational-evidence-access-gap.json",
     "Founder calibration and approval of the six required operational playbooks"
   ],
   "materialDecisions": [
@@ -158,8 +158,8 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Obtain authorized DNS Ops MCP access plus an approved audit and LIVE-01 alert-deduplication evidence path (or explicit contract decisions); collect and independently verify scan, signal, case, audit, restoration, and reopen evidence for every controlled scenario",
+    "Obtain authorized DNS Ops MCP access, an approved audit evidence path (or explicit audit-ID decision), and authorized web-session GET /api/alerts access; collect and independently verify scan, signal, case, audit, restoration, and reopen evidence for every controlled scenario",
     "Retain LIVE-01, LIVE-02, and LIVE-03 as pending until the checkpoint's missingForPass evidence is durable and correlated"
   ],
-  "updatedAt": "2026-08-05T19:39:29Z"
+  "updatedAt": "2026-08-05T19:46:14Z"
 }

--- a/docs/domain-operations/evidence/gate-3/asorin-mcp-operational-evidence-access-gap.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-mcp-operational-evidence-access-gap.json
@@ -1,18 +1,20 @@
 {
   "evidenceId": "GATE3-ASORIN-MCP-OPERATIONAL-EVIDENCE-ACCESS-GAP",
   "status": "BLOCKED_BY_EXTERNAL_EVIDENCE_ACCESS_DECISION",
-  "observedAt": "2026-08-05T19:39:29Z",
+  "observedAt": "2026-08-05T19:46:14Z",
   "purpose": "Static, secret-free reconciliation of the operational PASS manifest against the approved closed-world MCP contract. It identifies read-path evidence that cannot be independently retrieved through the ten approved MCP tools.",
   "reviewedRevision": "de2400567fc0b6799c0b8f4cf04f702c52d7657c",
   "reviewedSources": [
     "apps/web/hono/lib/mcp-tools.ts",
     "apps/web/hono/lib/mcp-read-service.ts",
     "packages/db/src/repos/portfolio.ts",
+    "apps/web/hono/routes/alerts.ts",
     "docs/domain-operations/evidence/gate-3/asorin-operational-pass-evidence-manifest.json"
   ],
   "confirmedMcpReadPaths": {
     "snapshotEvidence": "evidence_get returns snapshot, record sets, findings, and probe observations.",
     "signalsAndCases": "signal_list returns tenant-scoped signal/case pairs; case_get returns a tenant-scoped case, signal, and ordered internal case lifecycle events.",
+    "alertsOutsideMcp": "The existing authenticated web API exposes tenant-scoped alert reads at GET /api/alerts and GET /api/alerts/:id. These routes require normal web-session authentication and are intentionally outside the closed MCP contract.",
     "closedToolInventory": [
       "domain_search",
       "domain_get_profile",
@@ -35,11 +37,11 @@
     },
     {
       "requirement": "LIVE-01 reapplication proof that the canonical condition reopened without a duplicate active case or alert",
-      "observation": "The approved MCP inventory contains no alert read/list tool. domain_get_posture, signal_list, and case_get expose signals and cases, but no alert records. The manifest's alert-deduplication proof therefore cannot be independently retrieved through the approved MCP tools.",
-      "requiredResolution": "Provide an approved tenant-scoped alert export/read path that can correlate alerts to the canonical condition and reopen cycle, or explicitly revise the PASS contract."
+      "observation": "The approved MCP inventory contains no alert read/list tool. domain_get_posture, signal_list, and case_get expose signals and cases, but no alert records. The existing tenant-scoped GET /api/alerts web API can provide the required alert records, but it requires an authorized web-session principal and is not available to the MCP bearer principal.",
+      "requiredResolution": "Authorize a tenant-scoped web-session read path for GET /api/alerts with the correlation procedure recorded in the redacted artifact, or explicitly approve a different alert evidence path."
     }
   ],
-  "passImpact": "Every LIVE scenario remains PENDING_EXTERNAL_DNS_OPS_EVIDENCE. LIVE-01 additionally cannot satisfy its reopen no-duplicate-alert proof until the alert evidence path or an explicit contract decision is supplied.",
+  "passImpact": "Every LIVE scenario remains PENDING_EXTERNAL_DNS_OPS_EVIDENCE. LIVE-01 additionally cannot satisfy its reopen no-duplicate-alert proof until an authorized tenant-scoped alert read path is supplied.",
   "notPerformed": [
     "No MCP endpoint was contacted.",
     "No MCP bearer secret, endpoint, domain ID, tenant ID, actor ID, or audit/alert value was accessed or recorded.",


### PR DESCRIPTION
## Summary
- correct the operational evidence access record: authenticated tenant-scoped alert reads already exist at `GET /api/alerts`
- distinguish unavailable MCP alert reads from the required authorized web-session handoff
- keep every scenario pending and preserve the separate generic audit-read decision

## Validation
- `jq empty docs/domain-operations/checkpoints/current-state.json docs/domain-operations/evidence/gate-3/asorin-mcp-operational-evidence-access-gap.json`
- `git diff --check`

No endpoint, credential, scan, case action, DNS query, provider action, Railway action, or deployment was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified LIVE-01 alert evidence access in ops docs: tenant-scoped alert reads are available via authorized web-session at `GET /api/alerts` (not via MCP) and are required to verify reopen deduplication. All LIVE scenarios remain pending; audit evidence access stays a separate, unchanged decision.

<sup>Written for commit 5df7d8bbdbccf71ed23b39a7c08ca2a313f71b14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

