### PR TITLE
fix(runtime): make readiness dependency-aware

### DIFF
--- a/apps/collector/Dockerfile
+++ b/apps/collector/Dockerfile
@@ -87,9 +87,10 @@ RUN groupadd -r collector && useradd -r -g collector collector
 RUN chown -R collector:collector /app
 USER collector
 
-# Health check endpoint (uses curl which is installed above)
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:3001/health || exit 1
+# Readiness probe — dependency failure must not count as healthy.
+# start-period covers worker/queue startup before /readyz is required.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost:3001/readyz || exit 1
 
 EXPOSE 3001
 

--- a/apps/collector/Dockerfile.railway
+++ b/apps/collector/Dockerfile.railway
@@ -55,7 +55,9 @@ ENV PORT=3001
 
 EXPOSE 3001
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:3001/health || exit 1
+# Readiness probe — dependency failure must not count as healthy.
+# start-period covers worker/queue startup before /readyz is required.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost:3001/readyz || exit 1
 
 CMD ["node", "apps/collector/dist/index.js"]

--- a/apps/collector/railway.toml
+++ b/apps/collector/railway.toml
@@ -7,7 +7,9 @@ dockerfilePath = "apps/collector/Dockerfile.railway"
 
 [deploy]
 startCommand = "node dist/index.js"
-healthcheckPath = "/health"
-healthcheckTimeout = 10
+# Readiness (not liveness): dependency failure must not count as healthy.
+# Workers start before listen; timeout still covers slow Redis/DB cold start.
+healthcheckPath = "/readyz"
+healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3

--- a/apps/collector/src/index.test.ts
+++ b/apps/collector/src/index.test.ts
@@ -3,22 +3,27 @@
  *
  * Behavioral tests proving:
  * - /healthz, /health, /api/health are process-only liveness (200 without DB)
- * - /readyz runs a real DB query (not adapter construction)
- * - unreachable DB → 503
- * - reachable disposable DB → 200 (when workers not required)
+ * - /readyz runs a real bounded DB query (not adapter construction)
+ * - unreachable DB → 503 with public-safe messages (no driver/host leaks)
  * - WORKER_ENABLED=true with bad/missing Redis → 503 (not 500)
+ * - blackhole/timeout path is covered via @dns-ops/db ping unit tests
+ *
+ * Healthy disposable Postgres is opt-in only:
+ *   RUN_DB_INTEGRATION_TESTS=1
+ * Default unit runs never require Docker.
  */
 
 import { execFileSync, spawn } from 'node:child_process';
 import { createServer } from 'node:net';
-import pg from 'pg';
+import { pingDatabaseForReadiness } from '@dns-ops/db';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import app from './index.js';
 import { closeQueues } from './jobs/queue.js';
-import { resetSharedDbAdapterForTests } from './middleware/db.js';
+import { PUBLIC_DB_NOT_READY_MESSAGE, resetSharedDbAdapterForTests } from './middleware/db.js';
 
 const REFUSED_DB_URL = 'postgresql://postgres:postgres@127.0.0.1:1/postgres';
 const REFUSED_REDIS_URL = 'redis://127.0.0.1:1';
+const RUN_DB_INTEGRATION = process.env.RUN_DB_INTEGRATION_TESTS === '1';
 
 type ReadyzBody = {
   status: 'ready' | 'not_ready';
@@ -50,18 +55,11 @@ function getFreePort(): Promise<number> {
 async function waitForPostgres(url: string, attempts = 40): Promise<void> {
   let lastError: unknown;
   for (let i = 0; i < attempts; i++) {
-    const client = new pg.Client({
-      connectionString: url,
-      connectionTimeoutMillis: 1000,
-    });
     try {
-      await client.connect();
-      await client.query('SELECT 1');
-      await client.end();
+      await pingDatabaseForReadiness(url, { timeoutMs: 1_000 });
       return;
     } catch (error) {
       lastError = error;
-      await client.end().catch(() => undefined);
       await new Promise((r) => setTimeout(r, 250));
     }
   }
@@ -70,6 +68,16 @@ async function waitForPostgres(url: string, attempts = 40): Promise<void> {
       lastError instanceof Error ? lastError.message : String(lastError)
     }`
   );
+}
+
+function assertNoInternalLeak(body: ReadyzBody): void {
+  const serialized = JSON.stringify(body);
+  expect(serialized).not.toMatch(/127\.0\.0\.1/);
+  expect(serialized).not.toMatch(/ECONNREFUSED/i);
+  expect(serialized).not.toMatch(/password/i);
+  expect(serialized).not.toMatch(/postgresql:\/\//i);
+  expect(serialized).not.toMatch(/postgres:postgres/i);
+  expect(serialized).not.toMatch(/AggregateError/i);
 }
 
 describe('Collector liveness (process-only)', () => {
@@ -103,44 +111,147 @@ describe('Collector liveness (process-only)', () => {
   });
 });
 
-describe('Collector /readyz honest DB readiness', () => {
+describe('Collector /readyz honest DB readiness (no Docker)', () => {
   const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.WORKER_ENABLED;
+    delete process.env.REDIS_URL;
+    resetSharedDbAdapterForTests();
+  });
+
+  afterEach(async () => {
+    await closeQueues().catch(() => undefined);
+    resetSharedDbAdapterForTests();
+    process.env = { ...originalEnv };
+  });
+
+  it('returns 503 when DATABASE_URL is missing', async () => {
+    delete process.env.DATABASE_URL;
+
+    const res = await app.request('/readyz');
+    expect(res.status).toBe(503);
+
+    const body = (await res.json()) as ReadyzBody;
+    expect(body.status).toBe('not_ready');
+    expect(body.checks.database.status).toBe('error');
+    expect(body.checks.database.message).toBe(PUBLIC_DB_NOT_READY_MESSAGE);
+    assertNoInternalLeak(body);
+  });
+
+  it('returns 503 when DATABASE_URL points at a refused port', async () => {
+    process.env.DATABASE_URL = REFUSED_DB_URL;
+
+    const res = await app.request('/readyz');
+    expect(res.status).toBe(503);
+
+    const body = (await res.json()) as ReadyzBody;
+    expect(body.status).toBe('not_ready');
+    expect(body.service).toBe('dns-ops-collector');
+    expect(body.checks.database.status).toBe('error');
+    expect(body.checks.database.message).toBe(PUBLIC_DB_NOT_READY_MESSAGE);
+    assertNoInternalLeak(body);
+  });
+
+  it('with WORKER_ENABLED=true and missing REDIS_URL returns 503 (not 500)', async () => {
+    // DB will fail (refused) OR we only care that queue/worker checks run as 503.
+    // Use refused DB so this stays Docker-free; database is error, queues/workers too.
+    process.env.DATABASE_URL = REFUSED_DB_URL;
+    process.env.WORKER_ENABLED = 'true';
+    delete process.env.REDIS_URL;
+
+    const res = await app.request('/readyz');
+    expect(res.status).toBe(503);
+    expect(res.status).not.toBe(500);
+
+    const body = (await res.json()) as ReadyzBody;
+    expect(body.status).toBe('not_ready');
+    expect(body.checks.database.status).toBe('error');
+    expect(body.checks.queues.status).toBe('error');
+    expect(body.checks.queues.message).toBe('Queue connection unavailable');
+    expect(body.checks.workers.status).toBe('error');
+    expect(body.checks.workers.message).toBe('Workers not running');
+    assertNoInternalLeak(body);
+  });
+
+  it('with WORKER_ENABLED=true and refused Redis returns 503 (not 500)', async () => {
+    process.env.DATABASE_URL = REFUSED_DB_URL;
+    process.env.WORKER_ENABLED = 'true';
+    process.env.REDIS_URL = REFUSED_REDIS_URL;
+
+    const res = await app.request('/readyz');
+    expect(res.status).toBe(503);
+    expect(res.status).not.toBe(500);
+
+    const body = (await res.json()) as ReadyzBody;
+    expect(body.status).toBe('not_ready');
+    expect(body.checks.queues.status).toBe('error');
+    expect(body.checks.queues.message).toBe('Queue connection unavailable');
+    assertNoInternalLeak(body);
+  }, 15_000);
+});
+
+/**
+ * Opt-in healthy DB path. Never runs from DATABASE_URL alone.
+ *
+ *   RUN_DB_INTEGRATION_TESTS=1 bunx vitest run apps/collector/src/index.test.ts
+ */
+describe('Collector /readyz disposable Postgres (integration)', () => {
+  const originalEnv = { ...process.env };
+  const describeIfDb = RUN_DB_INTEGRATION ? describe : describe.skip;
+
   let disposable:
     | {
         containerName: string;
         databaseUrl: string;
       }
     | undefined;
+  let containerNameForCleanup: string | undefined;
 
   beforeAll(async () => {
+    if (!RUN_DB_INTEGRATION) return;
+
     const port = await getFreePort();
     const containerName = `dns-ops-rt3-readyz-${process.pid}-${port}`;
+    containerNameForCleanup = containerName;
     const databaseUrl = `postgresql://postgres:postgres@127.0.0.1:${port}/postgres`;
 
-    spawn(
-      'docker',
-      [
-        'run',
-        '--rm',
-        '--name',
-        containerName,
-        '-e',
-        'POSTGRES_PASSWORD=postgres',
-        '-p',
-        `127.0.0.1:${port}:5432`,
-        'postgres:16-alpine',
-      ],
-      { stdio: 'ignore', detached: true }
-    ).unref();
+    try {
+      spawn(
+        'docker',
+        [
+          'run',
+          '--rm',
+          '--name',
+          containerName,
+          '-e',
+          'POSTGRES_PASSWORD=postgres',
+          '-p',
+          `127.0.0.1:${port}:5432`,
+          'postgres:16-alpine',
+        ],
+        { stdio: 'ignore', detached: true }
+      ).unref();
 
-    await waitForPostgres(databaseUrl);
-    disposable = { containerName, databaseUrl };
+      await waitForPostgres(databaseUrl);
+      disposable = { containerName, databaseUrl };
+    } catch (error) {
+      try {
+        execFileSync('docker', ['rm', '-f', containerName], { stdio: 'ignore' });
+      } catch {
+        // best-effort cleanup when setup fails
+      }
+      containerNameForCleanup = undefined;
+      throw error;
+    }
   }, 60_000);
 
   afterAll(() => {
-    if (!disposable) return;
+    const name = disposable?.containerName ?? containerNameForCleanup;
+    if (!name) return;
     try {
-      execFileSync('docker', ['rm', '-f', disposable.containerName], { stdio: 'ignore' });
+      execFileSync('docker', ['rm', '-f', name], { stdio: 'ignore' });
     } catch {
       // best-effort cleanup
     }
@@ -159,63 +270,37 @@ describe('Collector /readyz honest DB readiness', () => {
     process.env = { ...originalEnv };
   });
 
-  it('returns 503 when DATABASE_URL points at a refused port', async () => {
-    process.env.DATABASE_URL = REFUSED_DB_URL;
+  describeIfDb('when RUN_DB_INTEGRATION_TESTS=1', () => {
+    it('returns 200 after a real SELECT 1 against disposable local DB', async () => {
+      if (!disposable) throw new Error('Disposable Postgres was not started');
+      process.env.DATABASE_URL = disposable.databaseUrl;
 
-    const res = await app.request('/readyz');
-    expect(res.status).toBe(503);
+      const res = await app.request('/readyz');
+      expect(res.status).toBe(200);
 
-    const body = (await res.json()) as ReadyzBody;
-    expect(body.status).toBe('not_ready');
-    expect(body.service).toBe('dns-ops-collector');
-    expect(body.checks.database.status).toBe('error');
-    expect(body.checks.database.message).toBeTruthy();
+      const body = (await res.json()) as ReadyzBody;
+      expect(body.status).toBe('ready');
+      expect(body.checks.database.status).toBe('ok');
+      expect(body.checks.queues).toBeUndefined();
+      expect(body.checks.workers).toBeUndefined();
+    });
+
+    it('with WORKER_ENABLED=true and missing REDIS_URL keeps DB ok and returns 503', async () => {
+      if (!disposable) throw new Error('Disposable Postgres was not started');
+      process.env.DATABASE_URL = disposable.databaseUrl;
+      process.env.WORKER_ENABLED = 'true';
+      delete process.env.REDIS_URL;
+
+      const res = await app.request('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.status).not.toBe(500);
+
+      const body = (await res.json()) as ReadyzBody;
+      expect(body.status).toBe('not_ready');
+      expect(body.checks.database.status).toBe('ok');
+      expect(body.checks.queues.status).toBe('error');
+      expect(body.checks.workers.status).toBe('error');
+      assertNoInternalLeak(body);
+    });
   });
-
-  it('returns 200 after a real SELECT 1 against disposable local DB', async () => {
-    if (!disposable) throw new Error('Disposable Postgres was not started');
-    process.env.DATABASE_URL = disposable.databaseUrl;
-
-    const res = await app.request('/readyz');
-    expect(res.status).toBe(200);
-
-    const body = (await res.json()) as ReadyzBody;
-    expect(body.status).toBe('ready');
-    expect(body.checks.database.status).toBe('ok');
-    expect(body.checks.queues).toBeUndefined();
-    expect(body.checks.workers).toBeUndefined();
-  });
-
-  it('with WORKER_ENABLED=true and missing REDIS_URL returns 503 (not 500)', async () => {
-    if (!disposable) throw new Error('Disposable Postgres was not started');
-    process.env.DATABASE_URL = disposable.databaseUrl;
-    process.env.WORKER_ENABLED = 'true';
-    delete process.env.REDIS_URL;
-
-    const res = await app.request('/readyz');
-    expect(res.status).toBe(503);
-    expect(res.status).not.toBe(500);
-
-    const body = (await res.json()) as ReadyzBody;
-    expect(body.status).toBe('not_ready');
-    expect(body.checks.database.status).toBe('ok');
-    expect(body.checks.queues.status).toBe('error');
-    expect(body.checks.workers.status).toBe('error');
-  });
-
-  it('with WORKER_ENABLED=true and refused Redis returns 503 (not 500)', async () => {
-    if (!disposable) throw new Error('Disposable Postgres was not started');
-    process.env.DATABASE_URL = disposable.databaseUrl;
-    process.env.WORKER_ENABLED = 'true';
-    process.env.REDIS_URL = REFUSED_REDIS_URL;
-
-    const res = await app.request('/readyz');
-    expect(res.status).toBe(503);
-    expect(res.status).not.toBe(500);
-
-    const body = (await res.json()) as ReadyzBody;
-    expect(body.status).toBe('not_ready');
-    expect(body.checks.queues.status).toBe('error');
-    expect(body.checks.queues.message).toBeTruthy();
-  }, 15_000);
 });

--- a/apps/collector/src/index.test.ts
+++ b/apps/collector/src/index.test.ts
@@ -1,137 +1,221 @@
 /**
- * Collector Health Endpoint Tests - PR-07.7
+ * RT-3: Collector honest readiness
  *
- * Tests for /readyz endpoint:
- * - With Redis: GET /readyz → checks.queues.status:ok
- * - Without Redis: GET /readyz → 503 with checks.queues.status:error
- * - Verify workersRunning() returns correct status
+ * Behavioral tests proving:
+ * - /healthz, /health, /api/health are process-only liveness (200 without DB)
+ * - /readyz runs a real DB query (not adapter construction)
+ * - unreachable DB → 503
+ * - reachable disposable DB → 200 (when workers not required)
+ * - WORKER_ENABLED=true with bad/missing Redis → 503 (not 500)
  */
 
-import { describe, expect, it } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import pg from 'pg';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import app from './index.js';
+import { closeQueues } from './jobs/queue.js';
+import { resetSharedDbAdapterForTests } from './middleware/db.js';
 
-// We test the health endpoint behavior through the actual exported app
-// These are integration tests that verify the endpoint structure
+const REFUSED_DB_URL = 'postgresql://postgres:postgres@127.0.0.1:1/postgres';
+const REFUSED_REDIS_URL = 'redis://127.0.0.1:1';
 
-describe('Collector Health Endpoint Structure', () => {
-  describe('Health check responses', () => {
-    it('documents expected /healthz response shape', async () => {
-      // The /healthz endpoint should return:
-      // { status: 'ok', service: 'dns-ops-collector', timestamp: ISO string }
-      const expectedShape = {
-        status: 'ok',
-        service: 'dns-ops-collector',
-        timestamp: expect.any(String),
-      };
-      expect(expectedShape).toBeDefined();
+type ReadyzBody = {
+  status: 'ready' | 'not_ready';
+  service: string;
+  timestamp: string;
+  checks: Record<string, { status: 'ok' | 'error'; message?: string }>;
+};
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to allocate free port'));
+        return;
+      }
+      const { port } = address;
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve(port);
+      });
     });
+    server.on('error', reject);
+  });
+}
 
-    it('documents expected /health response shape', async () => {
-      const expectedShape = {
-        status: 'ok',
-        service: 'dns-ops-collector',
-        timestamp: expect.any(String),
-      };
-      expect(expectedShape).toBeDefined();
+async function waitForPostgres(url: string, attempts = 40): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    const client = new pg.Client({
+      connectionString: url,
+      connectionTimeoutMillis: 1000,
     });
+    try {
+      await client.connect();
+      await client.query('SELECT 1');
+      await client.end();
+      return;
+    } catch (error) {
+      lastError = error;
+      await client.end().catch(() => undefined);
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+  throw new Error(
+    `Disposable Postgres did not become ready: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`
+  );
+}
+
+describe('Collector liveness (process-only)', () => {
+  it('GET /healthz returns 200 without probing DB', async () => {
+    const previous = process.env.DATABASE_URL;
+    delete process.env.DATABASE_URL;
+    resetSharedDbAdapterForTests();
+
+    const res = await app.request('/healthz');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; service: string };
+    expect(body.status).toBe('ok');
+    expect(body.service).toBe('dns-ops-collector');
+
+    if (previous === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previous;
   });
 
-  describe('Ready check checks', () => {
-    it('documents database check is always performed', () => {
-      // The /readyz endpoint should always check database
-      const checks = ['database'];
-      expect(checks).toContain('database');
-    });
-
-    it('documents queue and worker checks are conditional on WORKER_ENABLED', () => {
-      // When WORKER_ENABLED=true, checks include: database, queues, workers
-      // When WORKER_ENABLED=undefined/false, only database check is performed
-      const checksWithWorkers = ['database', 'queues', 'workers'];
-      const checksWithoutWorkers = ['database'];
-
-      expect(checksWithWorkers).toHaveLength(3);
-      expect(checksWithoutWorkers).toHaveLength(1);
-    });
+  it('GET /health returns 200 without probing DB', async () => {
+    const res = await app.request('/health');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('ok');
   });
 
-  describe('workersRunning behavior', () => {
-    it('documents workersRunning returns boolean status', () => {
-      // workersRunning() should return true when workers are active
-      // and false when workers are not running
-      const workersActive = true;
-      const workersInactive = false;
-
-      expect(typeof workersActive).toBe('boolean');
-      expect(typeof workersInactive).toBe('boolean');
-    });
-
-    it('documents readyz returns 200 when all checks pass', () => {
-      // When database, queues, and workers are all healthy → 200
-      const allHealthy = true;
-      expect(allHealthy).toBe(true);
-    });
-
-    it('documents readyz returns 503 when any check fails', () => {
-      // When database, queues, or workers are unhealthy → 503
-      const someUnhealthy = false;
-      expect(someUnhealthy).toBe(false);
-    });
-  });
-
-  describe('Queue health check', () => {
-    it('documents queue check uses getQueueHealth()', () => {
-      // getQueueHealth() returns { available: boolean }
-      // If available: checks.queues.status = 'ok'
-      // If !available: checks.queues.status = 'error'
-      const queueAvailable = true;
-      const queueStatus = queueAvailable ? 'ok' : 'error';
-      expect(['ok', 'error']).toContain(queueStatus);
-    });
-
-    it('documents queue check contributes to overall readiness', () => {
-      // If queue is unavailable, overall status should be 'not_ready'
-      const queueAvailable = false;
-      const allHealthy = false;
-      expect(allHealthy).toBe(queueAvailable);
-    });
-  });
-
-  describe('Endpoint status codes', () => {
-    it('documents /healthz always returns 200', () => {
-      const healthzStatus = 200;
-      expect(healthzStatus).toBe(200);
-    });
-
-    it('documents /readyz returns 200 or 503', () => {
-      // /readyz can return 200 (ready) or 503 (not ready)
-      const possibleStatuses = [200, 503];
-      expect(possibleStatuses).toContain(200);
-      expect(possibleStatuses).toContain(503);
-    });
+  it('GET /api/health returns 200 without probing DB', async () => {
+    const res = await app.request('/api/health');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('ok');
   });
 });
 
-describe('Health Check Integration', () => {
-  it('documents expected checks structure when workers enabled', () => {
-    const checks = {
-      database: { status: 'ok' },
-      queues: { status: 'ok' },
-      workers: { status: 'ok' },
-    };
+describe('Collector /readyz honest DB readiness', () => {
+  const originalEnv = { ...process.env };
+  let disposable:
+    | {
+        containerName: string;
+        databaseUrl: string;
+      }
+    | undefined;
 
-    expect(checks).toHaveProperty('database');
-    expect(checks).toHaveProperty('queues');
-    expect(checks).toHaveProperty('workers');
+  beforeAll(async () => {
+    const port = await getFreePort();
+    const containerName = `dns-ops-rt3-readyz-${process.pid}-${port}`;
+    const databaseUrl = `postgresql://postgres:postgres@127.0.0.1:${port}/postgres`;
+
+    spawn(
+      'docker',
+      [
+        'run',
+        '--rm',
+        '--name',
+        containerName,
+        '-e',
+        'POSTGRES_PASSWORD=postgres',
+        '-p',
+        `127.0.0.1:${port}:5432`,
+        'postgres:16-alpine',
+      ],
+      { stdio: 'ignore', detached: true }
+    ).unref();
+
+    await waitForPostgres(databaseUrl);
+    disposable = { containerName, databaseUrl };
+  }, 60_000);
+
+  afterAll(() => {
+    if (!disposable) return;
+    try {
+      execFileSync('docker', ['rm', '-f', disposable.containerName], { stdio: 'ignore' });
+    } catch {
+      // best-effort cleanup
+    }
   });
 
-  it('documents checks with error details include message', () => {
-    const checks = {
-      database: { status: 'error', message: 'DB not initialized' },
-      queues: { status: 'error', message: 'Queue connection unavailable' },
-      workers: { status: 'error', message: 'Workers not running' },
-    };
-
-    expect(checks.database.message).toBeDefined();
-    expect(checks.queues.message).toBeDefined();
-    expect(checks.workers.message).toBeDefined();
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.WORKER_ENABLED;
+    delete process.env.REDIS_URL;
+    resetSharedDbAdapterForTests();
   });
+
+  afterEach(async () => {
+    await closeQueues().catch(() => undefined);
+    resetSharedDbAdapterForTests();
+    process.env = { ...originalEnv };
+  });
+
+  it('returns 503 when DATABASE_URL points at a refused port', async () => {
+    process.env.DATABASE_URL = REFUSED_DB_URL;
+
+    const res = await app.request('/readyz');
+    expect(res.status).toBe(503);
+
+    const body = (await res.json()) as ReadyzBody;
+    expect(body.status).toBe('not_ready');
+    expect(body.service).toBe('dns-ops-collector');
+    expect(body.checks.database.status).toBe('error');
+    expect(body.checks.database.message).toBeTruthy();
+  });
+
+  it('returns 200 after a real SELECT 1 against disposable local DB', async () => {
+    if (!disposable) throw new Error('Disposable Postgres was not started');
+    process.env.DATABASE_URL = disposable.databaseUrl;
+
+    const res = await app.request('/readyz');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as ReadyzBody;
+    expect(body.status).toBe('ready');
+    expect(body.checks.database.status).toBe('ok');
+    expect(body.checks.queues).toBeUndefined();
+    expect(body.checks.workers).toBeUndefined();
+  });
+
+  it('with WORKER_ENABLED=true and missing REDIS_URL returns 503 (not 500)', async () => {
+    if (!disposable) throw new Error('Disposable Postgres was not started');
+    process.env.DATABASE_URL = disposable.databaseUrl;
+    process.env.WORKER_ENABLED = 'true';
+    delete process.env.REDIS_URL;
+
+    const res = await app.request('/readyz');
+    expect(res.status).toBe(503);
+    expect(res.status).not.toBe(500);
+
+    const body = (await res.json()) as ReadyzBody;
+    expect(body.status).toBe('not_ready');
+    expect(body.checks.database.status).toBe('ok');
+    expect(body.checks.queues.status).toBe('error');
+    expect(body.checks.workers.status).toBe('error');
+  });
+
+  it('with WORKER_ENABLED=true and refused Redis returns 503 (not 500)', async () => {
+    if (!disposable) throw new Error('Disposable Postgres was not started');
+    process.env.DATABASE_URL = disposable.databaseUrl;
+    process.env.WORKER_ENABLED = 'true';
+    process.env.REDIS_URL = REFUSED_REDIS_URL;
+
+    const res = await app.request('/readyz');
+    expect(res.status).toBe(503);
+    expect(res.status).not.toBe(500);
+
+    const body = (await res.json()) as ReadyzBody;
+    expect(body.status).toBe('not_ready');
+    expect(body.checks.queues.status).toBe('error');
+    expect(body.checks.queues.message).toBeTruthy();
+  }, 15_000);
 });

--- a/apps/collector/src/index.ts
+++ b/apps/collector/src/index.ts
@@ -40,17 +40,28 @@ const collectorLogger = createLogger({
 /** Bound queue/redis readiness so a hung Redis client cannot stall the probe forever. */
 const QUEUE_HEALTH_TIMEOUT_MS = 2_000;
 
+/** Public-safe dependency messages — never echo driver/host/user details. */
+const PUBLIC_QUEUE_NOT_READY_MESSAGE = 'Queue connection unavailable';
+const PUBLIC_WORKERS_NOT_READY_MESSAGE = 'Workers not running';
+
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
+    let settled = false;
     const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
       reject(new Error(`${label} timed out after ${ms}ms`));
     }, ms);
     promise.then(
       (value) => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
         resolve(value);
       },
       (error: unknown) => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
         reject(error);
       }
@@ -99,7 +110,7 @@ app.get('/readyz', async (c) => {
   const checks: Record<string, { status: 'ok' | 'error'; message?: string }> = {};
   let allHealthy = true;
 
-  // Real dependency proof — SELECT 1, not adapter construction.
+  // Real dependency proof — bounded SELECT 1, not adapter construction.
   const dbCheck = await checkDatabaseReady();
   if (dbCheck.ok) {
     checks.database = { status: 'ok' };
@@ -119,21 +130,26 @@ app.get('/readyz', async (c) => {
 
       checks.queues = queueHealth.available
         ? { status: 'ok' }
-        : { status: 'error', message: 'Queue connection unavailable' };
+        : { status: 'error', message: PUBLIC_QUEUE_NOT_READY_MESSAGE };
       if (!queueHealth.available) {
         allHealthy = false;
       }
     } catch (error) {
+      collectorLogger.error(
+        'Queue readiness check failed',
+        error instanceof Error ? error : new Error(String(error)),
+        { path: '/readyz' }
+      );
       checks.queues = {
         status: 'error',
-        message: error instanceof Error ? error.message : 'Queue check failed',
+        message: PUBLIC_QUEUE_NOT_READY_MESSAGE,
       };
       allHealthy = false;
     }
 
     checks.workers = workersRunning()
       ? { status: 'ok' }
-      : { status: 'error', message: 'Workers not running' };
+      : { status: 'error', message: PUBLIC_WORKERS_NOT_READY_MESSAGE };
     if (!workersRunning()) {
       allHealthy = false;
     }
@@ -192,30 +208,32 @@ export default app;
  * Boot the HTTP server and optional workers.
  * Skipped under Vitest so readiness tests can import the app without binding a port.
  */
-function bootstrap(): void {
+async function bootstrap(): Promise<void> {
   assertEnvValid();
 
   const { port } = getEnvConfig();
+
+  // Start workers before accepting traffic so configured /readyz healthchecks
+  // do not observe a transient workers-not-running window after listen.
+  if (process.env.WORKER_ENABLED === 'true') {
+    collectorLogger.info('Starting job queue workers...');
+    await startWorkers();
+
+    collectorLogger.info('Initializing monitoring schedules...');
+    await initializeSchedules();
+  }
 
   const server = serve(
     {
       fetch: app.fetch,
       port,
     },
-    async (info) => {
+    (info) => {
       collectorLogger.info('DNS Ops Collector started', {
         port: info.port,
         livenessUrl: `http://localhost:${info.port}/healthz`,
         readinessUrl: `http://localhost:${info.port}/readyz`,
       });
-
-      if (process.env.WORKER_ENABLED === 'true') {
-        collectorLogger.info('Starting job queue workers...');
-        await startWorkers();
-
-        collectorLogger.info('Initializing monitoring schedules...');
-        await initializeSchedules();
-      }
     }
   );
 
@@ -248,5 +266,11 @@ const shouldBootstrap =
   process.env.VITEST !== 'true' && process.env.COLLECTOR_SKIP_LISTEN !== 'true';
 
 if (shouldBootstrap) {
-  bootstrap();
+  void bootstrap().catch((error: unknown) => {
+    collectorLogger.error(
+      'Collector bootstrap failed',
+      error instanceof Error ? error : new Error(String(error))
+    );
+    process.exit(1);
+  });
 }

--- a/apps/collector/src/index.ts
+++ b/apps/collector/src/index.ts
@@ -24,13 +24,11 @@ import { probeRoutes } from './jobs/probe-routes.js';
 import { closeQueues, getQueueHealth } from './jobs/queue.js';
 import { cleanupSchedules, initializeSchedules } from './jobs/scheduler.js';
 import { startWorkers, stopWorkers, workersRunning } from './jobs/worker.js';
-import { dbMiddleware, getSharedDbAdapter } from './middleware/db.js';
+import { checkDatabaseReady, dbMiddleware } from './middleware/db.js';
 import { requireServiceAuthMiddleware } from './middleware/index.js';
 import { rateLimitMiddleware } from './middleware/rate-limit.js';
 import { notificationRoutes } from './notifications/routes.js';
 import type { Env } from './types.js';
-
-assertEnvValid();
 
 // Create logger before middleware that uses it
 const collectorLogger = createLogger({
@@ -38,6 +36,27 @@ const collectorLogger = createLogger({
   version: '1.0.0',
   minLevel: 'info',
 });
+
+/** Bound queue/redis readiness so a hung Redis client cannot stall the probe forever. */
+const QUEUE_HEALTH_TIMEOUT_MS = 2_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
 
 const app = new Hono<Env>();
 
@@ -50,6 +69,7 @@ app.use(
   }) as unknown as MiddlewareHandler
 );
 
+// Liveness: process-only. Never probe dependencies here.
 app.get('/healthz', (c) => {
   return c.json({
     status: 'ok',
@@ -66,7 +86,7 @@ app.get('/health', (c) => {
   });
 });
 
-// Shared health endpoint for unified railway.toml healthcheckPath
+// Shared health endpoint for unified railway.toml healthcheckPath (liveness-style).
 app.get('/api/health', (c) => {
   return c.json({
     status: 'ok',
@@ -79,24 +99,35 @@ app.get('/readyz', async (c) => {
   const checks: Record<string, { status: 'ok' | 'error'; message?: string }> = {};
   let allHealthy = true;
 
-  try {
-    getSharedDbAdapter();
+  // Real dependency proof — SELECT 1, not adapter construction.
+  const dbCheck = await checkDatabaseReady();
+  if (dbCheck.ok) {
     checks.database = { status: 'ok' };
-  } catch (error) {
-    checks.database = {
-      status: 'error',
-      message: error instanceof Error ? error.message : 'DB not initialized',
-    };
+  } else {
+    checks.database = { status: 'error', message: dbCheck.message };
     allHealthy = false;
   }
 
   if (process.env.WORKER_ENABLED === 'true') {
-    const queueHealth = await getQueueHealth();
+    // Queue/redis failures must surface as 503 (not_ready), never as an uncaught 500.
+    try {
+      const queueHealth = await withTimeout(
+        getQueueHealth(),
+        QUEUE_HEALTH_TIMEOUT_MS,
+        'Queue health check'
+      );
 
-    checks.queues = queueHealth.available
-      ? { status: 'ok' }
-      : { status: 'error', message: 'Queue connection unavailable' };
-    if (!queueHealth.available) {
+      checks.queues = queueHealth.available
+        ? { status: 'ok' }
+        : { status: 'error', message: 'Queue connection unavailable' };
+      if (!queueHealth.available) {
+        allHealthy = false;
+      }
+    } catch (error) {
+      checks.queues = {
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Queue check failed',
+      };
       allHealthy = false;
     }
 
@@ -155,52 +186,67 @@ app.onError((err, c) => {
   );
 });
 
-const { port } = getEnvConfig();
+export default app;
 
-const server = serve(
-  {
-    fetch: app.fetch,
-    port,
-  },
-  async (info) => {
-    collectorLogger.info('DNS Ops Collector started', {
-      port: info.port,
-      livenessUrl: `http://localhost:${info.port}/healthz`,
-      readinessUrl: `http://localhost:${info.port}/readyz`,
-    });
+/**
+ * Boot the HTTP server and optional workers.
+ * Skipped under Vitest so readiness tests can import the app without binding a port.
+ */
+function bootstrap(): void {
+  assertEnvValid();
 
-    if (process.env.WORKER_ENABLED === 'true') {
-      collectorLogger.info('Starting job queue workers...');
-      await startWorkers();
+  const { port } = getEnvConfig();
 
-      collectorLogger.info('Initializing monitoring schedules...');
-      await initializeSchedules();
+  const server = serve(
+    {
+      fetch: app.fetch,
+      port,
+    },
+    async (info) => {
+      collectorLogger.info('DNS Ops Collector started', {
+        port: info.port,
+        livenessUrl: `http://localhost:${info.port}/healthz`,
+        readinessUrl: `http://localhost:${info.port}/readyz`,
+      });
+
+      if (process.env.WORKER_ENABLED === 'true') {
+        collectorLogger.info('Starting job queue workers...');
+        await startWorkers();
+
+        collectorLogger.info('Initializing monitoring schedules...');
+        await initializeSchedules();
+      }
     }
+  );
+
+  async function shutdown(signal: string): Promise<void> {
+    collectorLogger.info('Received shutdown signal', { signal });
+
+    if (workersRunning()) {
+      collectorLogger.info('Cleaning up schedules...');
+      await cleanupSchedules();
+
+      collectorLogger.info('Stopping workers...');
+      await stopWorkers();
+    }
+
+    collectorLogger.info('Closing queue connections...');
+    await closeQueues();
+
+    collectorLogger.info('Closing HTTP server...');
+    server.close();
+
+    collectorLogger.info('Shutdown complete');
+    process.exit(0);
   }
-);
 
-async function shutdown(signal: string): Promise<void> {
-  collectorLogger.info('Received shutdown signal', { signal });
-
-  if (workersRunning()) {
-    collectorLogger.info('Cleaning up schedules...');
-    await cleanupSchedules();
-
-    collectorLogger.info('Stopping workers...');
-    await stopWorkers();
-  }
-
-  collectorLogger.info('Closing queue connections...');
-  await closeQueues();
-
-  collectorLogger.info('Closing HTTP server...');
-  server.close();
-
-  collectorLogger.info('Shutdown complete');
-  process.exit(0);
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-process.on('SIGTERM', () => shutdown('SIGTERM'));
-process.on('SIGINT', () => shutdown('SIGINT'));
+const shouldBootstrap =
+  process.env.VITEST !== 'true' && process.env.COLLECTOR_SKIP_LISTEN !== 'true';
 
-export default app;
+if (shouldBootstrap) {
+  bootstrap();
+}

--- a/apps/collector/src/middleware/db.ts
+++ b/apps/collector/src/middleware/db.ts
@@ -4,17 +4,22 @@
  * Sets up database context for collector routes.
  * Creates a PostgreSQL adapter once per process and attaches it to the Hono context.
  *
- * Readiness checks must call checkDatabaseReady() which runs a real SELECT 1 —
- * constructing the adapter alone is not proof the database is reachable.
+ * Readiness checks must call checkDatabaseReady() which runs a bounded real
+ * SELECT 1 via a short-lived client — constructing the adapter alone is not
+ * proof the database is reachable, and ordinary shared-pool queries must not
+ * inherit the readiness timeout.
  */
 
 import type { IDatabaseAdapter } from '@dns-ops/db';
-import { createPostgresAdapter, pingDatabase } from '@dns-ops/db';
+import { createPostgresAdapter, pingDatabaseForReadiness } from '@dns-ops/db';
 import { createMiddleware } from 'hono/factory';
 import type { Env } from '../types.js';
 import { getCollectorLogger } from './error-tracking.js';
 
 const logger = getCollectorLogger();
+
+/** Public-safe message — never echo driver/host/user details on readiness. */
+export const PUBLIC_DB_NOT_READY_MESSAGE = 'Database unreachable';
 
 let sharedAdapter: IDatabaseAdapter | null = null;
 let sharedDatabaseUrl: string | null = null;
@@ -52,16 +57,33 @@ export function resetSharedDbAdapterForTests(): void {
 /**
  * Prove the configured database is reachable with a bounded SELECT 1.
  * Adapter construction alone is not sufficient (false-green).
+ *
+ * Uses a short-lived client with an explicit timeout so a blackholed peer
+ * cannot stall readiness. Does not apply that timeout to the shared adapter
+ * used by ordinary application queries.
  */
-export async function checkDatabaseReady(): Promise<{ ok: true } | { ok: false; message: string }> {
+export async function checkDatabaseReady(options?: {
+  timeoutMs?: number;
+}): Promise<{ ok: true } | { ok: false; message: string }> {
   try {
-    const db = getSharedDbAdapter();
-    await pingDatabase(db);
+    const databaseUrl = getDatabaseUrl();
+    await pingDatabaseForReadiness(databaseUrl, options);
+    // Warm the shared adapter only after connectivity is proven.
+    getSharedDbAdapter();
     return { ok: true };
   } catch (error) {
+    const detail = error instanceof Error ? error.message : 'DB check failed';
+    logger.error(
+      'Database readiness check failed',
+      error instanceof Error ? error : new Error(detail),
+      {
+        path: '/readyz',
+      }
+    );
     return {
       ok: false,
-      message: error instanceof Error ? error.message : 'DB check failed',
+      // Never surface driver/host/user material on the public readiness body.
+      message: PUBLIC_DB_NOT_READY_MESSAGE,
     };
   }
 }

--- a/apps/collector/src/middleware/db.ts
+++ b/apps/collector/src/middleware/db.ts
@@ -3,10 +3,13 @@
  *
  * Sets up database context for collector routes.
  * Creates a PostgreSQL adapter once per process and attaches it to the Hono context.
+ *
+ * Readiness checks must call checkDatabaseReady() which runs a real SELECT 1 —
+ * constructing the adapter alone is not proof the database is reachable.
  */
 
 import type { IDatabaseAdapter } from '@dns-ops/db';
-import { createPostgresAdapter } from '@dns-ops/db';
+import { createPostgresAdapter, pingDatabase } from '@dns-ops/db';
 import { createMiddleware } from 'hono/factory';
 import type { Env } from '../types.js';
 import { getCollectorLogger } from './error-tracking.js';
@@ -35,6 +38,32 @@ export function getSharedDbAdapter(): IDatabaseAdapter {
   }
 
   return sharedAdapter;
+}
+
+/**
+ * Reset the process-scoped adapter cache.
+ * Intended for tests that change DATABASE_URL between cases.
+ */
+export function resetSharedDbAdapterForTests(): void {
+  sharedAdapter = null;
+  sharedDatabaseUrl = null;
+}
+
+/**
+ * Prove the configured database is reachable with a bounded SELECT 1.
+ * Adapter construction alone is not sufficient (false-green).
+ */
+export async function checkDatabaseReady(): Promise<{ ok: true } | { ok: false; message: string }> {
+  try {
+    const db = getSharedDbAdapter();
+    await pingDatabase(db);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : 'DB check failed',
+    };
+  }
 }
 
 export const dbMiddleware = createMiddleware<Env>(async (c, next) => {

--- a/apps/web/hono/routes/api.ts
+++ b/apps/web/hono/routes/api.ts
@@ -8,6 +8,7 @@ import {
 } from '@dns-ops/db';
 import { type Domain, domains } from '@dns-ops/db/schema';
 import { Hono } from 'hono';
+import { getEnvConfig } from '../config/env.js';
 import { collectorCircuit, proxyToCollector } from '../lib/collector-proxy.js';
 import {
   requireAdminAccess,
@@ -87,8 +88,10 @@ apiRoutes.get('/health', async (c) => {
   };
 
   // Adapter presence alone is a false-green; require a configured URL and a
-  // bounded SELECT 1. Public body never includes driver/host/user details.
-  const databaseUrl = process.env.DATABASE_URL;
+  // bounded SELECT 1. Resolve URL the same way db middleware does (bindings +
+  // HYPERDRIVE_URL fallback), not process.env.DATABASE_URL alone.
+  // Public body never includes driver/host/user details.
+  const { databaseUrl } = getEnvConfig(c.env);
   if (!db || !databaseUrl) {
     return c.json(degradedBody, 503);
   }

--- a/apps/web/hono/routes/api.ts
+++ b/apps/web/hono/routes/api.ts
@@ -2,6 +2,7 @@ import {
   DomainRepository,
   type IDatabaseAdapter,
   ObservationRepository,
+  pingDatabase,
   RecordSetRepository,
   SnapshotRepository,
 } from '@dns-ops/db';
@@ -75,23 +76,34 @@ async function resolveAccessibleSnapshot(
   return { snapshot, domain };
 }
 
-apiRoutes.get('/health', (c) => {
+// Railway readiness endpoint: 200 only after a real DB query succeeds.
+apiRoutes.get('/health', async (c) => {
   const db = c.get('db');
-  const hasDbConnection = !!db;
+  const degradedBody = {
+    status: 'degraded' as const,
+    service: 'dns-ops-web',
+    timestamp: new Date().toISOString(),
+    warning: 'Database connection not available - API functionality limited',
+  };
 
-  return c.json(
-    {
-      status: hasDbConnection ? 'healthy' : 'degraded',
-      service: 'dns-ops-web',
-      timestamp: new Date().toISOString(),
-      ...(hasDbConnection
-        ? {}
-        : {
-            warning: 'Database connection not available - API functionality limited',
-          }),
-    },
-    hasDbConnection ? 200 : 503
-  );
+  if (!db) {
+    return c.json(degradedBody, 503);
+  }
+
+  try {
+    // Prove reachability — adapter presence alone is a false-green.
+    await pingDatabase(db);
+    return c.json(
+      {
+        status: 'healthy' as const,
+        service: 'dns-ops-web',
+        timestamp: new Date().toISOString(),
+      },
+      200
+    );
+  } catch {
+    return c.json(degradedBody, 503);
+  }
 });
 
 // Detailed health check with admin access (PR-10.3)

--- a/apps/web/hono/routes/api.ts
+++ b/apps/web/hono/routes/api.ts
@@ -2,7 +2,7 @@ import {
   DomainRepository,
   type IDatabaseAdapter,
   ObservationRepository,
-  pingDatabase,
+  pingDatabaseForReadiness,
   RecordSetRepository,
   SnapshotRepository,
 } from '@dns-ops/db';
@@ -86,13 +86,15 @@ apiRoutes.get('/health', async (c) => {
     warning: 'Database connection not available - API functionality limited',
   };
 
-  if (!db) {
+  // Adapter presence alone is a false-green; require a configured URL and a
+  // bounded SELECT 1. Public body never includes driver/host/user details.
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!db || !databaseUrl) {
     return c.json(degradedBody, 503);
   }
 
   try {
-    // Prove reachability — adapter presence alone is a false-green.
-    await pingDatabase(db);
+    await pingDatabaseForReadiness(databaseUrl);
     return c.json(
       {
         status: 'healthy' as const,
@@ -101,7 +103,12 @@ apiRoutes.get('/health', async (c) => {
       },
       200
     );
-  } catch {
+  } catch (error) {
+    getWebLogger().error(
+      'Web readiness DB check failed',
+      error instanceof Error ? error : new Error(String(error)),
+      { path: '/api/health', method: 'GET' }
+    );
     return c.json(degradedBody, 503);
   }
 });

--- a/apps/web/hono/routes/health.ready.test.ts
+++ b/apps/web/hono/routes/health.ready.test.ts
@@ -144,6 +144,51 @@ describe('GET /api/health honest readiness (RT-3, no Docker)', () => {
     expect(body.warning).toBeTruthy();
     assertNoInternalLeak(body);
   });
+
+  it('resolves connection URL via getEnvConfig HYPERDRIVE_URL bindings (not process.env alone)', async () => {
+    // Neither process env var is set — only request bindings supply the URL.
+    delete process.env.DATABASE_URL;
+    delete process.env.HYPERDRIVE_URL;
+
+    const unreachable = createPostgresAdapter(REFUSED_DB_URL);
+    const app = createHealthApp(unreachable);
+
+    // Without bindings, missing URL short-circuits to degraded (same status),
+    // but with HYPERDRIVE_URL bindings getEnvConfig must surface the URL and
+    // the handler must attempt a real probe against the refused port.
+    const res = await app.request('/api/health', undefined, {
+      HYPERDRIVE_URL: REFUSED_DB_URL,
+    });
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe('degraded');
+    expect(body.service).toBe('dns-ops-web');
+    expect(body.warning).toMatch(/Database connection not available/i);
+    assertNoInternalLeak(body);
+
+    // Control: same app with no bindings and no process env must also be 503
+    // (missing URL) — establishes that bindings path is exercised above via
+    // refused-port probe rather than only adapter presence.
+    const missingUrlRes = await app.request('/api/health');
+    expect(missingUrlRes.status).toBe(503);
+  });
+
+  it('resolves process.env.HYPERDRIVE_URL when DATABASE_URL is unset', async () => {
+    delete process.env.DATABASE_URL;
+    process.env.HYPERDRIVE_URL = REFUSED_DB_URL;
+
+    const unreachable = createPostgresAdapter(REFUSED_DB_URL);
+    const app = createHealthApp(unreachable);
+
+    const res = await app.request('/api/health');
+    expect(res.status).toBe(503);
+
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe('degraded');
+    expect(body.warning).toBeTruthy();
+    assertNoInternalLeak(body);
+  });
 });
 
 /**

--- a/apps/web/hono/routes/health.ready.test.ts
+++ b/apps/web/hono/routes/health.ready.test.ts
@@ -2,21 +2,26 @@
  * RT-3: Web /api/health honest readiness
  *
  * Railway readiness endpoint semantics:
- * - 503 when DB is missing or unreachable (real query fails)
+ * - 503 when DB is missing or unreachable (real bounded query fails)
  * - 200 only after a real SELECT 1 succeeds
  * - Preserve public response shape (status/service/timestamp[/warning])
+ * - Never leak driver/host/user details in the public body
+ *
+ * Healthy disposable Postgres is opt-in only:
+ *   RUN_DB_INTEGRATION_TESTS=1
+ * Default unit runs never require Docker.
  */
 
 import { execFileSync, spawn } from 'node:child_process';
 import { createServer } from 'node:net';
-import { createPostgresAdapter } from '@dns-ops/db';
+import { createPostgresAdapter, pingDatabaseForReadiness } from '@dns-ops/db';
 import { Hono } from 'hono';
-import pg from 'pg';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../types.js';
 import { apiRoutes } from './api.js';
 
 const REFUSED_DB_URL = 'postgresql://postgres:postgres@127.0.0.1:1/postgres';
+const RUN_DB_INTEGRATION = process.env.RUN_DB_INTEGRATION_TESTS === '1';
 
 type HealthBody = {
   status: 'healthy' | 'degraded';
@@ -60,18 +65,11 @@ function getFreePort(): Promise<number> {
 async function waitForPostgres(url: string, attempts = 40): Promise<void> {
   let lastError: unknown;
   for (let i = 0; i < attempts; i++) {
-    const client = new pg.Client({
-      connectionString: url,
-      connectionTimeoutMillis: 1000,
-    });
     try {
-      await client.connect();
-      await client.query('SELECT 1');
-      await client.end();
+      await pingDatabaseForReadiness(url, { timeoutMs: 1_000 });
       return;
     } catch (error) {
       lastError = error;
-      await client.end().catch(() => undefined);
       await new Promise((r) => setTimeout(r, 250));
     }
   }
@@ -82,49 +80,30 @@ async function waitForPostgres(url: string, attempts = 40): Promise<void> {
   );
 }
 
-describe('GET /api/health honest readiness (RT-3)', () => {
-  let disposable:
-    | {
-        containerName: string;
-        databaseUrl: string;
-      }
-    | undefined;
+function assertNoInternalLeak(body: HealthBody): void {
+  const serialized = JSON.stringify(body);
+  expect(serialized).not.toMatch(/127\.0\.0\.1/);
+  expect(serialized).not.toMatch(/ECONNREFUSED/i);
+  expect(serialized).not.toMatch(/password/i);
+  expect(serialized).not.toMatch(/postgresql:\/\//i);
+  expect(serialized).not.toMatch(/postgres:postgres/i);
+  expect(serialized).not.toMatch(/AggregateError/i);
+  expect(serialized).not.toMatch(/timed out after/i);
+}
 
-  beforeAll(async () => {
-    const port = await getFreePort();
-    const containerName = `dns-ops-rt3-web-health-${process.pid}-${port}`;
-    const databaseUrl = `postgresql://postgres:postgres@127.0.0.1:${port}/postgres`;
+describe('GET /api/health honest readiness (RT-3, no Docker)', () => {
+  const originalEnv = { ...process.env };
 
-    spawn(
-      'docker',
-      [
-        'run',
-        '--rm',
-        '--name',
-        containerName,
-        '-e',
-        'POSTGRES_PASSWORD=postgres',
-        '-p',
-        `127.0.0.1:${port}:5432`,
-        'postgres:16-alpine',
-      ],
-      { stdio: 'ignore', detached: true }
-    ).unref();
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
 
-    await waitForPostgres(databaseUrl);
-    disposable = { containerName, databaseUrl };
-  }, 60_000);
-
-  afterAll(() => {
-    if (!disposable) return;
-    try {
-      execFileSync('docker', ['rm', '-f', disposable.containerName], { stdio: 'ignore' });
-    } catch {
-      // best-effort cleanup
-    }
+  afterEach(() => {
+    process.env = { ...originalEnv };
   });
 
   it('returns 503 when db context is missing', async () => {
+    delete process.env.DATABASE_URL;
     const app = createHealthApp(undefined);
     const res = await app.request('/api/health');
 
@@ -134,9 +113,25 @@ describe('GET /api/health honest readiness (RT-3)', () => {
     expect(body.service).toBe('dns-ops-web');
     expect(body.timestamp).toBeTruthy();
     expect(body.warning).toMatch(/Database connection not available/i);
+    assertNoInternalLeak(body);
+  });
+
+  it('returns 503 when DATABASE_URL is missing even if db is present', async () => {
+    delete process.env.DATABASE_URL;
+    // Presence of adapter alone must not green the probe.
+    const unreachable = createPostgresAdapter(REFUSED_DB_URL);
+    const app = createHealthApp(unreachable);
+
+    const res = await app.request('/api/health');
+    expect(res.status).toBe(503);
+
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe('degraded');
+    assertNoInternalLeak(body);
   });
 
   it('returns 503 when DB port refuses connections (false-green regression)', async () => {
+    process.env.DATABASE_URL = REFUSED_DB_URL;
     const unreachable = createPostgresAdapter(REFUSED_DB_URL);
     const app = createHealthApp(unreachable);
 
@@ -147,20 +142,99 @@ describe('GET /api/health honest readiness (RT-3)', () => {
     expect(body.status).toBe('degraded');
     expect(body.service).toBe('dns-ops-web');
     expect(body.warning).toBeTruthy();
+    assertNoInternalLeak(body);
+  });
+});
+
+/**
+ * Opt-in healthy DB path. Never runs from DATABASE_URL alone.
+ *
+ *   RUN_DB_INTEGRATION_TESTS=1 bunx vitest run apps/web/hono/routes/health.ready.test.ts
+ */
+describe('GET /api/health disposable Postgres (integration)', () => {
+  const originalEnv = { ...process.env };
+  const describeIfDb = RUN_DB_INTEGRATION ? describe : describe.skip;
+
+  let disposable:
+    | {
+        containerName: string;
+        databaseUrl: string;
+      }
+    | undefined;
+  let containerNameForCleanup: string | undefined;
+
+  beforeAll(async () => {
+    if (!RUN_DB_INTEGRATION) return;
+
+    const port = await getFreePort();
+    const containerName = `dns-ops-rt3-web-health-${process.pid}-${port}`;
+    containerNameForCleanup = containerName;
+    const databaseUrl = `postgresql://postgres:postgres@127.0.0.1:${port}/postgres`;
+
+    try {
+      spawn(
+        'docker',
+        [
+          'run',
+          '--rm',
+          '--name',
+          containerName,
+          '-e',
+          'POSTGRES_PASSWORD=postgres',
+          '-p',
+          `127.0.0.1:${port}:5432`,
+          'postgres:16-alpine',
+        ],
+        { stdio: 'ignore', detached: true }
+      ).unref();
+
+      await waitForPostgres(databaseUrl);
+      disposable = { containerName, databaseUrl };
+    } catch (error) {
+      try {
+        execFileSync('docker', ['rm', '-f', containerName], { stdio: 'ignore' });
+      } catch {
+        // best-effort cleanup when setup fails
+      }
+      containerNameForCleanup = undefined;
+      throw error;
+    }
+  }, 60_000);
+
+  afterAll(() => {
+    const name = disposable?.containerName ?? containerNameForCleanup;
+    if (!name) return;
+    try {
+      execFileSync('docker', ['rm', '-f', name], { stdio: 'ignore' });
+    } catch {
+      // best-effort cleanup
+    }
   });
 
-  it('returns 200 only after a real query against disposable local DB', async () => {
-    if (!disposable) throw new Error('Disposable Postgres was not started');
-    const db = createPostgresAdapter(disposable.databaseUrl);
-    const app = createHealthApp(db);
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
 
-    const res = await app.request('/api/health');
-    expect(res.status).toBe(200);
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
 
-    const body = (await res.json()) as HealthBody;
-    expect(body.status).toBe('healthy');
-    expect(body.service).toBe('dns-ops-web');
-    expect(body.timestamp).toBeTruthy();
-    expect(body.warning).toBeUndefined();
+  describeIfDb('when RUN_DB_INTEGRATION_TESTS=1', () => {
+    it('returns 200 only after a real query against disposable local DB', async () => {
+      if (!disposable) throw new Error('Disposable Postgres was not started');
+      process.env.DATABASE_URL = disposable.databaseUrl;
+      const db = createPostgresAdapter(disposable.databaseUrl);
+      const app = createHealthApp(db);
+
+      const res = await app.request('/api/health');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as HealthBody;
+      expect(body.status).toBe('healthy');
+      expect(body.service).toBe('dns-ops-web');
+      expect(body.timestamp).toBeTruthy();
+      expect(body.warning).toBeUndefined();
+      assertNoInternalLeak(body);
+    });
   });
 });

--- a/apps/web/hono/routes/health.ready.test.ts
+++ b/apps/web/hono/routes/health.ready.test.ts
@@ -1,0 +1,166 @@
+/**
+ * RT-3: Web /api/health honest readiness
+ *
+ * Railway readiness endpoint semantics:
+ * - 503 when DB is missing or unreachable (real query fails)
+ * - 200 only after a real SELECT 1 succeeds
+ * - Preserve public response shape (status/service/timestamp[/warning])
+ */
+
+import { execFileSync, spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { createPostgresAdapter } from '@dns-ops/db';
+import { Hono } from 'hono';
+import pg from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../types.js';
+import { apiRoutes } from './api.js';
+
+const REFUSED_DB_URL = 'postgresql://postgres:postgres@127.0.0.1:1/postgres';
+
+type HealthBody = {
+  status: 'healthy' | 'degraded';
+  service: string;
+  timestamp: string;
+  warning?: string;
+};
+
+function createHealthApp(db: Env['Variables']['db'] | undefined) {
+  const app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    if (db) {
+      c.set('db', db);
+    }
+    await next();
+  });
+  app.route('/api', apiRoutes);
+  return app;
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to allocate free port'));
+        return;
+      }
+      const { port } = address;
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve(port);
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+async function waitForPostgres(url: string, attempts = 40): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    const client = new pg.Client({
+      connectionString: url,
+      connectionTimeoutMillis: 1000,
+    });
+    try {
+      await client.connect();
+      await client.query('SELECT 1');
+      await client.end();
+      return;
+    } catch (error) {
+      lastError = error;
+      await client.end().catch(() => undefined);
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+  throw new Error(
+    `Disposable Postgres did not become ready: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`
+  );
+}
+
+describe('GET /api/health honest readiness (RT-3)', () => {
+  let disposable:
+    | {
+        containerName: string;
+        databaseUrl: string;
+      }
+    | undefined;
+
+  beforeAll(async () => {
+    const port = await getFreePort();
+    const containerName = `dns-ops-rt3-web-health-${process.pid}-${port}`;
+    const databaseUrl = `postgresql://postgres:postgres@127.0.0.1:${port}/postgres`;
+
+    spawn(
+      'docker',
+      [
+        'run',
+        '--rm',
+        '--name',
+        containerName,
+        '-e',
+        'POSTGRES_PASSWORD=postgres',
+        '-p',
+        `127.0.0.1:${port}:5432`,
+        'postgres:16-alpine',
+      ],
+      { stdio: 'ignore', detached: true }
+    ).unref();
+
+    await waitForPostgres(databaseUrl);
+    disposable = { containerName, databaseUrl };
+  }, 60_000);
+
+  afterAll(() => {
+    if (!disposable) return;
+    try {
+      execFileSync('docker', ['rm', '-f', disposable.containerName], { stdio: 'ignore' });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  it('returns 503 when db context is missing', async () => {
+    const app = createHealthApp(undefined);
+    const res = await app.request('/api/health');
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe('degraded');
+    expect(body.service).toBe('dns-ops-web');
+    expect(body.timestamp).toBeTruthy();
+    expect(body.warning).toMatch(/Database connection not available/i);
+  });
+
+  it('returns 503 when DB port refuses connections (false-green regression)', async () => {
+    const unreachable = createPostgresAdapter(REFUSED_DB_URL);
+    const app = createHealthApp(unreachable);
+
+    const res = await app.request('/api/health');
+    expect(res.status).toBe(503);
+
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe('degraded');
+    expect(body.service).toBe('dns-ops-web');
+    expect(body.warning).toBeTruthy();
+  });
+
+  it('returns 200 only after a real query against disposable local DB', async () => {
+    if (!disposable) throw new Error('Disposable Postgres was not started');
+    const db = createPostgresAdapter(disposable.databaseUrl);
+    const app = createHealthApp(db);
+
+    const res = await app.request('/api/health');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe('healthy');
+    expect(body.service).toBe('dns-ops-web');
+    expect(body.timestamp).toBeTruthy();
+    expect(body.warning).toBeUndefined();
+  });
+});

--- a/apps/web/hono/routes/health.url-resolution.test.ts
+++ b/apps/web/hono/routes/health.url-resolution.test.ts
@@ -1,0 +1,103 @@
+/**
+ * RT-3 follow-up: /api/health must resolve the DB URL via getEnvConfig(c.env)
+ * (bindings + HYPERDRIVE_URL fallback), not process.env.DATABASE_URL alone.
+ *
+ * Behavioral coverage with a mocked readiness ping so we assert the exact URL
+ * passed to the probe without needing a live database.
+ */
+
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../types.js';
+
+const pingDatabaseForReadiness = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('@dns-ops/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dns-ops/db')>();
+  return {
+    ...actual,
+    pingDatabaseForReadiness,
+  };
+});
+
+const { apiRoutes } = await import('./api.js');
+
+const STUB_DB = { dialect: 'postgres' } as unknown as IDatabaseAdapter;
+const HYPERDRIVE_URL = 'postgresql://hd-user:secret@hyperdrive.internal:5432/app';
+const DATABASE_URL = 'postgresql://primary-user:secret@db.internal:5432/app';
+
+function createHealthApp(db: IDatabaseAdapter | undefined = STUB_DB) {
+  const app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    if (db) {
+      c.set('db', db);
+    }
+    await next();
+  });
+  app.route('/api', apiRoutes);
+  return app;
+}
+
+describe('GET /api/health URL resolution via getEnvConfig (RT-3)', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.DATABASE_URL;
+    delete process.env.HYPERDRIVE_URL;
+    pingDatabaseForReadiness.mockReset();
+    pingDatabaseForReadiness.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('probes HYPERDRIVE_URL from request bindings when process env is empty', async () => {
+    const app = createHealthApp();
+    const res = await app.request('/api/health', undefined, {
+      HYPERDRIVE_URL,
+    });
+
+    expect(res.status).toBe(200);
+    expect(pingDatabaseForReadiness).toHaveBeenCalledTimes(1);
+    expect(pingDatabaseForReadiness).toHaveBeenCalledWith(HYPERDRIVE_URL);
+
+    const body = await res.json();
+    expect(body).toMatchObject({ status: 'healthy', service: 'dns-ops-web' });
+    expect(JSON.stringify(body)).not.toMatch(/hyperdrive\.internal|hd-user|secret/i);
+  });
+
+  it('probes process.env.HYPERDRIVE_URL when DATABASE_URL is unset', async () => {
+    process.env.HYPERDRIVE_URL = HYPERDRIVE_URL;
+    const app = createHealthApp();
+
+    const res = await app.request('/api/health');
+    expect(res.status).toBe(200);
+    expect(pingDatabaseForReadiness).toHaveBeenCalledWith(HYPERDRIVE_URL);
+  });
+
+  it('prefers binding DATABASE_URL over HYPERDRIVE_URL', async () => {
+    process.env.HYPERDRIVE_URL = HYPERDRIVE_URL;
+    const app = createHealthApp();
+
+    const res = await app.request('/api/health', undefined, {
+      DATABASE_URL,
+      HYPERDRIVE_URL: 'postgresql://should-not-use:5432/db',
+    });
+
+    expect(res.status).toBe(200);
+    expect(pingDatabaseForReadiness).toHaveBeenCalledWith(DATABASE_URL);
+  });
+
+  it('returns 503 without probing when no URL is configured anywhere', async () => {
+    const app = createHealthApp();
+    const res = await app.request('/api/health');
+
+    expect(res.status).toBe(503);
+    expect(pingDatabaseForReadiness).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body).toMatchObject({ status: 'degraded', service: 'dns-ops-web' });
+  });
+});

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -175,6 +175,8 @@ export function createAdapterFromConfig(config: DBConfig): IDatabaseAdapter {
     connectionString: config.connectionString,
     ssl: parseSSLConfig(config.connectionString),
   });
+  // Idle client errors (server restart/teardown) must not crash the process.
+  pool.on('error', () => {});
 
   const db = drizzlePg(pool, { schema });
   return createSimpleAdapter(db, 'postgres');
@@ -188,6 +190,8 @@ export function createPostgresAdapter(connectionString: string): IDatabaseAdapte
     connectionString,
     ssl: parseSSLConfig(connectionString, { strictDefault: true }),
   });
+  // Idle client errors (server restart/teardown) must not crash the process.
+  pool.on('error', () => {});
 
   const db = drizzlePg(pool, { schema });
   return createSimpleAdapter(db, 'postgres');

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9,6 +9,8 @@ export * from './client.js';
 
 // Export database adapter and types
 export * from './database/index.js';
+// Connectivity probe for readiness/health endpoints
+export * from './ping.js';
 // Export repositories
 export * from './repos/index.js';
 export * from './schema/index.js';

--- a/packages/db/src/ping.test.ts
+++ b/packages/db/src/ping.test.ts
@@ -6,7 +6,9 @@
  */
 
 import { type AddressInfo, createServer, type Server } from 'node:net';
+import pg from 'pg';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { parseSSLConfig } from './client.js';
 import type { IDatabaseAdapter } from './database/simple-adapter.js';
 import { DEFAULT_DB_READINESS_TIMEOUT_MS, pingDatabase, pingDatabaseForReadiness } from './ping.js';
 
@@ -95,5 +97,96 @@ describe('pingDatabaseForReadiness (bounded)', () => {
     // Must settle near the bound — not hang for tens of seconds.
     expect(elapsed).toBeGreaterThanOrEqual(timeoutMs - 50);
     expect(elapsed).toBeLessThan(timeoutMs + 1_500);
+  });
+});
+
+describe('pingDatabaseForReadiness TLS strictness (matches createPostgresAdapter)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  function mockClientCapturingConfig(): {
+    captured: pg.ClientConfig[];
+  } {
+    const captured: pg.ClientConfig[] = [];
+    vi.spyOn(pg, 'Client').mockImplementation(function MockClient(
+      this: {
+        connect: ReturnType<typeof vi.fn>;
+        query: ReturnType<typeof vi.fn>;
+        end: ReturnType<typeof vi.fn>;
+      },
+      config: string | pg.ClientConfig | undefined
+    ) {
+      captured.push(typeof config === 'string' || config === undefined ? {} : config);
+      this.connect = vi.fn().mockRejectedValue(new Error('connect short-circuit'));
+      this.query = vi.fn();
+      this.end = vi.fn().mockResolvedValue(undefined);
+      return this;
+    } as unknown as typeof pg.Client);
+    return { captured };
+  }
+
+  it('uses parseSSLConfig strictDefault=true in production (not the lenient default)', async () => {
+    process.env = { ...originalEnv, NODE_ENV: 'production' };
+    delete process.env.DB_TLS_REJECT_UNAUTHORIZED;
+
+    const url = 'postgresql://db.example:5432/app';
+    const lenient = parseSSLConfig(url);
+    const strict = parseSSLConfig(url, { strictDefault: true });
+    // Preconditions: production defaults must diverge without an override.
+    expect(lenient).toEqual({ rejectUnauthorized: false });
+    expect(strict).toEqual({ rejectUnauthorized: true });
+
+    const { captured } = mockClientCapturingConfig();
+    await expect(pingDatabaseForReadiness(url, { timeoutMs: 100 })).rejects.toThrow(
+      /connect short-circuit/
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual(
+      expect.objectContaining({
+        connectionString: url,
+        ssl: strict,
+      })
+    );
+    expect(captured[0]?.ssl).not.toEqual(lenient);
+  });
+
+  it('still honors sslmode from the connection string (no duplicated policy)', async () => {
+    process.env = { ...originalEnv, NODE_ENV: 'production' };
+    delete process.env.DB_TLS_REJECT_UNAUTHORIZED;
+
+    const url = 'postgresql://db.example:5432/app?sslmode=require';
+    const expected = parseSSLConfig(url, { strictDefault: true });
+    expect(expected).toEqual({ rejectUnauthorized: false });
+
+    const { captured } = mockClientCapturingConfig();
+    await expect(pingDatabaseForReadiness(url, { timeoutMs: 100 })).rejects.toThrow(
+      /connect short-circuit/
+    );
+
+    expect(captured[0]?.ssl).toEqual(expected);
+  });
+
+  it('still honors DB_TLS_REJECT_UNAUTHORIZED=false over strictDefault', async () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'production',
+      DB_TLS_REJECT_UNAUTHORIZED: 'false',
+    };
+
+    const url = 'postgresql://db.example:5432/app';
+    const expected = parseSSLConfig(url, { strictDefault: true });
+    expect(expected).toEqual({ rejectUnauthorized: false });
+
+    const { captured } = mockClientCapturingConfig();
+    await expect(pingDatabaseForReadiness(url, { timeoutMs: 100 })).rejects.toThrow(
+      /connect short-circuit/
+    );
+
+    expect(captured[0]?.ssl).toEqual(expected);
   });
 });

--- a/packages/db/src/ping.test.ts
+++ b/packages/db/src/ping.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Bounded readiness probe tests (RT-3).
+ *
+ * Covers the timeout/blackhole path deterministically without Docker:
+ * a TCP server accepts connections but never speaks the Postgres protocol.
+ */
+
+import { type AddressInfo, createServer, type Server } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IDatabaseAdapter } from './database/simple-adapter.js';
+import { DEFAULT_DB_READINESS_TIMEOUT_MS, pingDatabase, pingDatabaseForReadiness } from './ping.js';
+
+async function listenBlackhole(): Promise<{ server: Server; port: number }> {
+  const server = createServer((_socket) => {
+    // Accept TCP but never complete the Postgres startup handshake.
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  return { server, port: address.port };
+}
+
+describe('pingDatabase (adapter, unbounded)', () => {
+  it('resolves when adapter execute succeeds', async () => {
+    const db = {
+      execute: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+    } as unknown as IDatabaseAdapter;
+
+    await expect(pingDatabase(db)).resolves.toBeUndefined();
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when adapter execute fails', async () => {
+    const db = {
+      execute: vi.fn().mockRejectedValue(new Error('connection refused')),
+    } as unknown as IDatabaseAdapter;
+
+    await expect(pingDatabase(db)).rejects.toThrow(/connection refused/);
+  });
+});
+
+describe('pingDatabaseForReadiness (bounded)', () => {
+  let blackhole: { server: Server; port: number } | undefined;
+
+  afterEach(async () => {
+    if (!blackhole) return;
+    const { server } = blackhole;
+    blackhole = undefined;
+    await new Promise<void>((resolve) => {
+      // Drop any lingering accepted sockets so close() cannot hang the suite.
+      if ('closeAllConnections' in server && typeof server.closeAllConnections === 'function') {
+        server.closeAllConnections();
+      }
+      server.close(() => resolve());
+      setTimeout(resolve, 200);
+    });
+  });
+
+  it('exports a positive default readiness timeout', () => {
+    expect(DEFAULT_DB_READINESS_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(DEFAULT_DB_READINESS_TIMEOUT_MS).toBeLessThanOrEqual(10_000);
+  });
+
+  it('rejects invalid timeoutMs', async () => {
+    await expect(
+      pingDatabaseForReadiness('postgresql://postgres:postgres@127.0.0.1:1/postgres', {
+        timeoutMs: 0,
+      })
+    ).rejects.toThrow(/timeoutMs/);
+  });
+
+  it('fails quickly against a refused port', async () => {
+    const started = Date.now();
+    await expect(
+      pingDatabaseForReadiness('postgresql://postgres:postgres@127.0.0.1:1/postgres', {
+        timeoutMs: 500,
+      })
+    ).rejects.toThrow();
+    expect(Date.now() - started).toBeLessThan(3_000);
+  });
+
+  it('times out against a TCP blackhole without hanging past the bound', async () => {
+    blackhole = await listenBlackhole();
+    const url = `postgresql://postgres:postgres@127.0.0.1:${blackhole.port}/postgres`;
+    const timeoutMs = 250;
+    const started = Date.now();
+
+    await expect(pingDatabaseForReadiness(url, { timeoutMs })).rejects.toThrow(
+      /timed out after 250ms/i
+    );
+
+    const elapsed = Date.now() - started;
+    // Must settle near the bound — not hang for tens of seconds.
+    expect(elapsed).toBeGreaterThanOrEqual(timeoutMs - 50);
+    expect(elapsed).toBeLessThan(timeoutMs + 1_500);
+  });
+});

--- a/packages/db/src/ping.ts
+++ b/packages/db/src/ping.ts
@@ -1,17 +1,106 @@
 /**
- * Bounded database connectivity probe.
+ * Database connectivity probes.
  *
- * Used by readiness/health endpoints to prove the dependency is reachable
- * rather than merely that an adapter object was constructed.
+ * - pingDatabase: ordinary adapter round-trip (no readiness timeout).
+ * - pingDatabaseForReadiness: short-lived client with a hard bound so a
+ *   blackholed TCP peer cannot stall the readiness endpoint forever.
+ *
+ * Readiness timeouts are intentionally NOT applied to shared pools used by
+ * migrations or application queries.
  */
 
 import { sql } from 'drizzle-orm';
+import pg from 'pg';
+import { parseSSLConfig } from './client.js';
 import type { IDatabaseAdapter } from './database/simple-adapter.js';
+
+/** Default bound for readiness-only probes (not ordinary queries). */
+export const DEFAULT_DB_READINESS_TIMEOUT_MS = 2_000;
 
 /**
  * Execute a single round-trip `SELECT 1` against the given adapter.
  * Rejects if the database is unreachable or the query fails.
+ *
+ * No timeout is imposed here — callers that need a bound (readiness) must
+ * use {@link pingDatabaseForReadiness} instead.
  */
 export async function pingDatabase(db: IDatabaseAdapter): Promise<void> {
   await db.execute(sql`SELECT 1`);
+}
+
+function destroyClientSocket(client: pg.Client): void {
+  try {
+    const connection = (client as unknown as { connection?: { stream?: NodeJS.ReadWriteStream } })
+      .connection;
+    const stream = connection?.stream as { destroy?: () => void } | undefined;
+    stream?.destroy?.();
+  } catch {
+    // best-effort hard close
+  }
+}
+
+async function forceEndClient(client: pg.Client): Promise<void> {
+  destroyClientSocket(client);
+  await Promise.race([
+    client.end().catch(() => undefined),
+    // Never let teardown stall the readiness caller.
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    }),
+  ]);
+}
+
+/**
+ * Bounded readiness probe via a short-lived `pg.Client`.
+ *
+ * Uses connection/query timeouts and always tears down the client (including
+ * destroying the socket on timeout) so neither the probe promise nor an
+ * in-flight connect is left hanging indefinitely.
+ */
+export async function pingDatabaseForReadiness(
+  connectionString: string,
+  options?: { timeoutMs?: number }
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_DB_READINESS_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('timeoutMs must be a positive finite number');
+  }
+
+  const client = new pg.Client({
+    connectionString,
+    connectionTimeoutMillis: timeoutMs,
+    query_timeout: timeoutMs,
+    ssl: parseSSLConfig(connectionString),
+  });
+
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        destroyClientSocket(client);
+        reject(new Error(`Database readiness probe timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      void client
+        .connect()
+        .then(() => client.query('SELECT 1'))
+        .then(() => {
+          if (settled) return;
+          settled = true;
+          resolve();
+        })
+        .catch((error: unknown) => {
+          if (settled) return;
+          settled = true;
+          reject(error instanceof Error ? error : new Error(String(error)));
+        });
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
+    await forceEndClient(client);
+  }
 }

--- a/packages/db/src/ping.ts
+++ b/packages/db/src/ping.ts
@@ -39,23 +39,33 @@ function destroyClientSocket(client: pg.Client): void {
   }
 }
 
-async function forceEndClient(client: pg.Client): Promise<void> {
-  destroyClientSocket(client);
+/** Graceful client teardown; never let end() stall the readiness caller. */
+async function endClientQuietly(client: pg.Client): Promise<void> {
   await Promise.race([
     client.end().catch(() => undefined),
-    // Never let teardown stall the readiness caller.
     new Promise<void>((resolve) => {
       setTimeout(resolve, 50);
     }),
   ]);
 }
 
+/** Hard-close path for timed-out probes (socket destroy + bounded end). */
+async function forceEndClient(client: pg.Client): Promise<void> {
+  destroyClientSocket(client);
+  await endClientQuietly(client);
+}
+
 /**
  * Bounded readiness probe via a short-lived `pg.Client`.
  *
- * Uses connection/query timeouts and always tears down the client (including
- * destroying the socket on timeout) so neither the probe promise nor an
- * in-flight connect is left hanging indefinitely.
+ * Uses the same TLS policy as {@link createPostgresAdapter} (`strictDefault:
+ * true`) so a self-signed/invalid cert cannot pass readiness while the app
+ * pool fails. SSL mode still comes from {@link parseSSLConfig} (sslmode /
+ * DB_TLS_REJECT_UNAUTHORIZED / env defaults) — policy is not duplicated here.
+ *
+ * Uses connection/query timeouts and always tears down the client. Socket
+ * destruction is reserved for the hard-timeout path so a successful ping is
+ * not followed by an abrupt destroy.
  */
 export async function pingDatabaseForReadiness(
   connectionString: string,
@@ -66,14 +76,16 @@ export async function pingDatabaseForReadiness(
     throw new Error('timeoutMs must be a positive finite number');
   }
 
+  // Match createPostgresAdapter TLS strictness (not the lenient web createClient default).
   const client = new pg.Client({
     connectionString,
     connectionTimeoutMillis: timeoutMs,
     query_timeout: timeoutMs,
-    ssl: parseSSLConfig(connectionString),
+    ssl: parseSSLConfig(connectionString, { strictDefault: true }),
   });
 
   let settled = false;
+  let timedOut = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
 
   try {
@@ -81,6 +93,7 @@ export async function pingDatabaseForReadiness(
       timer = setTimeout(() => {
         if (settled) return;
         settled = true;
+        timedOut = true;
         destroyClientSocket(client);
         reject(new Error(`Database readiness probe timed out after ${timeoutMs}ms`));
       }, timeoutMs);
@@ -101,6 +114,10 @@ export async function pingDatabaseForReadiness(
     });
   } finally {
     if (timer) clearTimeout(timer);
-    await forceEndClient(client);
+    if (timedOut) {
+      await forceEndClient(client);
+    } else {
+      await endClientQuietly(client);
+    }
   }
 }

--- a/packages/db/src/ping.ts
+++ b/packages/db/src/ping.ts
@@ -1,0 +1,17 @@
+/**
+ * Bounded database connectivity probe.
+ *
+ * Used by readiness/health endpoints to prove the dependency is reachable
+ * rather than merely that an adapter object was constructed.
+ */
+
+import { sql } from 'drizzle-orm';
+import type { IDatabaseAdapter } from './database/simple-adapter.js';
+
+/**
+ * Execute a single round-trip `SELECT 1` against the given adapter.
+ * Rejects if the database is unreachable or the query fails.
+ */
+export async function pingDatabase(db: IDatabaseAdapter): Promise<void> {
+  await db.execute(sql`SELECT 1`);
+}

--- a/scripts/deploy/smoke-test.ts
+++ b/scripts/deploy/smoke-test.ts
@@ -39,7 +39,11 @@ async function fetchWithTimeout(
 async function runTest(
   name: string,
   service: 'web' | 'collector',
-  testFn: () => Promise<{ passed: boolean; response?: { status: number; body?: unknown }; error?: string }>
+  testFn: () => Promise<{
+    passed: boolean;
+    response?: { status: number; body?: unknown };
+    error?: string;
+  }>
 ): Promise<TestResult> {
   const start = Date.now();
   try {
@@ -77,16 +81,28 @@ async function testWebHomepage(): Promise<TestResult> {
   });
 }
 
-async function testCollectorHealth(path: '/health' | '/healthz' | '/readyz', expectedStatus: number) {
+async function testCollectorHealth(
+  path: '/health' | '/healthz' | '/readyz',
+  expectedStatus: number
+) {
   return runTest(`Collector ${path}`, 'collector', async () => {
     const response = await fetchWithTimeout(`${COLLECTOR_URL}${path}`);
-    const body = await response.json();
-    const passed = response.status === expectedStatus || (path === '/readyz' && response.status === 503);
+    const body = await response.json().catch(() => undefined);
+    // /readyz is readiness: dependency failure (503) is a smoke failure, not a pass.
+    const passed = response.status === expectedStatus;
+    let error: string | undefined;
+    if (!passed) {
+      if (path === '/readyz' && response.status === 503) {
+        error = 'Collector not ready (dependency check failed)';
+      } else {
+        error = `Expected HTTP ${expectedStatus}, got ${response.status}`;
+      }
+    }
 
     return {
       passed,
       response: { status: response.status, body },
-      error: path === '/readyz' && response.status === 503 ? 'Service not ready (check dependencies)' : undefined,
+      error,
     };
   });
 }
@@ -134,7 +150,9 @@ function printResults(results: TestResult[]): void {
       if (verbose && test.response) {
         console.log(`     Status: ${test.response.status}`);
         if (test.response.body) {
-          console.log(`     Body: ${JSON.stringify(test.response.body, null, 2).split('\n').join('\n     ')}`);
+          console.log(
+            `     Body: ${JSON.stringify(test.response.body, null, 2).split('\n').join('\n     ')}`
+          );
         }
       }
     }


### PR DESCRIPTION
## RT-3 — honest readiness

- Web `/api/health` performs bounded, TLS-policy-aligned DB probes and returns sanitized 503 failures.
- Collector `/readyz` checks DB plus worker Redis/queue state; liveness remains process-only.
- Docker/Railway health and smoke checks target readiness.
- Docker-backed integration suites are opt-in; default tests stay Docker-free.

Validated after rebase: focused readiness suite (25 passed, 3 integration skips). Independent review approved the pre-rebase implementation; rebase was conflict-free onto merged RT-1/RT-2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make readiness honest for RT-3: collector `/readyz` and web `/api/health` now return OK only after a real, bounded DB probe; collector also reports queue/worker issues as 503 with safe messages. Liveness endpoints remain process-only.

- **New Features**
  - Collector: `/readyz` runs a bounded `SELECT 1` via `@dns-ops/db` and checks Redis/queues/workers when `WORKER_ENABLED=true`; dependency failures return 503 with sanitized messages.
  - Web: `/api/health` returns 200 only after a real DB ping; resolves the URL via `getEnvConfig` (`DATABASE_URL`/`HYPERDRIVE_URL`), never leaks driver/host/user data.
  - DB package: added `pingDatabaseForReadiness` with strict TLS policy and hard timeouts; unit tests cover refused ports and blackholes; pool now ignores idle client errors.
  - Ops: Docker/Railway health checks now target `/readyz`; smoke tests treat 503 as not ready; workers start before listen to avoid transient “not running” readiness.

- **Migration**
  - Point collector readiness checks to `/readyz`; use web `/api/health` for web readiness. Update any external monitors if they targeted `/health`.
  - To run DB-backed tests locally, set `RUN_DB_INTEGRATION_TESTS=1`; default test runs stay Docker-free.

<sup>Written for commit df90f3162839ce4c5b432eae0812dff94ee61fbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

