### PR TITLE
fix(collector): restore DNS packet ESM and DNSSEC collection

### DIFF
--- a/apps/collector/package.json
+++ b/apps/collector/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check src",
     "test": "vitest run src",
-    "test:live-dns": "RUN_LIVE_DNS_TESTS=1 vitest run src/dns/integration.test.ts --testTimeout=30000 --hookTimeout=30000",
+    "test:live-dns": "RUN_LIVE_DNS_TESTS=1 vitest run src/dns/integration.test.ts src/e2e/dnssec-resolver.e2e.test.ts --testTimeout=30000 --hookTimeout=30000",
     "docker:build": "docker build -f Dockerfile -t dns-ops-collector ../..",
     "docker:run": "docker run -p 3001:3001 --env-file .env dns-ops-collector"
   },

--- a/apps/collector/package.json
+++ b/apps/collector/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.0",
+    "esbuild": "^0.28.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
     "vitest": "^4.1.0"

--- a/apps/collector/src/dns/dnssec-decode.test.ts
+++ b/apps/collector/src/dns/dnssec-decode.test.ts
@@ -48,6 +48,26 @@ describe('encodeDnsQuery', () => {
 
     expect((packet.flags ?? 0) & (dnsPacket.RECURSION_DESIRED as number)).toBe(0);
   });
+
+  // dns-packet's types.toType() calls name.toUpperCase() — numeric RR type
+  // codes (48/43) throw. Questions must carry string type names.
+  it('encodes DNSKEY as a string type accepted by dns-packet', () => {
+    const buf = encodeDnsQuery({ name: 'example.com', type: 'DNSKEY' });
+    const packet = dnsPacket.decode(buf);
+
+    expect(packet.questions).toHaveLength(1);
+    expect(packet.questions?.[0]?.type).toBe('DNSKEY');
+    expect(packet.questions?.[0]?.name).toBe('example.com');
+  });
+
+  it('encodes DS as a string type accepted by dns-packet', () => {
+    const buf = encodeDnsQuery({ name: 'example.com', type: 'DS' });
+    const packet = dnsPacket.decode(buf);
+
+    expect(packet.questions).toHaveLength(1);
+    expect(packet.questions?.[0]?.type).toBe('DS');
+    expect(packet.questions?.[0]?.name).toBe('example.com');
+  });
 });
 
 describe('decodeDnsResponse', () => {

--- a/apps/collector/src/dns/dnssec-decode.test.ts
+++ b/apps/collector/src/dns/dnssec-decode.test.ts
@@ -218,6 +218,68 @@ describe('decodeDnsResponse', () => {
       expect(r.answers[0].data).toContain('letsencrypt.org');
       expect(r.answers[0].data).toBe('0 issue "letsencrypt.org"');
     });
+
+    it('DNSKEY: real ttl + presentation with key bytes base64-encoded', () => {
+      // dns-packet decodes DNSKEY RDATA as { flags, algorithm, key: Buffer }.
+      // Presentation form is "flags protocol algorithm base64(key)" (protocol always 3).
+      const keyB64 = 'AQO3dtF8aQ6iFxV8U/AM4Q==';
+      const key = Buffer.from(keyB64, 'base64');
+      const buf = encodeResponse([
+        {
+          name: 'example.com',
+          type: 'DNSKEY',
+          class: 'IN',
+          ttl: 3600,
+          data: { flags: 257, algorithm: 8, key },
+        },
+      ]);
+
+      const r = decodeDnsResponse(buf, 'DNSKEY');
+
+      expect(r.answers[0]).toMatchObject({
+        name: 'example.com',
+        type: 'DNSKEY',
+        ttl: 3600,
+      });
+      // Must not JSON.stringify the decoded object (key would stay a Buffer dump).
+      expect(r.answers[0].data).not.toContain('"type":"Buffer"');
+      expect(r.answers[0].data).toBe(`257 3 8 ${keyB64}`);
+      // Trailing token is pure base64 of the public key bytes.
+      const tokens = r.answers[0].data.split(' ');
+      expect(tokens).toHaveLength(4);
+      expect(tokens[3]).toBe(keyB64);
+      expect(Buffer.from(tokens[3], 'base64').equals(key)).toBe(true);
+    });
+
+    it('DS: real ttl + presentation with digest bytes hex-encoded', () => {
+      // dns-packet decodes DS RDATA as { keyTag, algorithm, digestType, digest: Buffer }.
+      // Presentation form is "keyTag algorithm digestType hex(digest)".
+      const digestHex = '2bb183af5f22588179a53b0a98631fad1a292118';
+      const digest = Buffer.from(digestHex, 'hex');
+      const buf = encodeResponse([
+        {
+          name: 'example.com',
+          type: 'DS',
+          class: 'IN',
+          ttl: 86400,
+          data: { keyTag: 370, algorithm: 13, digestType: 2, digest },
+        },
+      ]);
+
+      const r = decodeDnsResponse(buf, 'DS');
+
+      expect(r.answers[0]).toMatchObject({
+        name: 'example.com',
+        type: 'DS',
+        ttl: 86400,
+      });
+      expect(r.answers[0].data).not.toContain('"type":"Buffer"');
+      expect(r.answers[0].data).toBe(`370 13 2 ${digestHex}`);
+      const tokens = r.answers[0].data.split(' ');
+      expect(tokens).toHaveLength(4);
+      expect(tokens[3]).toBe(digestHex);
+      expect(Buffer.from(tokens[3], 'hex').equals(digest)).toBe(true);
+    });
   });
 
   describe('response codes', () => {

--- a/apps/collector/src/dns/dnssec-resolver.test.ts
+++ b/apps/collector/src/dns/dnssec-resolver.test.ts
@@ -1,44 +1,175 @@
 /**
  * DNSSEC DNS Resolver Tests - DNS-002
+ *
+ * Network-free unit coverage for encode/transport contracts. Live public-DNS
+ * checks live under e2e / test:live-dns, not here.
  */
 
-import { describe, expect, it } from 'vitest';
-import { queryDNSKEY, queryDS } from './dnssec-resolver.js';
+import { spawnSync } from 'node:child_process';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as dnsPacket from 'dns-packet';
+import { build as esbuildBuild } from 'esbuild';
+import { afterAll, describe, expect, it } from 'vitest';
+import { encodeDnsQuery, queryDNSKEY, queryDS, queryWithDnsPacket } from './dnssec-resolver.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const collectorRoot = join(here, '../..');
+const esmProofDir = join(collectorRoot, 'dist', 'rt1-esm-proof');
+
+function encodeAResponse(queryBuf: Buffer, ip: string): Buffer {
+  const query = dnsPacket.decode(queryBuf);
+  return dnsPacket.encode({
+    type: 'response',
+    id: query.id,
+    flags: (dnsPacket.RECURSION_DESIRED as number) | (dnsPacket.RECURSION_AVAILABLE as number),
+    questions: query.questions,
+    answers: [
+      {
+        name: query.questions?.[0]?.name ?? 'example.com',
+        type: 'A',
+        class: 'IN',
+        ttl: 60,
+        data: ip,
+      },
+    ],
+  });
+}
+
+afterAll(async () => {
+  await rm(esmProofDir, { recursive: true, force: true });
+});
 
 describe('DNSSEC DNS Resolver', () => {
-  describe('DNSKEY queries', () => {
-    it('should handle DNSKEY query to real domain', async () => {
-      // Test against a real domain that supports DNSSEC
-      const result = await queryDNSKEY('cloudflare.com');
+  describe('record-type encoding for dns-packet', () => {
+    it('encodes DNSKEY with a string RR type (numeric 48 is rejected by dns-packet)', () => {
+      // Ground truth: dns-packet throws on numeric type codes.
+      expect(() =>
+        dnsPacket.encode({
+          type: 'query',
+          id: 1,
+          questions: [{ type: 48 as unknown as string, name: 'example.com', class: 'IN' }],
+        })
+      ).toThrow(/toUpperCase/);
 
-      // Should complete without error
-      expect(typeof result.success).toBe('boolean');
-      expect(Array.isArray(result.answers)).toBe(true);
+      const buf = encodeDnsQuery({ name: 'example.com', type: 'DNSKEY' });
+      expect(dnsPacket.decode(buf).questions?.[0]?.type).toBe('DNSKEY');
     });
 
-    it('should return empty for domain without DNSKEY', async () => {
-      // Test against a domain that might not have DNSKEY
-      const result = await queryDNSKEY('example.invalid');
+    it('encodes DS with a string RR type (numeric 43 is rejected by dns-packet)', () => {
+      expect(() =>
+        dnsPacket.encode({
+          type: 'query',
+          id: 1,
+          questions: [{ type: 43 as unknown as string, name: 'example.com', class: 'IN' }],
+        })
+      ).toThrow(/toUpperCase/);
 
-      // Should complete - may or may not have answers
-      expect(typeof result.success).toBe('boolean');
-      expect(Array.isArray(result.answers)).toBe(true);
+      const buf = encodeDnsQuery({ name: 'example.com', type: 'DS' });
+      expect(dnsPacket.decode(buf).questions?.[0]?.type).toBe('DS');
     });
   });
 
-  describe('DS queries', () => {
-    it('should handle DS query to real domain', async () => {
-      // Test against a real DNSSEC-signed domain
-      const result = await queryDS('cloudflare.com');
+  describe('ESM transport regression (no public DNS)', () => {
+    it('A query reaches injected transport and decodes the response', async () => {
+      const reached: Array<{ server: string; port: number; type: string | undefined }> = [];
 
-      expect(typeof result.success).toBe('boolean');
-      expect(Array.isArray(result.answers)).toBe(true);
+      const result = await queryWithDnsPacket({ name: 'example.com', type: 'A' }, '127.0.0.1', {
+        transport: async (packet, server, port) => {
+          const decoded = dnsPacket.decode(packet);
+          reached.push({
+            server,
+            port,
+            type: decoded.questions?.[0]?.type ? String(decoded.questions[0].type) : undefined,
+          });
+          return encodeAResponse(packet, '93.184.216.34');
+        },
+      });
+
+      expect(reached).toEqual([{ server: '127.0.0.1', port: 53, type: 'A' }]);
+      expect(result.responseCode).toBe(0);
+      expect(result.answers).toEqual([
+        expect.objectContaining({
+          name: 'example.com',
+          type: 'A',
+          ttl: 60,
+          data: '93.184.216.34',
+        }),
+      ]);
     });
 
-    it('should return empty for non-existent domain', async () => {
-      const result = await queryDS('nonexistent.invalid.test');
+    it('compiled ESM build reaches transport without require()', async () => {
+      // Emit the resolver as plain Node ESM under the package tree so workspace
+      // deps resolve, then execute it with stock Node (no vitest loader). A
+      // leftover require('node:dgram') becomes __require and throws under ESM.
+      await mkdir(esmProofDir, { recursive: true });
+      const outfile = join(esmProofDir, 'dnssec-resolver.mjs');
+      const harnessFile = join(esmProofDir, 'harness.mjs');
 
-      expect(typeof result.success).toBe('boolean');
+      await esbuildBuild({
+        absWorkingDir: collectorRoot,
+        entryPoints: [join(here, 'dnssec-resolver.ts')],
+        outfile,
+        bundle: true,
+        platform: 'node',
+        format: 'esm',
+        target: 'node20',
+        packages: 'external',
+        write: true,
+      });
+
+      const emitted = await readFile(outfile, 'utf8');
+      expect(emitted).toMatch(/from\s+["']node:dgram["']/);
+      expect(emitted).toMatch(/from\s+["']node:net["']/);
+      expect(emitted).not.toMatch(/require\(\s*["']node:dgram["']\s*\)/);
+      expect(emitted).not.toMatch(/__require\(\s*["']node:dgram["']\s*\)/);
+
+      await writeFile(
+        harnessFile,
+        `import * as dnsPacket from 'dns-packet';
+import { queryWithDnsPacket } from './dnssec-resolver.mjs';
+
+const reached = [];
+const result = await queryWithDnsPacket(
+  { name: 'example.com', type: 'A' },
+  '192.0.2.1',
+  {
+    transport: async (packet, server, port) => {
+      const q = dnsPacket.decode(packet);
+      reached.push(\`\${server}:\${port}:\${q.questions?.[0]?.type}\`);
+      return dnsPacket.encode({
+        type: 'response',
+        id: q.id,
+        flags: dnsPacket.RECURSION_DESIRED | dnsPacket.RECURSION_AVAILABLE,
+        questions: q.questions,
+        answers: [{
+          name: 'example.com',
+          type: 'A',
+          class: 'IN',
+          ttl: 60,
+          data: '198.51.100.10',
+        }],
+      });
+    },
+  }
+);
+
+if (reached.join() !== '192.0.2.1:53:A') {
+  throw new Error('transport not reached: ' + JSON.stringify(reached));
+}
+if (result.answers?.[0]?.data !== '198.51.100.10') {
+  throw new Error('bad answer: ' + JSON.stringify(result.answers));
+}
+`
+      );
+
+      const run = spawnSync(process.execPath, [harnessFile], {
+        cwd: collectorRoot,
+        encoding: 'utf8',
+      });
+
+      expect(run.status, `${run.stdout}\n${run.stderr}`).toBe(0);
     });
   });
 
@@ -46,8 +177,15 @@ describe('DNSSEC DNS Resolver', () => {
     it('should handle invalid domain gracefully', async () => {
       const result = await queryDNSKEY('');
 
-      // Should handle gracefully
-      expect(typeof result.success).toBe('boolean');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Domain is required');
+    });
+
+    it('should handle invalid domain for DS gracefully', async () => {
+      const result = await queryDS('');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Domain is required');
     });
   });
 });

--- a/apps/collector/src/dns/dnssec-resolver.ts
+++ b/apps/collector/src/dns/dnssec-resolver.ts
@@ -5,29 +5,22 @@
  * Node.js native dns module doesn't support these record types.
  */
 
+import dgram from 'node:dgram';
+import net from 'node:net';
 import { DNS_RCODE } from '@dns-ops/contracts';
 import * as dnsPacket from 'dns-packet';
 import type { DNSAnswer, DNSQuery } from './types.js';
 
 /**
- * DNS record types supported by dns-packet
- */
-const DNS_TYPES: Record<string, number> = {
-  DNSKEY: 48,
-  DS: 43,
-  RRSIG: 46,
-  NSEC: 47,
-  NSEC3: 50,
-  NSEC3PARAM: 51,
-  TLSA: 52,
-  CDS: 59,
-  CDNSKEY: 60,
-};
-
-/**
  * Default DNS servers for recursive queries
  */
 const DEFAULT_DNS_SERVERS = ['8.8.8.8', '1.1.1.1'];
+
+/**
+ * Wire transport used by queryWithDnsPacket. Tests inject a deterministic
+ * transport so coverage does not depend on public DNS.
+ */
+export type DnsTransport = (packet: Buffer, server: string, port: number) => Promise<Buffer>;
 
 /**
  * dns-packet decodes the response code as a string name ('NOERROR', 'NXDOMAIN',
@@ -70,18 +63,22 @@ export interface DnsResponseSections {
  */
 export interface DnsQueryOptions {
   recursionDesired?: boolean;
+  /** Override UDP/TCP transport (tests). Defaults to sendDnsQuery. */
+  transport?: DnsTransport;
 }
 
 /** Encode a DNS query without performing I/O so recursion policy is testable. */
 export function encodeDnsQuery(query: DNSQuery, options: DnsQueryOptions = {}): Buffer {
   const { recursionDesired = true } = options;
+  // dns-packet types.toType() requires string RR names (calls toUpperCase).
+  // Numeric codes (e.g. DNSKEY=48, DS=43) throw at encode time.
   return dnsPacket.encode({
     type: 'query',
     id: Math.floor(Math.random() * 0xffff),
     flags: recursionDesired ? (dnsPacket.RECURSION_DESIRED as number) : 0,
     questions: [
       {
-        type: DNS_TYPES[query.type] || query.type,
+        type: query.type,
         name: query.name,
         class: 'IN',
       },
@@ -94,7 +91,8 @@ export async function queryWithDnsPacket(
   dnsServer: string = DEFAULT_DNS_SERVERS[0],
   options: DnsQueryOptions = {}
 ): Promise<DnsResponseSections> {
-  const response = await sendDnsQuery(encodeDnsQuery(query, options), dnsServer, 53);
+  const { transport = sendDnsQuery, recursionDesired } = options;
+  const response = await transport(encodeDnsQuery(query, { recursionDesired }), dnsServer, 53);
   return decodeDnsResponse(response, query.type);
 }
 
@@ -284,7 +282,6 @@ async function sendDnsQuery(
   const { timeoutMs = 5000, fallbackToTcp = true } = options;
 
   return new Promise((resolve, reject) => {
-    const dgram = require('node:dgram');
     const client = dgram.createSocket('udp4');
 
     const timeout = setTimeout(() => {
@@ -331,7 +328,6 @@ async function sendDnsQueryTcp(
   timeoutMs: number = 5000
 ): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const net = require('node:net');
     const client = new net.Socket();
 
     const timeout = setTimeout(() => {
@@ -357,7 +353,7 @@ async function sendDnsQueryTcp(
       }
 
       const responseLength = data.readUInt16BE(0);
-      const dnsResponse = data.slice(2);
+      const dnsResponse = data.subarray(2);
 
       if (dnsResponse.length < responseLength) {
         // Handle case where data comes in multiple chunks

--- a/apps/collector/src/dns/dnssec-resolver.ts
+++ b/apps/collector/src/dns/dnssec-resolver.ts
@@ -256,17 +256,60 @@ function formatCaa(data: unknown): string {
   return bufferToString(data);
 }
 
-/** DNSKEY: public key bytes, base64-encoded. */
+/**
+ * DNSKEY presentation: "flags protocol algorithm base64(key)".
+ * dns-packet decodes RDATA as { flags, algorithm, key: Buffer } (protocol is
+ * always 3 for DNSSEC and is not surfaced on the decoded object).
+ */
 function formatDnskey(data: unknown): string {
   if (typeof data === 'string') return data;
   if (Buffer.isBuffer(data)) return data.toString('base64');
+  if (data && typeof data === 'object') {
+    const dnskey = data as {
+      flags?: number;
+      protocol?: number;
+      algorithm?: number;
+      key?: Buffer | string;
+    };
+    const flags = dnskey.flags ?? 0;
+    const protocol = dnskey.protocol ?? 3;
+    const algorithm = dnskey.algorithm ?? 0;
+    let key = '';
+    if (Buffer.isBuffer(dnskey.key)) {
+      key = dnskey.key.toString('base64');
+    } else if (typeof dnskey.key === 'string') {
+      key = dnskey.key;
+    }
+    return `${flags} ${protocol} ${algorithm} ${key}`;
+  }
   return JSON.stringify(data);
 }
 
-/** DS: digest bytes, hex-encoded. */
+/**
+ * DS presentation: "keyTag algorithm digestType hex(digest)".
+ * dns-packet decodes RDATA as { keyTag, algorithm, digestType, digest: Buffer }.
+ */
 function formatDs(data: unknown): string {
   if (typeof data === 'string') return data;
   if (Buffer.isBuffer(data)) return data.toString('hex');
+  if (data && typeof data === 'object') {
+    const ds = data as {
+      keyTag?: number;
+      algorithm?: number;
+      digestType?: number;
+      digest?: Buffer | string;
+    };
+    const keyTag = ds.keyTag ?? 0;
+    const algorithm = ds.algorithm ?? 0;
+    const digestType = ds.digestType ?? 0;
+    let digest = '';
+    if (Buffer.isBuffer(ds.digest)) {
+      digest = ds.digest.toString('hex');
+    } else if (typeof ds.digest === 'string') {
+      digest = ds.digest;
+    }
+    return `${keyTag} ${algorithm} ${digestType} ${digest}`;
+  }
   return JSON.stringify(data);
 }
 

--- a/apps/collector/src/e2e/dnssec-resolver.e2e.test.ts
+++ b/apps/collector/src/e2e/dnssec-resolver.e2e.test.ts
@@ -1,306 +1,133 @@
 /**
  * E2E Integration Tests: DNSSEC DNS Resolver - DNS-002
  *
- * Tests that verify DNSKEY/DS query functionality:
- * 1. DNSKEY queries work correctly
- * 2. DS queries work correctly
- * 3. Error handling for various failure modes
- * 4. TCP fallback for truncated responses
- * 5. Timeout handling
- * 6. Invalid domain handling
+ * Default path is offline-only (input validation). Public recursive DNS checks
+ * are opt-in via RUN_LIVE_DNS_TESTS so the collector default suite stays
+ * deterministic and does not pass vacuously when the network is absent.
  *
- * These tests catch issues like:
- * - Missing TCP fallback for large responses
- * - Buffer overflow handling
- * - Response parsing edge cases
+ * Run live checks with:
+ * - `RUN_LIVE_DNS_TESTS=1 bun run --filter @dns-ops/collector test`
+ * - or the package `test:live-dns` script (integration suite)
  */
 
 import { describe, expect, it } from 'vitest';
 import { queryDNSKEY, queryDS } from '../dns/dnssec-resolver.js';
 
+function isTruthy(value: string | undefined): boolean {
+  return value === '1' || value?.toLowerCase() === 'true';
+}
+
+const LIVE_DNS_ENABLED = isTruthy(process.env.RUN_LIVE_DNS_TESTS);
+const liveDescribe = LIVE_DNS_ENABLED ? describe : describe.skip;
+const LIVE_DOMAIN = process.env.LIVE_DNS_DOMAIN?.trim() || 'cloudflare.com';
+const LIVE_TEST_TIMEOUT_MS = 30_000;
+
 describe('DNSSEC DNS Resolver E2E', () => {
-  describe('DNSKEY Query Handling', () => {
-    it('should handle DNSKEY query to real DNSSEC-enabled domain', async () => {
-      // cloudflare.com has DNSSEC enabled
-      const result = await queryDNSKEY('cloudflare.com');
-
-      // Should complete without throwing
-      expect(typeof result.success).toBe('boolean');
-      expect(Array.isArray(result.answers)).toBe(true);
-
-      if (result.success && result.answers.length > 0) {
-        // Verify answer structure
-        const answer = result.answers[0];
-        expect(answer.name).toBe('cloudflare.com');
-        expect(answer.type).toBe('DNSKEY');
-        expect(typeof answer.ttl).toBe('number');
-        expect(typeof answer.data).toBe('string');
-      }
-    });
-
-    it('should handle DNSKEY query to non-existent domain', async () => {
-      const result = await queryDNSKEY('nonexistent.invalid.test');
-
-      expect(typeof result.success).toBe('boolean');
-      expect(Array.isArray(result.answers)).toBe(true);
-      // May return empty answers or error based on DNS response
-    });
-
-    it('should handle empty domain string', async () => {
+  describe('offline input validation (no network)', () => {
+    it('rejects empty domain for DNSKEY', async () => {
       const result = await queryDNSKEY('');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Domain is required');
-      expect(result.answers).toHaveLength(0);
+      expect(result.answers).toEqual([]);
     });
 
-    it('should handle very long domain name', async () => {
-      // Most DNS servers limit domain names to 253 characters
-      const longDomain = `${'a'.repeat(250)}.com`;
-      const result = await queryDNSKEY(longDomain);
-
-      // Should either succeed or fail gracefully
-      expect(typeof result.success).toBe('boolean');
-    });
-
-    it('should handle internationalized domain names', async () => {
-      // IDN domain - should handle or return error gracefully
-      const result = await queryDNSKEY('münchen.de');
-
-      // Should not throw - may fail with validation error or query error
-      expect(typeof result.success).toBe('boolean');
-    });
-  });
-
-  describe('DS Query Handling', () => {
-    it('should handle DS query to real DNSSEC-enabled domain', async () => {
-      const result = await queryDS('cloudflare.com');
-
-      expect(typeof result.success).toBe('boolean');
-      expect(Array.isArray(result.answers)).toBe(true);
-    });
-
-    it('should handle DS query to non-DNSSEC domain', async () => {
-      // Most domains don't have DNSSEC
-      const result = await queryDS('example.com');
-
-      expect(typeof result.success).toBe('boolean');
-      // May return empty answers if domain doesn't have DS records
-    });
-
-    it('should handle DS query to non-existent domain', async () => {
-      const result = await queryDS('nonexistent.invalid.test');
-
-      expect(typeof result.success).toBe('boolean');
-    });
-
-    it('should handle empty domain string', async () => {
+    it('rejects empty domain for DS', async () => {
       const result = await queryDS('');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Domain is required');
-      expect(result.answers).toHaveLength(0);
+      expect(result.answers).toEqual([]);
     });
   });
 
-  // =============================================================================
-  // TCP FALLBACK TESTS - Critical for large DNS responses
-  // DNS responses larger than 512 bytes are truncated over UDP
-  // TCP fallback ensures these responses are still received
-  // =============================================================================
+  liveDescribe('live public DNS (RUN_LIVE_DNS_TESTS)', () => {
+    it(
+      'DNSKEY query returns presentation data with base64 key material',
+      async () => {
+        const result = await queryDNSKEY(LIVE_DOMAIN);
 
-  describe('TCP Fallback for Large Responses', () => {
-    it('should handle large DNSKEY responses via TCP fallback', async () => {
-      // Domains with many DNSKEY records will trigger truncation
-      // The resolver should automatically retry over TCP
-      const result = await queryDNSKEY('cloudflare.com');
-
-      // Should succeed even if response was truncated over UDP
-      expect(typeof result.success).toBe('boolean');
-
-      if (result.success) {
-        // If we got answers, TCP fallback worked
-        // (or response fit in UDP packet)
-        expect(Array.isArray(result.answers)).toBe(true);
-      }
-    });
-
-    it('should handle DS responses with TCP fallback', async () => {
-      // DS records are typically smaller but test the fallback mechanism
-      const result = await queryDS('cloudflare.com');
-
-      expect(typeof result.success).toBe('boolean');
-    });
-
-    it('should not throw when TCP fallback is needed', async () => {
-      // The resolver should handle TCP fallback internally
-      // This test verifies no exceptions are thrown
-      const result = await queryDNSKEY('google.com');
-
-      // Should return a result object, not throw
-      expect(result).toBeDefined();
-      expect('success' in result).toBe(true);
-      expect('answers' in result).toBe(true);
-    });
-
-    it('should handle multiple DNSKEY queries with TCP fallback', async () => {
-      // Multiple queries test concurrent TCP fallback handling
-      const results = await Promise.all([
-        queryDNSKEY('cloudflare.com'),
-        queryDNSKEY('google.com'),
-        queryDNSKEY('github.com'),
-      ]);
-
-      results.forEach((result) => {
-        expect(result).toBeDefined();
-        expect(typeof result.success).toBe('boolean');
-      });
-    });
-  });
-
-  describe('Error Response Handling', () => {
-    it('should handle SERVFAIL response', async () => {
-      // Some domains cause SERVFAIL due to validation issues
-      // The result should indicate failure
-      const result = await queryDNSKEY('test.servfail.example');
-
-      // If it fails, should have proper error message
-      if (!result.success) {
-        expect(result.error).toBeTruthy();
-      }
-    });
-
-    it('should handle REFUSED response', async () => {
-      const result = await queryDS('refused.test.example');
-
-      // Should handle gracefully
-      expect(typeof result.success).toBe('boolean');
-    });
-
-    it('should handle NXDOMAIN response', async () => {
-      const result = await queryDNSKEY('this-domain-definitely-does-not-exist-12345xyz.invalid');
-
-      // Should return empty or failure gracefully
-      expect(typeof result.success).toBe('boolean');
-    });
-  });
-
-  describe('Timeout Handling', () => {
-    it('should handle DNS server timeout', async () => {
-      // Use a non-routable IP that won't respond
-      // Note: This test might be slow due to UDP timeout
-      const result = await queryDNSKEY('timeout-test.example');
-
-      // Should either succeed (if server is reachable) or timeout
-      expect(typeof result.success).toBe('boolean');
-    });
-  });
-
-  describe('Type Coercion in Response Parsing', () => {
-    it('should handle numeric DNS record type in response', async () => {
-      // The formatRecordData function should handle different type formats
-      const result = await queryDNSKEY('cloudflare.com');
-
-      // Should parse answers regardless of internal type representation
-      if (result.success && result.answers.length > 0) {
-        const answer = result.answers[0];
-        // Data should be a string (base64 encoded for DNSKEY)
-        expect(typeof answer.data).toBe('string');
-      }
-    });
-
-    it('should handle buffer-type data in DNSKEY response', async () => {
-      const result = await queryDNSKEY('cloudflare.com');
-
-      if (result.success && result.answers.length > 0) {
-        // DNSKEY data should be base64 encoded
-        const data = result.answers[0].data;
-        // Base64 strings only contain A-Z, a-z, 0-9, +, /, =
-        expect(/^[A-Za-z0-9+/=]+$/.test(data)).toBe(true);
-      }
-    });
-
-    it('should handle DS record with hex data', async () => {
-      const result = await queryDS('cloudflare.com');
-
-      if (result.success && result.answers.length > 0) {
-        // DS records typically contain hex data
-        const data = result.answers[0].data;
-        expect(typeof data).toBe('string');
-      }
-    });
-
-    it('should handle empty answers array gracefully', async () => {
-      // Domain without DNSKEY records
-      const result = await queryDNSKEY('nonexistent.domain.invalid');
-
-      expect(Array.isArray(result.answers)).toBe(true);
-      expect(result.answers).toHaveLength(0);
-    });
-  });
-
-  describe('Query ID Randomization', () => {
-    it('should generate unique query IDs for concurrent queries', async () => {
-      // Make multiple queries concurrently
-      const results = await Promise.all([
-        queryDNSKEY('cloudflare.com'),
-        queryDNSKEY('google.com'),
-        queryDNSKEY('github.com'),
-      ]);
-
-      // All should complete without errors
-      expect(results).toHaveLength(3);
-      results.forEach((result) => {
-        expect(typeof result.success).toBe('boolean');
-      });
-    });
-  });
-
-  describe('Response Code Mapping', () => {
-    it('should correctly map NOERROR responses', async () => {
-      // This is implicitly tested by successful queries
-      // If we get answers, the response was NOERROR
-      const result = await queryDNSKEY('cloudflare.com');
-
-      if (result.success) {
+        expect(result.success).toBe(true);
+        expect(result.error).toBeUndefined();
         expect(result.answers.length).toBeGreaterThan(0);
-      }
-    });
 
-    it('should handle non-NOERROR responses gracefully', async () => {
-      // Query for a DS record on a domain without DS records
-      // Should not throw, but should indicate the query didn't succeed
-      const result = await queryDS('example.com');
+        const answer = result.answers[0];
+        expect(answer.type).toBe('DNSKEY');
+        expect(typeof answer.ttl).toBe('number');
+        expect(answer.ttl).toBeGreaterThan(0);
+        expect(typeof answer.data).toBe('string');
+        // flags protocol algorithm base64(key)
+        expect(answer.data).toMatch(/^\d+ \d+ \d+ [A-Za-z0-9+/=]+$/);
+        // Must not leak the raw dns-packet object dump
+        expect(answer.data).not.toContain('"type":"Buffer"');
 
-      // Should not throw an exception
-      expect(typeof result.success).toBe('boolean');
-    });
-  });
+        const keyB64 = answer.data.split(' ')[3] ?? '';
+        expect(keyB64.length).toBeGreaterThan(0);
+        expect(() => Buffer.from(keyB64, 'base64')).not.toThrow();
+      },
+      LIVE_TEST_TIMEOUT_MS
+    );
 
-  // =============================================================================
-  // EDGE CASES
-  // =============================================================================
+    it(
+      'DS query returns presentation data with hex digest material',
+      async () => {
+        const result = await queryDS(LIVE_DOMAIN);
 
-  describe('Edge Cases', () => {
-    it('should handle domain with trailing dot', async () => {
-      const result = await queryDNSKEY('cloudflare.com.');
-      expect(typeof result.success).toBe('boolean');
-    });
+        expect(result.success).toBe(true);
+        expect(result.error).toBeUndefined();
+        expect(result.answers.length).toBeGreaterThan(0);
 
-    it('should handle uppercase domain', async () => {
-      const result = await queryDNSKEY('CLOUDFLARE.COM');
-      expect(typeof result.success).toBe('boolean');
-    });
+        const answer = result.answers[0];
+        expect(answer.type).toBe('DS');
+        expect(typeof answer.ttl).toBe('number');
+        expect(typeof answer.data).toBe('string');
+        // keyTag algorithm digestType hex(digest)
+        expect(answer.data).toMatch(/^\d+ \d+ \d+ [0-9a-fA-F]+$/);
+        expect(answer.data).not.toContain('"type":"Buffer"');
 
-    it('should handle mixed case domain', async () => {
-      const result = await queryDNSKEY('CloudFlare.Com');
-      expect(typeof result.success).toBe('boolean');
-    });
+        const digestHex = answer.data.split(' ')[3] ?? '';
+        expect(digestHex.length).toBeGreaterThan(0);
+        expect(digestHex.length % 2).toBe(0);
+      },
+      LIVE_TEST_TIMEOUT_MS
+    );
 
-    it('should handle single-label domain', async () => {
-      // Single label domains don't have TLD
-      const result = await queryDNSKEY('localhost');
-      expect(typeof result.success).toBe('boolean');
-    });
+    it(
+      'handles NXDOMAIN / non-existent names without throwing',
+      async () => {
+        const result = await queryDNSKEY('this-domain-definitely-does-not-exist-12345xyz.invalid');
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: expect.any(Boolean),
+            answers: expect.any(Array),
+          })
+        );
+        // Non-existent names must not surface fabricated DNSKEY answers.
+        expect(result.answers).toHaveLength(0);
+      },
+      LIVE_TEST_TIMEOUT_MS
+    );
+
+    it(
+      'concurrent DNSKEY queries complete independently',
+      async () => {
+        const results = await Promise.all([
+          queryDNSKEY(LIVE_DOMAIN),
+          queryDNSKEY('google.com'),
+          queryDNSKEY('github.com'),
+        ]);
+
+        expect(results).toHaveLength(3);
+        for (const result of results) {
+          expect(typeof result.success).toBe('boolean');
+          expect(Array.isArray(result.answers)).toBe(true);
+        }
+        // At least the known DNSSEC-enabled target must succeed with data.
+        expect(results[0].success).toBe(true);
+        expect(results[0].answers.length).toBeGreaterThan(0);
+      },
+      LIVE_TEST_TIMEOUT_MS
+    );
   });
 });

--- a/apps/collector/src/e2e/dnssec-resolver.e2e.test.ts
+++ b/apps/collector/src/e2e/dnssec-resolver.e2e.test.ts
@@ -7,7 +7,7 @@
  *
  * Run live checks with:
  * - `RUN_LIVE_DNS_TESTS=1 bun run --filter @dns-ops/collector test`
- * - or the package `test:live-dns` script (integration suite)
+ * - or the package `test:live-dns` script (integration + this e2e file)
  */
 
 import { describe, expect, it } from 'vitest';

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.10.0",
+        "esbuild": "^0.28.0",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0",
         "vitest": "^4.1.0",


### PR DESCRIPTION
## RT-1

Fixes compiled-ESM DNS transport, DNSKEY/DS string RR encoding, and DNSKEY/DS presentation formatting. Public DNS checks are opt-in and the live-DNS script includes them.

### Evidence
- `bun run --filter @dns-ops/collector test`: 1201 passed, 15 skipped
- `bun run --filter @dns-ops/collector lint`
- `bun run --filter @dns-ops/collector typecheck`
- `bun run --filter @dns-ops/collector build`
- `bun run --filter @dns-ops/collector test:live-dns`: 18 passed, 1 skipped
- Independent Claude Fable review approved the patch and rebase integrity.

### Caveat
TCP fallback multi-chunk framing is pre-existing and intentionally not changed in this scoped PR. No deployment or migration is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the DNS runtime’s ESM transport and fixes DNSSEC collection by encoding `DNSKEY`/`DS` queries correctly for `dns-packet` and formatting their answers in presentation form. Addresses RT-1 and makes live public-DNS checks opt-in via the `test:live-dns` script.

- **Bug Fixes**
  - Encode queries with string RR names for `DNSKEY`/`DS` to satisfy `dns-packet` (prevents toUpperCase crash).
  - Format `DNSKEY`/`DS` answers as presentation strings (DNSKEY: "flags 3 algorithm base64(key)", DS: "keyTag algorithm digestType hex(digest)"); TTLs preserved.
  - Restore compiled ESM support by replacing `require('node:dgram'|'node:net')` with static ESM imports.

- **Refactors**
  - Introduced injectable `DnsTransport` to enable network-free tests and an ESM bundle proof; default tests run offline, and public DNS checks are gated behind `RUN_LIVE_DNS_TESTS` and included in `test:live-dns`.

<sup>Written for commit 16f0763bac9b7a5d0cfa269fa5cbe45c3138fb1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

