### PR TITLE
docs: require web evidence preflight

### DIFF
--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -126,6 +126,7 @@
       "Audit IDs for scan, signal, case, and restoration lifecycle",
       "An authorized tenant-scoped web-session read path for GET /api/portfolio/audit to retrieve audit evidence",
       "An authorized tenant-scoped web-session read path for GET /api/alerts to verify LIVE-01 reopen alert deduplication",
+      "Successful redacted MCP and web-evidence preflight artifacts from their separate protected runtime secret files",
       "An authorized DNS Ops MCP endpoint and principal with required scopes"
     ]
   },
@@ -158,8 +159,8 @@
     "Client portal, billing, and commercial features"
   ],
   "nextActions": [
-    "Obtain authorized DNS Ops MCP access plus authorized web-session GET /api/portfolio/audit and GET /api/alerts access; collect and independently verify scan, signal, case, audit, restoration, and reopen evidence for every controlled scenario",
+    "Obtain authorized DNS Ops MCP access plus authorized web-session GET /api/portfolio/audit and GET /api/alerts access; run both required redacted preflights, then collect and independently verify scan, signal, case, audit, restoration, and reopen evidence for every controlled scenario",
     "Retain LIVE-01, LIVE-02, and LIVE-03 as pending until the checkpoint's missingForPass evidence is durable and correlated"
   ],
-  "updatedAt": "2026-08-05T19:50:55Z"
+  "updatedAt": "2026-08-05T20:12:53Z"
 }

--- a/docs/domain-operations/evidence/gate-3/asorin-operational-pass-evidence-manifest.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-operational-pass-evidence-manifest.json
@@ -8,6 +8,12 @@
     "requiredScopes": ["DOMAIN_READ", "SIGNAL_READ", "CASE_READ", "CASE_WRITE", "SCAN_REQUEST"],
     "requiredRuntimeInputs": ["authorized MCP endpoint", "mode-0600 runtime-only bearer secret", "registered tenant-owned domain IDs", "operator run authorization"]
   },
+  "webEvidencePreflight": {
+    "required": true,
+    "command": "node tools/controlled-live-harness/runner.mjs web-evidence-preflight <redacted-artifact-path>",
+    "requiredRuntimeInputs": ["authorized HTTPS web endpoint", "separate mode-0600 runtime-only dns_ops_session token"],
+    "validatedReadPaths": ["GET /api/portfolio/audit?limit=1", "GET /api/alerts?limit=1"]
+  },
   "scenarios": [
     {
       "mutationId": "LIVE-01",


### PR DESCRIPTION
## Summary
- require the merged authenticated web-evidence preflight alongside MCP preflight in the controlled-live PASS collection contract
- record its separate protected runtime input and validated tenant-scoped audit/alert read paths
- keep all LIVE scenarios pending until both redacted preflight artifacts and the scenario evidence are durable

## Validation
- `jq empty docs/domain-operations/checkpoints/current-state.json docs/domain-operations/evidence/gate-3/asorin-operational-pass-evidence-manifest.json`
- `git diff --check`

Documentation only; no endpoint, credential, scan, case action, provider/DNS action, Railway action, or deployment was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a tenant-scoped web-evidence preflight alongside the MCP preflight for the controlled-live PASS contract. Docs now capture separate protected runtime inputs and validated audit/alert read paths; LIVE scenarios remain pending until both redacted preflight artifacts and scenario evidence are durable.

- **Migration**
  - Run both preflights and store redacted artifacts: MCP preflight, plus `node tools/controlled-live-harness/runner.mjs web-evidence-preflight <redacted-artifact-path>`.
  - Use a separate mode-0600 runtime-only `dns_ops_session` token and an authorized HTTPS web endpoint; verify `GET /api/portfolio/audit?limit=1` and `GET /api/alerts?limit=1`.
  - Keep LIVE-01, LIVE-02, and LIVE-03 pending until all required evidence is durable and correlated.

<sup>Written for commit c613e9d7c34845aebcd4da780d8119228e76a966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

