### PR TITLE
docs: record durable evidence redaction audit

### DIFF
--- a/docs/domain-operations/checkpoints/current-state.json
+++ b/docs/domain-operations/checkpoints/current-state.json
@@ -113,6 +113,7 @@
       "docs/domain-operations/evidence/gate-3/asorin-live-01-fixture-restored.json",
       "docs/domain-operations/evidence/gate-3/asorin-live-02-fixture-restored.json",
       "docs/domain-operations/evidence/gate-3/asorin-web-restoration-recheck.json",
+      "docs/domain-operations/evidence/gate-3/asorin-durable-evidence-redaction-audit.json",
       "docs/domain-operations/evidence/gate-3/asorin-live-01-02-authoritative-web.json",
       "docs/domain-operations/evidence/gate-3/asorin-live-03-authoritative-restoration.json",
       "docs/domain-operations/evidence/gate-3/asorin-authoritative-restoration-recheck.json",
@@ -164,5 +165,5 @@
     "Obtain authorized DNS Ops MCP access plus authorized web-session GET /api/portfolio/audit and GET /api/alerts access; run both required redacted preflights, then collect and independently verify scan, signal, case, audit, restoration, and reopen evidence for every controlled scenario",
     "Retain LIVE-01, LIVE-02, and LIVE-03 as pending until the checkpoint's missingForPass evidence is durable and correlated"
   ],
-  "updatedAt": "2026-08-05T20:36:39Z"
+  "updatedAt": "2026-08-05T21:08:36Z"
 }

--- a/docs/domain-operations/evidence/gate-3/asorin-durable-evidence-redaction-audit.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-durable-evidence-redaction-audit.json
@@ -1,0 +1,25 @@
+{
+  "evidenceId": "GATE3-ASORIN-DURABLE-EVIDENCE-REDACTION-AUDIT",
+  "recordedAt": "2026-08-05T21:08:36Z",
+  "auditedRevision": "083b3818899df2f48d4179967d7382c7514df063",
+  "result": "CLEAN_PENDING_EXTERNAL_DNS_OPS_EVIDENCE",
+  "scope": {
+    "checkpoint": "docs/domain-operations/checkpoints/current-state.json",
+    "durableArtifactCount": 11,
+    "artifactListSource": "controlledLiveCheckpoint.durableEvidence"
+  },
+  "method": {
+    "credentialKeyCheck": "Flagged sensitive-key fields only when their string value was neither a sha256 fingerprint nor the literal <redacted> marker.",
+    "credentialValueCheck": "Flagged only Bearer values, private-key blocks, JWT-shaped strings, and common live-key prefixes.",
+    "outputPolicy": "The audit emitted aggregate finding metadata only; it did not print, persist, or transmit artifact scalar values."
+  },
+  "findings": {
+    "unredactedSensitiveKeyValues": 0,
+    "tokenLikeValues": 0
+  },
+  "limitations": [
+    "This validates only the 11 checkpoint-linked JSON artifacts at auditedRevision; it does not inspect runtime secret files or unlinked repository content.",
+    "This is a redaction-quality gate, not a DNS Ops scan, signal, case, audit, authoritative-DNS lifecycle, restoration, or LIVE-01 reopen proof.",
+    "No credentials, MCP calls, scans, case actions, provider/Railway actions, mutations, or deployments were performed."
+  ]
+}


### PR DESCRIPTION
## Summary
- persist a bounded redaction-quality audit for the 11 checkpoint-linked artifacts at `083b381`
- record zero unredacted sensitive-key values and zero token-like values without persisting scalar evidence values
- link the audit from the checkpoint while retaining its pending status

## Validation
- `jq empty docs/domain-operations/checkpoints/current-state.json docs/domain-operations/evidence/gate-3/asorin-durable-evidence-redaction-audit.json`
- checkpoint inventory assertion (`RESTORED_PENDING_DNS_OPS_EVIDENCE`, 12 linked artifacts, audit scope/count assertions)
- `git diff --check`

This is a redaction-quality gate only. It does not provide DNS Ops scan, signal, case, audit, lifecycle, restoration, or LIVE-01 reopen PASS evidence. No credentials, MCP calls, provider/Railway actions, mutations, or deployments were performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records a durable evidence redaction audit for 11 checkpoint-linked artifacts and links it in the checkpoint while keeping the checkpoint pending. The audit found zero unredacted sensitive-key values and zero token-like values and did not persist any scalar values.

- **New Features**
  - Added `docs/domain-operations/evidence/gate-3/asorin-durable-evidence-redaction-audit.json` and linked it in `docs/domain-operations/checkpoints/current-state.json`.
  - Scope: validates only checkpoint-linked JSON artifacts; this is a redaction gate, not DNS Ops scan or pass evidence.

<sup>Written for commit a21115fdeaed0b2bf2f14b1703ce803a2c109260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

