### PR TITLE
feat: preflight authenticated web evidence reads

### DIFF
--- a/scripts/controlled-live-harness.test.mjs
+++ b/scripts/controlled-live-harness.test.mjs
@@ -21,10 +21,13 @@ import {
 } from '../tools/controlled-live-harness/fixture-control.mjs';
 import {
   loadManifest,
+  loadWebEvidencePreflightSecret,
   policyFromManifest,
   protectedToken,
   protectedValues,
   reserveFixtureArtifact,
+  runWebEvidencePreflight,
+  validateWebEvidenceEndpoint,
   writeArtifact,
   writeFixtureArtifactAfterTransition,
 } from '../tools/controlled-live-harness/runner.mjs';
@@ -270,6 +273,138 @@ test('fixture artifacts are written mode 600', () => {
   const path = join(mkdtempSync(join(tmpdir(), 'dnsops-')), 'fixture-artifact.json');
   writeArtifact(path, { status: 'redacted' });
   assert.equal(statSync(path).mode & 0o777, 0o600);
+});
+
+test('web evidence preflight pins a public HTTPS endpoint, accepts only the scoped session format, and redacts its artifact', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'dnsops-'));
+  const secretPath = join(directory, 'web-evidence.env');
+  const artifactPath = join(directory, 'web-evidence-preflight.json');
+  const sessionToken = 'a'.repeat(64);
+  writeFileSync(
+    secretPath,
+    [
+      "export DNSOPS_WEB_EVIDENCE_ENDPOINT='https://evidence.example'",
+      `export DNSOPS_WEB_EVIDENCE_SESSION_TOKEN='${sessionToken}'`,
+      '',
+    ].join('\n'),
+    { mode: 0o600 }
+  );
+  chmodSync(secretPath, 0o600);
+  const calls = [];
+  const artifact = await runWebEvidencePreflight({
+    secretFile: secretPath,
+    artifactPath,
+    resolveHostname: async () => [{ address: '8.8.8.8', family: 4 }],
+    fetchImpl: async (endpoint, init) => {
+      calls.push({ endpoint, init });
+      await new Promise((resolve, reject) =>
+        init.lookup('evidence.example', { family: 4 }, (error, address, family) => {
+          if (error) reject(error);
+          else {
+            assert.equal(address, '8.8.8.8');
+            assert.equal(family, 4);
+            resolve();
+          }
+        })
+      );
+      if (endpoint.pathname === '/api/portfolio/audit')
+        return { ok: true, status: 200, json: async () => ({ events: [{ private: 'value' }] }) };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ alerts: [{ private: 'value' }], pagination: { total: 1 } }),
+      };
+    },
+  });
+  assert.equal(artifact.status, 'WEB_EVIDENCE_PREFLIGHT_OK');
+  assert.deepEqual(artifact.verifiedReadPaths, [
+    'GET /api/portfolio/audit: 200',
+    'GET /api/alerts: 200',
+  ]);
+  assert.equal(statSync(artifactPath).mode & 0o777, 0o600);
+  const serialized = readFileSync(artifactPath, 'utf8');
+  assert.equal(serialized.includes(sessionToken), false);
+  assert.equal(serialized.includes('private'), false);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(
+    calls.map(({ endpoint }) => `${endpoint.pathname}${endpoint.search}`),
+    ['/api/portfolio/audit?limit=1', '/api/alerts?limit=1']
+  );
+  assert.equal(calls[0].init.headers.Cookie, `dns_ops_session=${sessionToken}`);
+  assert.equal(calls[1].init.headers.Cookie, `dns_ops_session=${sessionToken}`);
+});
+
+test('web evidence preflight rejects a missing artifact path before reading its session secret', () => {
+  const runner = fileURLToPath(
+    new URL('../tools/controlled-live-harness/runner.mjs', import.meta.url)
+  );
+  const result = spawnSync(process.execPath, [runner, 'web-evidence-preflight'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DNSOPS_WEB_EVIDENCE_SECRET_FILE: '/definitely-not-readable/web-evidence.env',
+    },
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /requires one output artifact path/);
+  assert.doesNotMatch(result.stderr, /secret file/);
+});
+
+test('web evidence preflight rejects unsafe origins and response shapes without publishing an artifact', async () => {
+  assert.throws(() => validateWebEvidenceEndpoint('https://127.0.0.1'), /web evidence endpoint/);
+  assert.throws(() => validateWebEvidenceEndpoint('https://evidence.example/api'), /web evidence endpoint/);
+  const directory = mkdtempSync(join(tmpdir(), 'dnsops-'));
+  const secretPath = join(directory, 'web-evidence.env');
+  const artifactPath = join(directory, 'web-evidence-preflight.json');
+  const existingArtifactPath = join(directory, 'existing-artifact.json');
+  writeFileSync(existingArtifactPath, 'existing artifact\n', { mode: 0o600 });
+  await assert.rejects(
+    runWebEvidencePreflight({
+      secretFile: '/definitely-not-readable/web-evidence.env',
+      artifactPath: existingArtifactPath,
+      fetchImpl: async () => {
+        throw new Error('network must not run');
+      },
+    }),
+    /output artifact path already exists/
+  );
+  assert.equal(readFileSync(existingArtifactPath, 'utf8'), 'existing artifact\n');
+  writeFileSync(
+    secretPath,
+    [
+      "export DNSOPS_WEB_EVIDENCE_ENDPOINT='https://evidence.example'",
+      `export DNSOPS_WEB_EVIDENCE_SESSION_TOKEN='${'B'.repeat(64)}'`,
+      '',
+    ].join('\n'),
+    { mode: 0o600 }
+  );
+  chmodSync(secretPath, 0o600);
+  assert.throws(() => loadWebEvidencePreflightSecret(secretPath), /session token is invalid/);
+  writeFileSync(
+    secretPath,
+    [
+      "export DNSOPS_WEB_EVIDENCE_ENDPOINT='https://evidence.example'",
+      `export DNSOPS_WEB_EVIDENCE_SESSION_TOKEN='${'b'.repeat(64)}'`,
+      '',
+    ].join('\n'),
+    { mode: 0o600 }
+  );
+  let calls = 0;
+  await assert.rejects(
+    runWebEvidencePreflight({
+      secretFile: secretPath,
+      artifactPath,
+      resolveHostname: async () => [{ address: '8.8.8.8', family: 4 }],
+      fetchImpl: async () => {
+        calls += 1;
+        return { ok: true, status: 200, json: async () => ({ events: 'not-an-array' }) };
+      },
+    }),
+    /web evidence .*failed/
+  );
+  assert.equal(calls, 1);
+  assert.equal(existsSync(artifactPath), false);
+  assert.deepEqual(readdirSync(directory).sort(), ['existing-artifact.json', 'web-evidence.env']);
 });
 
 test('fixture output preflight rejects invalid or existing destinations before any fixture fetch', async () => {

--- a/tools/controlled-live-harness/runner.mjs
+++ b/tools/controlled-live-harness/runner.mjs
@@ -40,6 +40,10 @@ const fail = (message) => {
 };
 
 const MCP_PREFLIGHT_SECRET_NAMES = ['DNSOPS_MCP_ENDPOINT', 'DNSOPS_MCP_BEARER_TOKEN'];
+const WEB_EVIDENCE_PREFLIGHT_SECRET_NAMES = [
+  'DNSOPS_WEB_EVIDENCE_ENDPOINT',
+  'DNSOPS_WEB_EVIDENCE_SESSION_TOKEN',
+];
 const REQUIRED_MCP_TOOLS = Object.freeze([
   ['domain_search', 'DOMAIN_READ'],
   ['domain_get_profile', 'DOMAIN_READ'],
@@ -147,6 +151,66 @@ export function loadMcpPreflightSecret(path) {
   return Object.freeze({
     endpoint: validateMcpEndpoint(values.DNSOPS_MCP_ENDPOINT),
     token: values.DNSOPS_MCP_BEARER_TOKEN,
+  });
+}
+
+/** Validates the HTTPS origin that serves authenticated, read-only evidence routes. */
+export function validateWebEvidenceEndpoint(value) {
+  if (typeof value !== 'string' || !value) fail('web evidence endpoint is invalid');
+  let endpoint;
+  try {
+    endpoint = new URL(value);
+  } catch {
+    fail('web evidence endpoint is invalid');
+  }
+  if (
+    endpoint.protocol !== 'https:' ||
+    endpoint.username ||
+    endpoint.password ||
+    endpoint.port ||
+    endpoint.pathname !== '/' ||
+    endpoint.search ||
+    endpoint.hash
+  )
+    fail('web evidence endpoint is invalid');
+
+  // Reuse MCP's hostname policy by constructing a synthetic /mcp target. This
+  // validates only the origin; the synthetic path is never contacted here.
+  let validatedMcpOrigin;
+  try {
+    validatedMcpOrigin = validateMcpEndpoint(new URL('/mcp', endpoint).toString());
+  } catch {
+    fail('web evidence endpoint is invalid');
+  }
+  return new URL('/', validatedMcpOrigin);
+}
+
+/** Reads the separately supplied, isolated web-session runtime secret. */
+export function loadWebEvidencePreflightSecret(path) {
+  if (!path || typeof path !== 'string' || !isAbsolute(path))
+    fail('web evidence preflight requires an explicit secret file path');
+  let contents;
+  try {
+    contents = readProtectedSecretFile(path, 'runtime secret file must be mode 600');
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === 'controlled-live harness: runtime secret file is invalid'
+    )
+      fail('web evidence preflight secret file is invalid');
+    if (
+      error instanceof Error &&
+      error.message === 'controlled-live harness: runtime secret file is unavailable'
+    )
+      fail('web evidence preflight secret file is unavailable');
+    throw error;
+  }
+  const values = parseProtectedValues(contents, WEB_EVIDENCE_PREFLIGHT_SECRET_NAMES);
+  if (!/^[a-f0-9]{64}$/.test(values.DNSOPS_WEB_EVIDENCE_SESSION_TOKEN))
+    fail('web evidence preflight session token is invalid');
+  return Object.freeze({
+    endpoint: validateWebEvidenceEndpoint(values.DNSOPS_WEB_EVIDENCE_ENDPOINT),
+    sessionToken: values.DNSOPS_WEB_EVIDENCE_SESSION_TOKEN,
   });
 }
 
@@ -409,6 +473,87 @@ export async function runMcpEvidencePreflight({
   }
 }
 
+function safeWebEvidenceFailure(operation) {
+  fail(`web evidence ${operation} failed`);
+}
+
+async function webEvidenceGet(fetchImpl, resolvedEndpoint, sessionToken, path, responseShape) {
+  let response;
+  try {
+    response = await fetchImpl(new URL(path, resolvedEndpoint.endpoint), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Cookie: `dns_ops_session=${sessionToken}`,
+      },
+      lookup: resolvedEndpoint.lookup,
+    });
+  } catch {
+    safeWebEvidenceFailure(path);
+  }
+  if (!response || response.status !== 200 || !response.ok) safeWebEvidenceFailure(path);
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    safeWebEvidenceFailure(path);
+  }
+  if (!responseShape(body)) safeWebEvidenceFailure(path);
+  return response.status;
+}
+
+/**
+ * Proves only that the pre-authorized audit and alert read paths are available.
+ * Neither their response bodies nor the session token can enter the emitted
+ * artifact; callers collect and redact scenario evidence separately.
+ */
+export async function runWebEvidencePreflight({
+  secretFile,
+  artifactPath,
+  fetchImpl = pinnedHttpsFetch,
+  resolveHostname = dns.lookup,
+}) {
+  const reservation = reserveFixtureArtifact(artifactPath);
+  try {
+    const secret = loadWebEvidencePreflightSecret(secretFile);
+    const resolvedEndpoint = await resolveMcpEndpoint(secret.endpoint, resolveHostname);
+    const auditStatus = await webEvidenceGet(
+      fetchImpl,
+      resolvedEndpoint,
+      secret.sessionToken,
+      '/api/portfolio/audit?limit=1',
+      (body) => body && typeof body === 'object' && Array.isArray(body.events)
+    );
+    const alertsStatus = await webEvidenceGet(
+      fetchImpl,
+      resolvedEndpoint,
+      secret.sessionToken,
+      '/api/alerts?limit=1',
+      (body) =>
+        body &&
+        typeof body === 'object' &&
+        Array.isArray(body.alerts) &&
+        body.pagination &&
+        typeof body.pagination === 'object'
+    );
+    const artifact = Object.freeze({
+      kind: 'DNSOPS_WEB_EVIDENCE_PREFLIGHT',
+      status: 'WEB_EVIDENCE_PREFLIGHT_OK',
+      checkedAt: new Date().toISOString(),
+      webEndpointFingerprint: fingerprint(secret.endpoint.toString()),
+      verifiedReadPaths: [
+        `GET /api/portfolio/audit: ${auditStatus}`,
+        `GET /api/alerts: ${alertsStatus}`,
+      ],
+    });
+    reservation.publish(artifact);
+    return artifact;
+  } catch (error) {
+    reservation.discard();
+    throw error;
+  }
+}
+
 /** Reads the runtime secret only from this isolated harness process. */
 export function protectedToken(path, name) {
   const contents = readProtectedSecretFile(path, `${name} secret file must be mode 600`);
@@ -574,6 +719,7 @@ async function main() {
       'fixture-apply',
       'fixture-restore',
       'mcp-evidence-preflight',
+      'web-evidence-preflight',
     ].includes(command)
   )
     fail('unsupported command');
@@ -591,6 +737,22 @@ async function main() {
         status: artifact.status,
         artifactPath: process.argv[3],
         mcpEndpointFingerprint: artifact.mcpEndpointFingerprint,
+      })
+    );
+    return;
+  }
+  if (command === 'web-evidence-preflight') {
+    if (!process.argv[3] || process.argv[4] !== undefined)
+      fail('web-evidence-preflight requires one output artifact path before credential access');
+    const artifact = await runWebEvidencePreflight({
+      secretFile: process.env.DNSOPS_WEB_EVIDENCE_SECRET_FILE,
+      artifactPath: process.argv[3],
+    });
+    console.log(
+      JSON.stringify({
+        status: artifact.status,
+        artifactPath: process.argv[3],
+        webEndpointFingerprint: artifact.webEndpointFingerprint,
       })
     );
     return;


### PR DESCRIPTION
## Summary
- add a fail-closed, read-only `web-evidence-preflight` harness command for the existing tenant-scoped audit and alert routes
- require a separate absolute, no-follow mode-`0600` secret file containing only an HTTPS origin and a 64-hex database session token
- pin public IPv4 DNS answers, reject redirects/non-200/wrong response shapes, and atomically emit a status/fingerprint-only mode-`0600` artifact
- validate artifact destinations before reading the session secret

## Validation
- `bun run test:controlled-live-harness` — 45/45 passed
- `bun run lint` — 8/8 passed
- independent security re-review: no remaining blocking/high findings

No endpoint, credential, scan, case mutation, provider/DNS action, Railway action, or deployment was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-closed, read-only `web-evidence-preflight` harness command to verify authenticated web evidence reads without exposing session tokens or response data. Improves safety by validating the HTTPS origin, pinning DNS, and emitting a redacted, mode-0600 artifact.

- **New Features**
  - New `web-evidence-preflight` command that proves `GET /api/portfolio/audit?limit=1` and `GET /api/alerts?limit=1` return 200 with valid shapes.
  - Requires a separate mode-0600 secret file with `DNSOPS_WEB_EVIDENCE_ENDPOINT` and a 64-hex `DNSOPS_WEB_EVIDENCE_SESSION_TOKEN`; rejects invalid tokens/origins.
  - Pins public IPv4 DNS via custom lookup; rejects redirects, non-200s, and wrong response shapes; fails closed.
  - Validates artifact destination before reading secrets; writes a mode-0600 artifact with only status, endpoint fingerprint, and verified paths (no token/body data).
  - CLI: `runner.mjs` exposes `web-evidence-preflight <artifactPath>` and prints status, artifact path, and endpoint fingerprint.
  - Added targeted tests for endpoint validation, artifact safety, token format, DNS pinning, and response-shape checks.

<sup>Written for commit b62516d612291b957f2578704d2196b30009d285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

