### PR TITLE
docs: clarify audit evidence access

### DIFF
--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -124,7 +124,7 @@
       "Expected signal IDs and statuses",
       "Canonical case IDs, dispositions, versions, and LIVE-01 reopen proof",
       "Audit IDs for scan, signal, case, and restoration lifecycle",
-      "An approved tenant-scoped audit evidence path, or an explicit decision that case_get lifecycle events satisfy the audit-ID requirement",
+      "An authorized tenant-scoped web-session read path for GET /api/portfolio/audit to retrieve audit evidence",
       "An authorized tenant-scoped web-session read path for GET /api/alerts to verify LIVE-01 reopen alert deduplication",
       "An authorized DNS Ops MCP endpoint and principal with required scopes"
     ]
@@ -134,7 +134,7 @@
     "Founder-verified portfolio selection, purpose, criticality, and observation-only classifications",
     "Authorized DNS Ops MCP endpoint and runtime-only principal with DOMAIN_READ, SIGNAL_READ, CASE_READ, CASE_WRITE, and SCAN_REQUEST scopes",
     "Timestamp-correlated DNS Ops scan, signal, case, audit, restoration, and LIVE-01 reopen evidence",
-    "Approved tenant-scoped audit evidence access (or explicit audit-ID decision) and authorized web-session access to GET /api/alerts for LIVE-01 alert deduplication, as documented in asorin-mcp-operational-evidence-access-gap.json",
+    "Authorized tenant-scoped web-session access to GET /api/portfolio/audit for audit evidence and GET /api/alerts for LIVE-01 alert deduplication, as documented in asorin-mcp-operational-evidence-access-gap.json",
     "Founder calibration and approval of the six required operational playbooks"
   ],
   "materialDecisions": [
@@ -158,8 +158,8 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Obtain authorized DNS Ops MCP access, an approved audit evidence path (or explicit audit-ID decision), and authorized web-session GET /api/alerts access; collect and independently verify scan, signal, case, audit, restoration, and reopen evidence for every controlled scenario",
+    "Obtain authorized DNS Ops MCP access plus authorized web-session GET /api/portfolio/audit and GET /api/alerts access; collect and independently verify scan, signal, case, audit, restoration, and reopen evidence for every controlled scenario",
     "Retain LIVE-01, LIVE-02, and LIVE-03 as pending until the checkpoint's missingForPass evidence is durable and correlated"
   ],
-  "updatedAt": "2026-08-05T19:46:14Z"
+  "updatedAt": "2026-08-05T19:50:55Z"
 }

--- a/docs/domain-operations/evidence/gate-3/asorin-mcp-operational-evidence-access-gap.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-mcp-operational-evidence-access-gap.json
@@ -1,19 +1,21 @@
 {
   "evidenceId": "GATE3-ASORIN-MCP-OPERATIONAL-EVIDENCE-ACCESS-GAP",
-  "status": "BLOCKED_BY_EXTERNAL_EVIDENCE_ACCESS_DECISION",
-  "observedAt": "2026-08-05T19:46:14Z",
-  "purpose": "Static, secret-free reconciliation of the operational PASS manifest against the approved closed-world MCP contract. It identifies read-path evidence that cannot be independently retrieved through the ten approved MCP tools.",
-  "reviewedRevision": "de2400567fc0b6799c0b8f4cf04f702c52d7657c",
+  "status": "BLOCKED_BY_EXTERNAL_EVIDENCE_ACCESS",
+  "observedAt": "2026-08-05T19:50:55Z",
+  "purpose": "Static, secret-free reconciliation of the operational PASS manifest against the approved closed-world MCP contract. It identifies audit and alert evidence that is intentionally outside MCP and therefore requires an authorized web-session read path.",
+  "reviewedRevision": "0f74d02265c231b618b9140de888f873e33a1cf5",
   "reviewedSources": [
     "apps/web/hono/lib/mcp-tools.ts",
     "apps/web/hono/lib/mcp-read-service.ts",
     "packages/db/src/repos/portfolio.ts",
+    "apps/web/hono/routes/portfolio.ts",
     "apps/web/hono/routes/alerts.ts",
     "docs/domain-operations/evidence/gate-3/asorin-operational-pass-evidence-manifest.json"
   ],
   "confirmedMcpReadPaths": {
     "snapshotEvidence": "evidence_get returns snapshot, record sets, findings, and probe observations.",
     "signalsAndCases": "signal_list returns tenant-scoped signal/case pairs; case_get returns a tenant-scoped case, signal, and ordered internal case lifecycle events.",
+    "auditOutsideMcp": "The existing authenticated web API exposes tenant-scoped audit reads at GET /api/portfolio/audit. This route requires normal web-session authentication and is intentionally outside the closed MCP contract.",
     "alertsOutsideMcp": "The existing authenticated web API exposes tenant-scoped alert reads at GET /api/alerts and GET /api/alerts/:id. These routes require normal web-session authentication and are intentionally outside the closed MCP contract.",
     "closedToolInventory": [
       "domain_search",
@@ -31,9 +33,8 @@
   "gaps": [
     {
       "requirement": "Audit IDs for fault, case, and restoration lifecycle evidence across LIVE-01, LIVE-02, and LIVE-03",
-      "observation": "The approved MCP inventory contains no generic audit read tool. evidence_get does not return audit records. AuditEventRepository can query tenant/entity/actor audit records internally, but this repository capability is not exposed by an approved MCP or HTTP read contract in the reviewed sources.",
-      "nonAssumption": "Internal case lifecycle event IDs returned by case_get are not treated as equivalent to the manifest's audit IDs without an explicit owner decision.",
-      "requiredResolution": "Provide an approved tenant-scoped audit export/read path with attributable, timestamped records, or explicitly declare which case_get lifecycle event IDs satisfy each audit requirement."
+      "observation": "The approved MCP inventory contains no generic audit read tool and evidence_get does not return audit records. The existing tenant-scoped GET /api/portfolio/audit web API returns audit records, but it requires an authorized web-session principal and is not available to the MCP bearer principal.",
+      "requiredResolution": "Authorize a tenant-scoped web-session read path for GET /api/portfolio/audit with the correlation procedure recorded in the redacted artifact."
     },
     {
       "requirement": "LIVE-01 reapplication proof that the canonical condition reopened without a duplicate active case or alert",
@@ -41,7 +42,7 @@
       "requiredResolution": "Authorize a tenant-scoped web-session read path for GET /api/alerts with the correlation procedure recorded in the redacted artifact, or explicitly approve a different alert evidence path."
     }
   ],
-  "passImpact": "Every LIVE scenario remains PENDING_EXTERNAL_DNS_OPS_EVIDENCE. LIVE-01 additionally cannot satisfy its reopen no-duplicate-alert proof until an authorized tenant-scoped alert read path is supplied.",
+  "passImpact": "Every LIVE scenario remains PENDING_EXTERNAL_DNS_OPS_EVIDENCE until the required MCP principal and authorized tenant-scoped web-session reads for audit and alert evidence are supplied. LIVE-01 additionally requires the alert read to prove reopen deduplication.",
   "notPerformed": [
     "No MCP endpoint was contacted.",
     "No MCP bearer secret, endpoint, domain ID, tenant ID, actor ID, or audit/alert value was accessed or recorded.",


### PR DESCRIPTION
## Summary
- correct the access-gap record: authenticated tenant-scoped audit reads exist at `GET /api/portfolio/audit`
- distinguish unavailable MCP audit reads from the required authorized web-session handoff
- retain pending status for all LIVE scenarios and the required alert web-session access

## Validation
- `jq empty docs/domain-operations/checkpoints/current-state.json docs/domain-operations/evidence/gate-3/asorin-mcp-operational-evidence-access-gap.json`
- `git diff --check`

No endpoint, credential, scan, case action, DNS query, provider action, Railway action, or deployment was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies audit evidence access in ops docs: tenant-scoped audit reads are available at GET /api/portfolio/audit and, like alerts, sit outside MCP and require an authorized web session.
Updates current-state and access-gap artifacts accordingly and keeps all LIVE scenarios pending until the MCP principal and web-session reads for audit and alerts are approved.

<sup>Written for commit 95a04f2191acf06f98f1963c30893bb99e126e06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

