### PR TITLE
feat(web): adopt Signal Room in Domain 360

### DIFF
--- a/apps/web/app/components/DomainEvidencePanel.tsx
+++ b/apps/web/app/components/DomainEvidencePanel.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useId } from 'react';
+import { Button } from './ui/Button.js';
 
 export type Unknown = {
   reason: string;
@@ -95,28 +96,34 @@ export function DomainEvidencePanel({ domain }: { domain: string }) {
       fetchJson<EvidenceResponse>(`/api/domains/${encodeURIComponent(domain)}/evidence`),
   });
 
+  const retry = () => {
+    void queryClient.invalidateQueries({ queryKey: ['domain-profile', domain] });
+    void queryClient.invalidateQueries({ queryKey: ['domain-evidence', domain] });
+  };
+
   if (profile.isLoading || evidence.isLoading) {
     return (
-      <p className="text-sm text-gray-500" role="status">
-        Loading evidence coverage…
-      </p>
+      <section className="domain-evidence ds-panel" aria-labelledby={headingId}>
+        <p id={headingId} className="domain-evidence__state" role="status">
+          Loading evidence coverage…
+        </p>
+      </section>
     );
   }
   if (profile.error || evidence.error) {
     return (
-      <div className="text-sm text-gray-600" role="alert">
-        Evidence setup status is currently unavailable.
-        <button
-          type="button"
-          className="ml-2 font-medium underline"
-          onClick={() => {
-            void queryClient.invalidateQueries({ queryKey: ['domain-profile', domain] });
-            void queryClient.invalidateQueries({ queryKey: ['domain-evidence', domain] });
-          }}
-        >
-          Retry
-        </button>
-      </div>
+      <section className="domain-evidence ds-panel" aria-labelledby={headingId}>
+        <div className="domain-evidence__error" role="alert">
+          <div>
+            <p className="ds-kicker">Evidence status</p>
+            <h3 id={headingId}>Evidence setup is unavailable</h3>
+            <p>Evidence setup status is currently unavailable.</p>
+          </div>
+          <Button onClick={retry} size="sm" variant="quiet">
+            Retry
+          </Button>
+        </div>
+      </section>
     );
   }
 
@@ -130,38 +137,52 @@ export function DomainEvidencePanel({ domain }: { domain: string }) {
   const observed = evidence.data?.evidence.filter(isCurrentEvidence) ?? [];
 
   return (
-    <section className="space-y-3" aria-labelledby={headingId}>
-      <div>
-        <h3 id={headingId} className="font-semibold text-gray-900">
-          Evidence coverage
-        </h3>
-        <p className="text-sm text-gray-500">
-          Known risk and completed evidence are separate. Unknown checks are never healthy.
-        </p>
-      </div>
+    <section className="domain-evidence ds-panel" aria-labelledby={headingId}>
+      <header className="domain-evidence__header">
+        <div>
+          <p className="ds-kicker">Evidence integrity</p>
+          <h3 id={headingId}>Evidence coverage</h3>
+        </div>
+        <p>Known risk and completed evidence are separate. Unknown checks are never healthy.</p>
+      </header>
+
       {uniqueSetup.length > 0 ? (
-        <div
-          className="rounded-lg border border-amber-200 bg-amber-50 p-3"
+        <section
+          className="domain-evidence__setup ds-panel--muted"
+          aria-labelledby={`${headingId}-setup`}
           data-testid="domain-needs-setup-evidence"
         >
-          <h4 className="font-medium text-amber-900">Needs setup/evidence</h4>
-          <ul className="mt-2 space-y-2 text-sm text-amber-900">
+          <div>
+            <p className="ds-kicker">Baseline and freshness</p>
+            <h4 id={`${headingId}-setup`}>Needs setup/evidence</h4>
+          </div>
+          <ul>
             {uniqueSetup.map((unknown) => (
               <li key={`${unknown.reason}-${unknown.action}-${unknown.explanation}`}>
-                <span className="font-medium">{unknown.actionLabel}:</span> {unknown.explanation}
+                <span className="ds-badge ds-badge--unknown">{unknown.actionLabel}</span>
+                <p>{unknown.explanation}</p>
               </li>
             ))}
           </ul>
-        </div>
+        </section>
       ) : null}
+
       {profile.data?.profile ? (
-        <p className="text-sm text-gray-600">
-          Purpose: <span className="font-medium">{profile.data.profile.purpose}</span> ·
-          Criticality: <span className="font-medium">{profile.data.profile.criticality}</span>
-        </p>
+        <dl className="domain-evidence__profile">
+          <div>
+            <dt>Purpose</dt>
+            <dd>{profile.data.profile.purpose}</dd>
+          </div>
+          <div>
+            <dt>Criticality</dt>
+            <dd>{profile.data.profile.criticality}</dd>
+          </div>
+        </dl>
       ) : null}
+
       {observed.length > 0 ? (
-        <p className="text-sm text-green-700" data-testid="domain-current-evidence">
+        <p className="domain-evidence__current" data-testid="domain-current-evidence">
+          <span className="ds-badge ds-badge--success">Current</span>
           {observed.length} probe observation{observed.length === 1 ? '' : 's'} recorded with
           current evidence.
         </p>

--- a/apps/web/app/components/SnapshotHistoryPanel.tsx
+++ b/apps/web/app/components/SnapshotHistoryPanel.tsx
@@ -1,22 +1,7 @@
-/**
- * Snapshot History Panel — Bead 07 UI
- *
- * Lists snapshots for a domain and allows comparing two snapshots
- * to see record changes, finding changes, scope/ruleset drift.
- *
- * API endpoints consumed:
- *   GET  /api/snapshots/:domain          → snapshot list
- *   POST /api/snapshots/:domain/diff     → compare two snapshots
- *   POST /api/snapshots/:domain/compare-latest → compare latest two
- */
-
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
+import { Button } from './ui/Button.js';
 import { EmptyState, ErrorState, LoadingState } from './ui/StateDisplay.js';
-
-// ---------------------------------------------------------------------------
-// Types — mirrors JSON responses from snapshots.ts
-// ---------------------------------------------------------------------------
 
 interface SnapshotListItem {
   id: string;
@@ -66,8 +51,8 @@ interface DiffComparison {
     namesRemoved: string[];
     typesAdded: string[];
     typesRemoved: string[];
-    vantagesAdded: string[];
     vantagesRemoved: string[];
+    vantagesAdded: string[];
     message: string;
   } | null;
   rulesetChange: {
@@ -108,23 +93,19 @@ interface DiffResponse {
   warnings?: string[];
 }
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
 interface SnapshotHistoryPanelProps {
   domain: string;
 }
 
 async function fetchSnapshots(domain: string): Promise<SnapshotListItem[]> {
-  const res = await fetch(`/api/snapshots/${encodeURIComponent(domain)}?limit=50`, {
+  const response = await fetch(`/api/snapshots/${encodeURIComponent(domain)}?limit=50`, {
     credentials: 'include',
   });
-  if (!res.ok) {
-    if (res.status === 404) return [];
-    throw new Error(`Failed to load snapshots: ${res.status} ${res.statusText}`);
+  if (!response.ok) {
+    if (response.status === 404) return [];
+    throw new Error(`Failed to load snapshots: ${response.status} ${response.statusText}`);
   }
-  const data = (await res.json()) as { snapshots: SnapshotListItem[] };
+  const data = (await response.json()) as { snapshots: SnapshotListItem[] };
   return data.snapshots ?? [];
 }
 
@@ -151,45 +132,36 @@ export function SnapshotHistoryPanel({ domain }: SnapshotHistoryPanelProps) {
         ? `/api/snapshots/${encodeURIComponent(domain)}/diff`
         : `/api/snapshots/${encodeURIComponent(domain)}/compare-latest`;
       const body = snapshotA ? JSON.stringify({ snapshotA, snapshotB }) : undefined;
-      const res = await fetch(url, {
+      const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body,
       });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!response.ok) {
+        const errorBody = (await response.json().catch(() => ({}))) as { error?: string };
         throw new Error(
-          body.error ?? `${snapshotA ? 'Diff' : 'Compare latest'} failed: ${res.status}`
+          errorBody.error ?? `${snapshotA ? 'Diff' : 'Compare latest'} failed: ${response.status}`
         );
       }
-      return (await res.json()) as DiffResponse;
+      return (await response.json()) as DiffResponse;
     },
     onSuccess: (data) => {
       setDiffResult(data);
       setDiffError(null);
     },
-    onError: (err) => {
-      setDiffError(err instanceof Error ? err.message : 'Unknown error');
+    onError: (error) => {
+      setDiffError(error instanceof Error ? error.message : 'Unknown error');
     },
   });
 
   const compareSelected = () => {
-    if (!selectedA || !selectedB) return;
-    compareMutation.mutate({ snapshotA: selectedA, snapshotB: selectedB });
-  };
-
-  const compareLatest = () => {
-    compareMutation.mutate({});
-  };
-
-  const clearDiff = () => {
-    setDiffResult(null);
-    setDiffError(null);
+    if (selectedA && selectedB)
+      compareMutation.mutate({ snapshotA: selectedA, snapshotB: selectedB });
   };
 
   if (isLoading) {
     return (
-      <div data-testid="snapshot-history-loading">
+      <div className="domain-history ds-panel" data-testid="snapshot-history-loading">
         <LoadingState message="Loading snapshot history…" />
       </div>
     );
@@ -197,7 +169,7 @@ export function SnapshotHistoryPanel({ domain }: SnapshotHistoryPanelProps) {
 
   if (error) {
     return (
-      <div data-testid="snapshot-history-error">
+      <div className="domain-history ds-panel" data-testid="snapshot-history-error">
         <ErrorState message={error.message} onRetry={refetch} />
       </div>
     );
@@ -205,7 +177,7 @@ export function SnapshotHistoryPanel({ domain }: SnapshotHistoryPanelProps) {
 
   if (snapshots.length === 0) {
     return (
-      <div data-testid="snapshot-history-empty">
+      <div className="domain-history ds-panel" data-testid="snapshot-history-empty">
         <EmptyState
           icon="document"
           title="No snapshots yet"
@@ -219,100 +191,95 @@ export function SnapshotHistoryPanel({ domain }: SnapshotHistoryPanelProps) {
   const diffLoading = compareMutation.isPending;
 
   return (
-    <div className="space-y-6" data-testid="snapshot-history-panel">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h3 className="font-semibold text-gray-900">Snapshot History</h3>
-          <p className="text-sm text-gray-500">
-            {snapshots.length} snapshot{snapshots.length !== 1 ? 's' : ''} collected
-          </p>
-        </div>
-        <div className="flex gap-2">
-          {snapshots.length >= 2 && (
-            <button
-              type="button"
-              onClick={compareLatest}
-              disabled={diffLoading}
-              className="focus-ring px-3 py-1.5 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400"
+    <section className="domain-history" data-testid="snapshot-history-panel" aria-label="Snapshots">
+      <div className="domain-history__toolbar">
+        <p className="domain-history__count">
+          {snapshots.length} snapshot{snapshots.length !== 1 ? 's' : ''} collected
+        </p>
+        <div className="domain-history__actions">
+          {snapshots.length >= 2 ? (
+            <Button
+              loading={diffLoading && !selectedA}
+              onClick={() => compareMutation.mutate({})}
+              size="sm"
+              variant="primary"
               data-testid="compare-latest-btn"
             >
-              {diffLoading && !selectedA ? 'Comparing…' : 'Compare Latest'}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={compareSelected}
+              Compare latest
+            </Button>
+          ) : null}
+          <Button
             disabled={diffLoading || !selectedA || !selectedB || selectedA === selectedB}
-            className="focus-ring px-3 py-1.5 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={compareSelected}
+            size="sm"
+            variant="secondary"
             data-testid="compare-selected-btn"
           >
-            Compare Selected
-          </button>
+            Compare selected
+          </Button>
         </div>
       </div>
 
-      <div className="overflow-x-auto border border-gray-200 rounded-lg">
-        <table className="min-w-full text-sm" data-testid="snapshot-list-table">
-          <thead className="bg-gray-50 text-gray-600">
+      <div className="domain-history__table-wrap">
+        <table className="domain-history__table" data-testid="snapshot-list-table">
+          <thead>
             <tr>
-              <th className="px-3 py-2 text-left font-medium">A</th>
-              <th className="px-3 py-2 text-left font-medium">B</th>
-              <th className="px-3 py-2 text-left font-medium">Created</th>
-              <th className="px-3 py-2 text-left font-medium">Ruleset</th>
-              <th className="px-3 py-2 text-left font-medium">Findings</th>
-              <th className="px-3 py-2 text-left font-medium">Scope</th>
+              <th scope="col">A</th>
+              <th scope="col">B</th>
+              <th scope="col">Created</th>
+              <th scope="col">Ruleset</th>
+              <th scope="col">Findings</th>
+              <th scope="col">Scope</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
-            {snapshots.map((snap) => (
+          <tbody>
+            {snapshots.map((snapshot) => (
               <tr
-                key={snap.id}
-                className={`hover:bg-gray-50 ${
-                  selectedA === snap.id || selectedB === snap.id ? 'bg-blue-50' : ''
-                }`}
+                key={snapshot.id}
+                className={
+                  selectedA === snapshot.id || selectedB === snapshot.id ? 'is-selected' : ''
+                }
               >
-                <td className="px-3 py-2">
+                <td data-label="A">
                   <input
                     type="radio"
                     name="snapshotA"
-                    checked={selectedA === snap.id}
-                    onChange={() => setSelectedA(snap.id)}
-                    aria-label={`Select snapshot ${snap.id.slice(0, 8)} as A (older)`}
-                    className="accent-blue-600"
+                    checked={selectedA === snapshot.id}
+                    onChange={() => setSelectedA(snapshot.id)}
+                    aria-label={`Select snapshot ${snapshot.id.slice(0, 8)} as A (older)`}
+                    className="domain-history__selection"
                   />
                 </td>
-                <td className="px-3 py-2">
+                <td data-label="B">
                   <input
                     type="radio"
                     name="snapshotB"
-                    checked={selectedB === snap.id}
-                    onChange={() => setSelectedB(snap.id)}
-                    aria-label={`Select snapshot ${snap.id.slice(0, 8)} as B (newer)`}
-                    className="accent-blue-600"
+                    checked={selectedB === snapshot.id}
+                    onChange={() => setSelectedB(snapshot.id)}
+                    aria-label={`Select snapshot ${snapshot.id.slice(0, 8)} as B (newer)`}
+                    className="domain-history__selection"
                   />
                 </td>
-                <td className="px-3 py-2 tabular-nums whitespace-nowrap">
-                  {new Date(snap.createdAt).toLocaleString()}
+                <td data-label="Created" className="domain-history__timestamp">
+                  {new Date(snapshot.createdAt).toLocaleString()}
                 </td>
-                <td className="px-3 py-2 font-mono text-xs">
-                  {snap.rulesetVersionId ? snap.rulesetVersionId.slice(0, 8) : '—'}
+                <td data-label="Ruleset" className="domain-history__mono">
+                  {snapshot.rulesetVersionId ? snapshot.rulesetVersionId.slice(0, 8) : '—'}
                 </td>
-                <td className="px-3 py-2">
-                  {snap.findingsEvaluated ? (
-                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
-                      Evaluated
-                    </span>
+                <td data-label="Findings">
+                  {snapshot.findingsEvaluated ? (
+                    <span className="ds-badge ds-badge--success">Evaluated</span>
                   ) : (
                     <span
-                      className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800"
-                      title={`${snap.evaluationCoverage.errors[0]?.unknown.explanation ?? 'Evaluation coverage is incomplete'} ${snap.evaluationCoverage.errors[0]?.unknown.actionLabel ?? 'Run a fresh scan'}.`}
+                      className="ds-badge ds-badge--unknown"
+                      title={`${snapshot.evaluationCoverage.errors[0]?.unknown.explanation ?? 'Evaluation coverage is incomplete'} ${snapshot.evaluationCoverage.errors[0]?.unknown.actionLabel ?? 'Run a fresh scan'}.`}
                     >
-                      UNKNOWN — run fresh scan
+                      Unknown — refresh
                     </span>
                   )}
                 </td>
-                <td className="px-3 py-2 text-xs text-gray-500">
-                  {snap.queryScope.names.length} names, {snap.queryScope.types.length} types
+                <td data-label="Scope" className="domain-history__scope">
+                  {snapshot.queryScope.names.length} names, {snapshot.queryScope.types.length} types
                 </td>
               </tr>
             ))}
@@ -320,284 +287,259 @@ export function SnapshotHistoryPanel({ domain }: SnapshotHistoryPanelProps) {
         </table>
       </div>
 
-      {diffError && (
-        <div
-          className="p-3 rounded-lg border border-red-200 bg-red-50 text-sm text-red-700"
-          role="alert"
-          data-testid="diff-error"
-        >
+      {diffError ? (
+        <div className="domain-history__error" role="alert" data-testid="diff-error">
           {diffError}
         </div>
-      )}
+      ) : null}
 
-      {diffLoading && (
-        <div data-testid="diff-loading">
+      {diffLoading ? (
+        <div className="domain-history__loading" data-testid="diff-loading">
           <LoadingState message="Computing snapshot diff…" size="sm" />
         </div>
-      )}
+      ) : null}
 
-      {diffResult && <DiffResultView result={diffResult} onClose={clearDiff} />}
-    </div>
+      {diffResult ? (
+        <DiffResultView result={diffResult} onClose={() => setDiffResult(null)} />
+      ) : null}
+    </section>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Diff Result View
-// ---------------------------------------------------------------------------
 
 function DiffResultView({ result, onClose }: { result: DiffResponse; onClose: () => void }) {
   const { diff, warnings } = result;
   const { findingsSummary, comparison } = diff;
-
-  const safeRecordChanges = Array.isArray(comparison?.recordChanges)
-    ? comparison.recordChanges
-    : [];
-  const nonUnchangedRecords = safeRecordChanges.filter((r) => r.type !== 'unchanged');
+  const recordChanges = Array.isArray(comparison?.recordChanges) ? comparison.recordChanges : [];
+  const nonUnchangedRecords = recordChanges.filter((record) => record.type !== 'unchanged');
   const recordStats = {
-    added: safeRecordChanges.filter((r) => r.type === 'added').length,
-    removed: safeRecordChanges.filter((r) => r.type === 'removed').length,
-    modified: safeRecordChanges.filter((r) => r.type === 'modified').length,
-    unchanged: safeRecordChanges.filter((r) => r.type === 'unchanged').length,
+    added: recordChanges.filter((record) => record.type === 'added').length,
+    removed: recordChanges.filter((record) => record.type === 'removed').length,
+    modified: recordChanges.filter((record) => record.type === 'modified').length,
+    unchanged: recordChanges.filter((record) => record.type === 'unchanged').length,
   };
 
   return (
-    <div className="space-y-4" data-testid="diff-result">
-      <div className="flex items-center justify-between">
-        <h4 className="font-semibold text-gray-900">Comparison Result</h4>
-        <button
-          type="button"
-          onClick={onClose}
-          className="text-sm text-gray-500 hover:text-gray-700"
-          data-testid="close-diff-btn"
-        >
-          ✕ Close
-        </button>
+    <section
+      className="domain-diff ds-panel"
+      data-testid="diff-result"
+      aria-label="Snapshot comparison"
+    >
+      <div className="domain-diff__header">
+        <div>
+          <p className="ds-kicker">Evidence comparison</p>
+          <h3>Comparison result</h3>
+        </div>
+        <Button onClick={onClose} size="sm" variant="quiet" data-testid="close-diff-btn">
+          Close
+        </Button>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-        <div className="rounded-lg bg-gray-50 p-3">
-          <p className="font-medium text-gray-700">Snapshot A (older)</p>
-          <p className="text-xs text-gray-500 tabular-nums">
-            {new Date(diff.snapshotA.createdAt).toLocaleString()}
-          </p>
-          <p className="text-xs text-gray-500 font-mono">
-            Ruleset: {diff.snapshotA.rulesetVersion.slice(0, 8)}
-          </p>
-        </div>
-        <div className="rounded-lg bg-gray-50 p-3">
-          <p className="font-medium text-gray-700">Snapshot B (newer)</p>
-          <p className="text-xs text-gray-500 tabular-nums">
-            {new Date(diff.snapshotB.createdAt).toLocaleString()}
-          </p>
-          <p className="text-xs text-gray-500 font-mono">
-            Ruleset: {diff.snapshotB.rulesetVersion.slice(0, 8)}
-          </p>
-        </div>
+      <div className="domain-diff__snapshots">
+        <SnapshotReference label="Snapshot A (older)" snapshot={diff.snapshotA} />
+        <SnapshotReference label="Snapshot B (newer)" snapshot={diff.snapshotB} />
       </div>
 
-      {warnings && warnings.length > 0 && (
+      {warnings?.length ? (
         <div
-          className="p-3 rounded-lg border border-yellow-200 bg-yellow-50 text-sm text-yellow-800"
+          className="domain-diff__notice domain-diff__notice--warning"
           data-testid="diff-warnings"
         >
-          <p className="font-medium mb-1">⚠ Warnings</p>
-          <ul className="list-disc list-inside space-y-1">
-            {warnings.map((w) => (
-              <li key={w}>{w}</li>
+          <p>Warnings</p>
+          <ul>
+            {warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
             ))}
           </ul>
         </div>
-      )}
+      ) : null}
 
-      <div>
-        <h5 className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-2">
-          DNS Records
-        </h5>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="diff-summary">
-          <SummaryCard label="Added" value={recordStats.added} color="green" />
-          <SummaryCard label="Removed" value={recordStats.removed} color="red" />
-          <SummaryCard label="Modified" value={recordStats.modified} color="yellow" />
-          <SummaryCard label="Unchanged" value={recordStats.unchanged} color="gray" />
+      <section>
+        <p className="ds-kicker">DNS records</p>
+        <div className="domain-diff__summary" data-testid="diff-summary">
+          <SummaryCard label="Added" value={recordStats.added} tone="success" />
+          <SummaryCard label="Removed" value={recordStats.removed} tone="danger" />
+          <SummaryCard label="Modified" value={recordStats.modified} tone="warning" />
+          <SummaryCard label="Unchanged" value={recordStats.unchanged} tone="neutral" />
         </div>
-      </div>
+      </section>
 
-      {comparison.scopeChanges && (
+      {comparison.scopeChanges ? (
         <div
-          className="p-3 rounded-lg border border-orange-200 bg-orange-50 text-sm"
+          className="domain-diff__notice domain-diff__notice--warning"
           data-testid="scope-changes"
         >
-          <p className="font-medium text-orange-800 mb-1">Scope Changed</p>
-          <p className="text-orange-700">{comparison.scopeChanges.message}</p>
+          <p>Scope changed</p>
+          <span>{comparison.scopeChanges.message}</span>
         </div>
-      )}
+      ) : null}
 
-      {comparison.rulesetChange && (
+      {comparison.rulesetChange ? (
         <div
-          className="p-3 rounded-lg border border-purple-200 bg-purple-50 text-sm"
+          className="domain-diff__notice domain-diff__notice--info"
           data-testid="ruleset-changes"
         >
-          <p className="font-medium text-purple-800 mb-1">Ruleset Changed</p>
-          <p className="text-purple-700">{comparison.rulesetChange.message}</p>
+          <p>Ruleset changed</p>
+          <span>{comparison.rulesetChange.message}</span>
         </div>
-      )}
+      ) : null}
 
-      {nonUnchangedRecords.length > 0 && (
-        <ChangeSection title="Record Changes" testId="record-changes">
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
-              <thead className="bg-gray-50 text-gray-600">
-                <tr>
-                  <th className="px-3 py-1.5 text-left font-medium">Change</th>
-                  <th className="px-3 py-1.5 text-left font-medium">Name</th>
-                  <th className="px-3 py-1.5 text-left font-medium">Type</th>
-                  <th className="px-3 py-1.5 text-left font-medium">Values</th>
+      {nonUnchangedRecords.length ? (
+        <ChangeSection title="Record changes" testId="record-changes">
+          <DiffTable>
+            <thead>
+              <tr>
+                <th scope="col">Change</th>
+                <th scope="col">Name</th>
+                <th scope="col">Type</th>
+                <th scope="col">Values</th>
+              </tr>
+            </thead>
+            <tbody>
+              {nonUnchangedRecords.map((record) => (
+                <tr key={`${record.name}-${record.recordType}-${record.type}`}>
+                  <td data-label="Change">
+                    <ChangeBadge type={record.type} />
+                  </td>
+                  <td data-label="Name" className="domain-history__mono">
+                    {record.name}
+                  </td>
+                  <td data-label="Type" className="domain-history__mono">
+                    {record.recordType}
+                  </td>
+                  <td data-label="Values">
+                    {record.type === 'added' && record.valuesB?.join(', ')}
+                    {record.type === 'removed' ? (
+                      <span className="domain-diff__removed">{record.valuesA?.join(', ')}</span>
+                    ) : null}
+                    {record.type === 'modified' ? (
+                      <span>
+                        <span className="domain-diff__removed">
+                          {record.diff?.removed?.join(', ')}
+                        </span>{' '}
+                        <span className="domain-diff__added">{record.diff?.added?.join(', ')}</span>
+                      </span>
+                    ) : null}
+                  </td>
                 </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {nonUnchangedRecords.map((r) => (
-                  <tr key={`${r.name}-${r.recordType}-${r.type}`}>
-                    <td className="px-3 py-1.5">
-                      <ChangeBadge type={r.type} />
-                    </td>
-                    <td className="px-3 py-1.5 font-mono text-xs">{r.name}</td>
-                    <td className="px-3 py-1.5 font-mono text-xs">{r.recordType}</td>
-                    <td className="px-3 py-1.5 text-xs">
-                      {r.type === 'added' && r.valuesB?.join(', ')}
-                      {r.type === 'removed' && (
-                        <span className="line-through text-gray-400">{r.valuesA?.join(', ')}</span>
-                      )}
-                      {r.type === 'modified' && (
-                        <span>
-                          <span className="line-through text-red-400 mr-1">
-                            {r.diff?.removed?.join(', ')}
-                          </span>
-                          <span className="text-green-700">{r.diff?.added?.join(', ')}</span>
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+              ))}
+            </tbody>
+          </DiffTable>
         </ChangeSection>
-      )}
+      ) : null}
 
-      {comparison.ttlChanges.length > 0 && (
-        <ChangeSection title="TTL Changes" testId="ttl-changes">
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
-              <thead className="bg-gray-50 text-gray-600">
-                <tr>
-                  <th className="px-3 py-1.5 text-left font-medium">Name</th>
-                  <th className="px-3 py-1.5 text-left font-medium">Type</th>
-                  <th className="px-3 py-1.5 text-right font-medium">Before</th>
-                  <th className="px-3 py-1.5 text-right font-medium">After</th>
-                  <th className="px-3 py-1.5 text-right font-medium">Δ</th>
+      {comparison.ttlChanges.length ? (
+        <ChangeSection title="TTL changes" testId="ttl-changes">
+          <DiffTable>
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Type</th>
+                <th scope="col">Before</th>
+                <th scope="col">After</th>
+                <th scope="col">Δ</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comparison.ttlChanges.map((ttl) => (
+                <tr key={`${ttl.name}-${ttl.recordType}`}>
+                  <td data-label="Name" className="domain-history__mono">
+                    {ttl.name}
+                  </td>
+                  <td data-label="Type" className="domain-history__mono">
+                    {ttl.recordType}
+                  </td>
+                  <td data-label="Before" className="domain-history__timestamp">
+                    {ttl.ttlA}s
+                  </td>
+                  <td data-label="After" className="domain-history__timestamp">
+                    {ttl.ttlB}s
+                  </td>
+                  <td
+                    data-label="Change"
+                    className={ttl.change > 0 ? 'domain-diff__added' : 'domain-diff__removed'}
+                  >
+                    {ttl.change > 0 ? '+' : ''}
+                    {ttl.change}s
+                  </td>
                 </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {comparison.ttlChanges.map((t) => (
-                  <tr key={`${t.name}-${t.recordType}`}>
-                    <td className="px-3 py-1.5 font-mono text-xs">{t.name}</td>
-                    <td className="px-3 py-1.5 font-mono text-xs">{t.recordType}</td>
-                    <td className="px-3 py-1.5 text-right tabular-nums">{t.ttlA}s</td>
-                    <td className="px-3 py-1.5 text-right tabular-nums">{t.ttlB}s</td>
-                    <td
-                      className={`px-3 py-1.5 text-right tabular-nums ${t.change > 0 ? 'text-green-700' : 'text-red-700'}`}
-                    >
-                      {t.change > 0 ? '+' : ''}
-                      {t.change}s
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+              ))}
+            </tbody>
+          </DiffTable>
         </ChangeSection>
-      )}
+      ) : null}
 
-      {findingsSummary.totalChanges > 0 && (
-        <ChangeSection title="Finding Changes" testId="finding-changes">
-          <div className="space-y-2">
-            <div className="flex gap-3 text-xs text-gray-500 mb-2">
-              <span>+{findingsSummary.added} added</span>
-              <span>−{findingsSummary.removed} removed</span>
-              <span>~{findingsSummary.modified} modified</span>
-            </div>
+      {findingsSummary.totalChanges ? (
+        <ChangeSection title="Finding changes" testId="finding-changes">
+          <div className="domain-diff__finding-summary">
+            <span>+{findingsSummary.added} added</span>
+            <span>−{findingsSummary.removed} removed</span>
+            <span>~{findingsSummary.modified} modified</span>
+          </div>
+          <ul className="domain-diff__findings">
             {comparison.findingChanges
-              .filter((f) => f.type !== 'unchanged')
-              .map((f) => (
-                <div
-                  key={`${f.findingType}-${f.type}`}
-                  className="flex items-start gap-2 p-2 rounded border border-gray-100"
-                >
-                  <ChangeBadge type={f.type} />
+              .filter((finding) => finding.type !== 'unchanged')
+              .map((finding) => (
+                <li key={`${finding.findingType}-${finding.type}`}>
+                  <ChangeBadge type={finding.type} />
                   <div>
-                    <p className="text-sm font-medium text-gray-900">{f.title}</p>
-                    <p className="text-xs text-gray-500">
-                      {f.findingType}
-                      {f.severityA && f.severityB && f.severityA !== f.severityB
-                        ? ` · severity ${f.severityA} → ${f.severityB}`
-                        : f.severityB
-                          ? ` · ${f.severityB}`
+                    <strong>{finding.title}</strong>
+                    <p>
+                      {finding.findingType}
+                      {finding.severityA &&
+                      finding.severityB &&
+                      finding.severityA !== finding.severityB
+                        ? ` · severity ${finding.severityA} → ${finding.severityB}`
+                        : finding.severityB
+                          ? ` · ${finding.severityB}`
                           : ''}
                     </p>
-                    {f.description && (
-                      <p className="text-xs text-gray-400 mt-0.5">{f.description}</p>
-                    )}
+                    {finding.description ? <small>{finding.description}</small> : null}
                   </div>
-                </div>
+                </li>
               ))}
-          </div>
+          </ul>
         </ChangeSection>
-      )}
+      ) : null}
 
-      {nonUnchangedRecords.length === 0 &&
-        comparison.ttlChanges.length === 0 &&
-        findingsSummary.totalChanges === 0 && (
-          <div className="text-center py-6 text-gray-500 text-sm" data-testid="no-changes">
-            No record or finding changes detected between these snapshots.
-          </div>
-        )}
+      {!nonUnchangedRecords.length &&
+      !comparison.ttlChanges.length &&
+      !findingsSummary.totalChanges ? (
+        <p className="domain-diff__empty" data-testid="no-changes">
+          No record or finding changes detected between these snapshots.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function SnapshotReference({
+  label,
+  snapshot,
+}: {
+  label: string;
+  snapshot: { createdAt: string; rulesetVersion: string };
+}) {
+  return (
+    <div className="domain-diff__snapshot ds-panel--muted">
+      <p>{label}</p>
+      <span className="domain-history__timestamp">
+        {new Date(snapshot.createdAt).toLocaleString()}
+      </span>
+      <code>Ruleset: {snapshot.rulesetVersion.slice(0, 8)}</code>
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Small helpers
-// ---------------------------------------------------------------------------
-
-function SummaryCard({
-  label,
-  value,
-  color,
-}: {
-  label: string;
-  value: number;
-  color: 'green' | 'red' | 'yellow' | 'gray';
-}) {
-  const bg = {
-    green: 'bg-green-50',
-    red: 'bg-red-50',
-    yellow: 'bg-yellow-50',
-    gray: 'bg-gray-50',
-  };
+function SummaryCard({ label, value, tone }: { label: string; value: number; tone: string }) {
   return (
-    <div className={`${bg[color]} rounded-lg p-3 text-center`}>
-      <div className="text-xl font-bold text-gray-900 tabular-nums">{value}</div>
-      <div className="text-xs text-gray-600">{label}</div>
+    <div className={`domain-diff__summary-card domain-diff__summary-card--${tone}`}>
+      <strong>{value}</strong>
+      <span>{label}</span>
     </div>
   );
 }
 
 function ChangeBadge({ type }: { type: string }) {
-  const styles: Record<string, string> = {
-    added: 'bg-green-100 text-green-800',
-    removed: 'bg-red-100 text-red-800',
-    modified: 'bg-yellow-100 text-yellow-800',
-    unchanged: 'bg-gray-100 text-gray-600',
-  };
   const labels: Record<string, string> = {
     added: '+',
     removed: '−',
@@ -605,9 +547,7 @@ function ChangeBadge({ type }: { type: string }) {
     unchanged: '=',
   };
   return (
-    <span
-      className={`inline-flex items-center justify-center w-5 h-5 rounded text-xs font-bold ${styles[type] ?? styles.unchanged}`}
-    >
+    <span className={`domain-change-badge domain-change-badge--${type}`}>
       {labels[type] ?? '?'}
     </span>
   );
@@ -623,9 +563,17 @@ function ChangeSection({
   children: React.ReactNode;
 }) {
   return (
-    <div data-testid={testId}>
-      <h5 className="font-medium text-gray-900 mb-2">{title}</h5>
+    <section className="domain-diff__section" data-testid={testId}>
+      <h4>{title}</h4>
       {children}
+    </section>
+  );
+}
+
+function DiffTable({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="domain-history__table-wrap">
+      <table className="domain-history__table domain-history__table--diff">{children}</table>
     </div>
   );
 }

--- a/apps/web/app/components/ui/Button.tsx
+++ b/apps/web/app/components/ui/Button.tsx
@@ -29,7 +29,7 @@ export function Button({
   return (
     <button
       {...props}
-      aria-busy={buttonState === 'loading' || undefined}
+      aria-busy={buttonState === 'loading'}
       className={`ds-button ds-button--${variant} ds-button--${size} ${className}`}
       data-state={buttonState}
       disabled={isDisabled}

--- a/apps/web/app/routes/domain/$domain.tsx
+++ b/apps/web/app/routes/domain/$domain.tsx
@@ -345,8 +345,10 @@ function Domain360Page() {
           </div>
         ) : (
           <div
-            className="domain-360__state domain-360__state--empty"
+            className="domain-360__state domain-360__state--warning"
+            data-state="warning"
             data-testid="domain-no-data-banner"
+            role="status"
           >
             <p>
               No DNS data for {domain} yet. Click <strong>Refresh</strong> to collect now.

--- a/apps/web/app/routes/domain/$domain.tsx
+++ b/apps/web/app/routes/domain/$domain.tsx
@@ -14,6 +14,7 @@ import { SimulationPanel } from '../../components/SimulationPanel.js';
 import { SnapshotHistoryPanel } from '../../components/SnapshotHistoryPanel.js';
 import { ResultStateBadge, ZoneManagementBadge } from '../../components/StatusBadges.js';
 import { TagsPanel } from '../../components/TagsPanel.js';
+import { Button } from '../../components/ui/Button.js';
 import { isDelegationTabEnabled, isSimulationEnabled } from '../../config/features.js';
 
 type DomainTabId = 'overview' | 'dns' | 'mail' | 'history' | 'delegation';
@@ -280,71 +281,63 @@ function Domain360Page() {
   }, [refreshMutation.mutate]);
 
   return (
-    <div data-loaded={!isLoading || undefined}>
-      <div className="mb-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-3xl font-bold text-gray-900 break-all">{domain}</h1>
-          <button
-            type="button"
+    <div className="domain-360" data-loaded={!isLoading || undefined}>
+      <header className="domain-360__header ds-panel">
+        <div className="domain-360__title-row">
+          <div>
+            <p className="ds-kicker">Domain 360</p>
+            <h1>{domain}</h1>
+          </div>
+          <Button
+            loading={refreshMutation.isPending}
             onClick={handleRefresh}
-            disabled={refreshMutation.isPending}
             aria-busy={refreshMutation.isPending}
-            className="focus-ring min-h-10 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400"
+            variant="primary"
           >
-            {refreshMutation.isPending ? 'Refreshing...' : 'Refresh'}
-          </button>
+            Refresh
+          </Button>
         </div>
 
         {snapshot ? (
           <>
-            <div className="mt-3 flex flex-wrap items-center gap-2">
+            <div className="domain-360__metadata">
               <ZoneManagementBadge type={snapshot.zoneManagement} />
               <ResultStateBadge state={snapshot.resultState} />
-              <span className="text-sm text-gray-500 tabular-nums">
+              <span className="domain-360__timestamp">
                 Last updated: {new Date(snapshot.createdAt).toLocaleString()}
               </span>
             </div>
             {snapshot.metadata?.authoritativeEvidence?.state === 'UNKNOWN' && (
-              <div className="mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+              <div className="domain-360__alert domain-360__alert--unknown ds-panel--muted">
                 <strong>Authoritative evidence UNKNOWN.</strong>{' '}
                 {snapshot.metadata.authoritativeEvidence.unknown?.explanation}{' '}
-                <button
-                  type="button"
-                  onClick={handleRefresh}
+                <Button
                   disabled={refreshMutation.isPending}
-                  className="font-semibold underline disabled:opacity-50"
+                  onClick={handleRefresh}
+                  size="sm"
+                  variant="quiet"
                 >
                   {snapshot.metadata.authoritativeEvidence.unknown?.actionLabel ??
                     'Retry authoritative DNS collection'}
-                </button>
+                </Button>
               </div>
             )}
           </>
         ) : loaderError ? (
           <div
-            className={`mt-4 p-4 rounded-lg border ${
-              loaderError.type === 'api_unreachable'
-                ? 'bg-red-50 border-red-200'
-                : 'bg-orange-50 border-orange-200'
-            }`}
+            className="domain-360__state domain-360__state--error"
             data-testid="loader-error-banner"
           >
-            <p
-              className={
-                loaderError.type === 'api_unreachable' ? 'text-red-800' : 'text-orange-800'
-              }
-            >
-              {loaderError.message}
-            </p>
+            <p>{loaderError.message}</p>
           </div>
         ) : refreshMutation.isPending ? (
           <div
-            className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg"
+            className="domain-360__state domain-360__state--collecting"
             data-testid="domain-collecting-banner"
           >
             <div className="flex items-center gap-3">
-              <div className="animate-spin h-4 w-4 border-2 border-blue-600 border-t-transparent rounded-full" />
-              <p className="text-blue-800">
+              <div className="ds-button__spinner" aria-hidden="true" />
+              <p>
                 Collecting DNS data for <strong>{domain}</strong>... This takes about 5 seconds.
                 {addToPortfolio ? ' This domain will be added to your portfolio.' : ''}
               </p>
@@ -352,10 +345,10 @@ function Domain360Page() {
           </div>
         ) : (
           <div
-            className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg"
+            className="domain-360__state domain-360__state--empty"
             data-testid="domain-no-data-banner"
           >
-            <p className="text-yellow-800">
+            <p>
               No DNS data for {domain} yet. Click <strong>Refresh</strong> to collect now.
             </p>
           </div>
@@ -363,53 +356,43 @@ function Domain360Page() {
 
         {refreshError ? (
           <div
-            className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+            className="domain-360__alert domain-360__state--error"
             data-testid="domain-refresh-error-banner"
             role="alert"
           >
-            {refreshError}
-            <button
-              type="button"
-              onClick={handleRefresh}
-              className="ml-3 font-medium underline"
+            <span>{refreshError}</span>
+            <Button
               disabled={refreshMutation.isPending}
+              onClick={handleRefresh}
+              size="sm"
+              variant="quiet"
             >
               Retry
-            </button>
+            </Button>
           </div>
         ) : null}
+      </header>
+
+      <div role="tablist" aria-label="Domain DNS views" className="domain-360__tabs">
+        {DOMAIN_TABS.map((tab, index) => (
+          <button
+            key={tab.id}
+            type="button"
+            id={getTabId(tab.id)}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={getPanelId(tab.id)}
+            tabIndex={activeTab === tab.id ? 0 : -1}
+            onClick={() => handleTabChange(tab.id)}
+            onKeyDown={(event) => handleTabKeyDown(event, index)}
+            className="domain-360__tab"
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
 
-      <div className="border-b border-gray-200 mb-6 overflow-x-auto">
-        <div
-          role="tablist"
-          aria-label="Domain DNS views"
-          className="-mb-px flex w-max min-w-full space-x-4 sm:space-x-8"
-        >
-          {DOMAIN_TABS.map((tab, index) => (
-            <button
-              key={tab.id}
-              type="button"
-              id={getTabId(tab.id)}
-              role="tab"
-              aria-selected={activeTab === tab.id}
-              aria-controls={getPanelId(tab.id)}
-              tabIndex={activeTab === tab.id ? 0 : -1}
-              onClick={() => handleTabChange(tab.id)}
-              onKeyDown={(event) => handleTabKeyDown(event, index)}
-              className={`focus-ring min-h-10 whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${
-                activeTab === tab.id
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
+      <div className="domain-360__panel ds-panel">
         <div
           role="tabpanel"
           id={getPanelId('overview')}
@@ -480,6 +463,9 @@ function OverviewTab({
   snapshot: Snapshot | null;
   observations: Observation[];
 }) {
+  const scopeHeadingId = useId();
+  const metadataHeadingId = useId();
+
   if (!snapshot) {
     return (
       <div className="space-y-6">
@@ -513,7 +499,7 @@ function OverviewTab({
 
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="domain-stat-grid">
         <StatCard label="Total Queries" value={observations.length} />
         <StatCard label="Successful" value={successCount} color="green" />
         <StatCard
@@ -535,45 +521,51 @@ function OverviewTab({
         </div>
       )}
 
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-        <h3 className="font-semibold text-blue-900 mb-3">Query Scope</h3>
-        <div className="space-y-3">
+      <section className="domain-scope ds-panel--muted" aria-labelledby={scopeHeadingId}>
+        <div>
+          <p className="ds-kicker">Collection boundary</p>
+          <h3 id={scopeHeadingId}>Query scope</h3>
+        </div>
+        <div className="domain-scope__lists">
           <ScopeList label="Names" values={snapshot.queriedNames || []} />
           <ScopeList label="Types" values={snapshot.queriedTypes || []} />
           <ScopeList label="Vantages" values={snapshot.vantages || []} />
         </div>
         {snapshot.zoneManagement === 'unmanaged' ? (
-          <p className="mt-3 text-xs text-blue-700">
+          <p className="domain-scope__notice">
             Targeted inspection mode: this is a DNS evidence snapshot, not a full zone enumeration.
           </p>
         ) : null}
-      </div>
+      </section>
 
-      <div>
-        <h3 className="font-semibold text-gray-900 mb-2">Snapshot Metadata</h3>
-        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+      <section className="domain-metadata" aria-labelledby={metadataHeadingId}>
+        <div>
+          <p className="ds-kicker">Collected evidence</p>
+          <h3 id={metadataHeadingId}>Snapshot metadata</h3>
+        </div>
+        <dl>
           <div>
-            <dt className="text-gray-500">Created</dt>
-            <dd className="text-gray-900 tabular-nums">
+            <dt>Created</dt>
+            <dd className="domain-360__timestamp">
               {new Date(snapshot.createdAt).toLocaleString()}
             </dd>
           </div>
           <div>
-            <dt className="text-gray-500">Duration</dt>
-            <dd className="text-gray-900 tabular-nums">
+            <dt>Duration</dt>
+            <dd className="domain-360__timestamp">
               {snapshot.collectionDurationMs ? `${snapshot.collectionDurationMs}ms` : 'N/A'}
             </dd>
           </div>
           <div>
-            <dt className="text-gray-500">Triggered By</dt>
-            <dd className="text-gray-900">{snapshot.triggeredBy || 'Unknown'}</dd>
+            <dt>Triggered by</dt>
+            <dd>{snapshot.triggeredBy || 'Unknown'}</dd>
           </div>
           <div>
-            <dt className="text-gray-500">Ruleset</dt>
-            <dd className="text-gray-900">{snapshot.rulesetVersionId || 'Pending evaluation'}</dd>
+            <dt>Ruleset</dt>
+            <dd>{snapshot.rulesetVersionId || 'Pending evaluation'}</dd>
           </div>
         </dl>
-      </div>
+      </section>
 
       <div className="space-y-4">
         <div>
@@ -668,11 +660,10 @@ function MailTab({ domain, snapshotId }: { domain: string; snapshotId?: string }
 function HistoryTab({ domain }: { domain: string }) {
   return (
     <div>
-      <div className="mb-4">
-        <h3 className="font-semibold text-gray-900">Snapshot History</h3>
-        <p className="text-sm text-gray-500">
-          View and compare past DNS snapshots to track changes over time for {domain}.
-        </p>
+      <div className="domain-section-heading">
+        <p className="ds-kicker">Evidence timeline</p>
+        <h2>Snapshot history</h2>
+        <p>View and compare past DNS snapshots to track changes over time for {domain}.</p>
       </div>
       <SnapshotHistoryPanel domain={domain} />
     </div>
@@ -702,37 +693,28 @@ function StatCard({
   value: number;
   color?: 'gray' | 'green' | 'red';
 }) {
-  const colorClasses = {
-    gray: 'bg-gray-50',
-    green: 'bg-green-50',
-    red: 'bg-red-50',
-  };
-
   return (
-    <div className={`${colorClasses[color]} rounded-lg p-4 text-center`}>
-      <div className="text-2xl font-bold text-gray-900 tabular-nums">{value}</div>
-      <div className="text-sm text-gray-600">{label}</div>
+    <div className={`domain-stat-card domain-stat-card--${color}`}>
+      <strong>{value}</strong>
+      <span>{label}</span>
     </div>
   );
 }
 
 function ScopeList({ label, values }: { label: string; values: string[] }) {
   return (
-    <div>
-      <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">{label}</p>
+    <div className="domain-scope__list">
+      <p>{label}</p>
       {values.length > 0 ? (
-        <div className="mt-1 flex flex-wrap gap-1.5">
+        <div>
           {values.map((value) => (
-            <span
-              key={`${label}-${value}`}
-              className="rounded-full bg-white/80 border border-blue-200 px-2 py-0.5 text-xs text-blue-900"
-            >
+            <span key={`${label}-${value}`} className="ds-badge ds-badge--info">
               {value}
             </span>
           ))}
         </div>
       ) : (
-        <p className="mt-1 text-sm text-blue-800">N/A</p>
+        <span className="domain-scope__empty">N/A</span>
       )}
     </div>
   );

--- a/apps/web/app/styles/app.css
+++ b/apps/web/app/styles/app.css
@@ -824,7 +824,7 @@
     border-color: var(--color-unknown);
   }
 
-  .domain-360__state--empty {
+  .domain-360__state--warning {
     background: var(--color-warning-surface);
     border-color: var(--color-warning);
   }

--- a/apps/web/app/styles/app.css
+++ b/apps/web/app/styles/app.css
@@ -744,3 +744,772 @@
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+@layer components {
+  .domain-360 {
+    display: grid;
+    gap: var(--space-lg);
+    min-inline-size: 0;
+  }
+
+  .domain-360__header,
+  .domain-360__panel {
+    padding: clamp(var(--space-md), 3vw, var(--space-xl));
+  }
+
+  .domain-360__header {
+    display: grid;
+    gap: var(--space-md);
+  }
+
+  .domain-360__title-row,
+  .domain-360__metadata,
+  .domain-360__tabs,
+  .domain-360__alert,
+  .domain-history__toolbar,
+  .domain-diff__header {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    justify-content: space-between;
+    min-inline-size: 0;
+  }
+
+  .domain-360__title-row h1,
+  .domain-section-heading h2,
+  .domain-evidence h3,
+  .domain-evidence h4,
+  .domain-diff h3,
+  .domain-diff h4 {
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    letter-spacing: -0.03em;
+    line-height: var(--leading-tight);
+    margin: 0;
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .domain-360__title-row h1 {
+    font-size: clamp(var(--text-2xl), 5vw, var(--text-3xl));
+  }
+
+  .domain-360__metadata {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+    justify-content: flex-start;
+  }
+
+  .domain-360__timestamp,
+  .domain-history__timestamp {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-variant-numeric: tabular-nums;
+    overflow-wrap: anywhere;
+  }
+
+  .domain-360__alert,
+  .domain-360__state {
+    border: var(--rule) solid var(--color-line);
+    border-radius: var(--radius-tight);
+    color: var(--color-text);
+    font-size: var(--text-sm);
+    padding: var(--space-md);
+  }
+
+  .domain-360__alert--unknown,
+  .domain-360__state--collecting {
+    background: var(--color-unknown-surface);
+    border-color: var(--color-unknown);
+  }
+
+  .domain-360__state--empty {
+    background: var(--color-warning-surface);
+    border-color: var(--color-warning);
+  }
+
+  .domain-360__state--error,
+  .domain-history__error {
+    background: var(--color-danger-surface);
+    border-color: var(--color-danger);
+    color: var(--color-danger);
+  }
+
+  .domain-360__tabs {
+    border-block-end: var(--rule) solid var(--color-line);
+    gap: var(--space-xs);
+    justify-content: flex-start;
+    padding-block-end: var(--space-2xs);
+  }
+
+  .domain-360__tab {
+    background: transparent;
+    border: 0;
+    border-block-end: 2px solid transparent;
+    color: var(--color-muted);
+    cursor: pointer;
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    min-block-size: 2.75rem;
+    padding-inline: var(--space-sm);
+    white-space: nowrap;
+  }
+
+  .domain-360__tab:hover,
+  .domain-360__tab[aria-selected='true'] {
+    border-block-end-color: var(--color-brand);
+    color: var(--color-brand);
+  }
+
+  .domain-360__tab:focus-visible,
+  .domain-history__selection:focus-visible {
+    outline: 3px solid var(--color-focus);
+    outline-offset: 2px;
+  }
+
+  .domain-360__tab:active {
+    transform: translateY(1px);
+  }
+
+  .domain-section-heading {
+    display: grid;
+    gap: var(--space-xs);
+    margin-block-end: var(--space-lg);
+  }
+
+  .domain-section-heading p:last-child {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+    margin: 0;
+    max-inline-size: 64ch;
+  }
+
+  .domain-evidence,
+  .domain-history,
+  .domain-diff {
+    display: grid;
+    gap: var(--space-lg);
+    min-inline-size: 0;
+    padding: var(--space-lg);
+  }
+
+  .domain-evidence__header {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .domain-evidence__header h3,
+  .domain-diff h3 {
+    font-size: var(--text-xl);
+    margin-block-start: var(--space-2xs);
+  }
+
+  .domain-evidence__header > p,
+  .domain-evidence__state,
+  .domain-evidence__error > div > p:last-child {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    margin: 0;
+    max-inline-size: 62ch;
+  }
+
+  .domain-evidence__setup {
+    display: grid;
+    gap: var(--space-md);
+    padding: var(--space-md);
+  }
+
+  .domain-evidence__setup h4 {
+    font-size: var(--text-lg);
+    margin-block-start: var(--space-2xs);
+  }
+
+  .domain-evidence__setup ul,
+  .domain-diff__notice ul,
+  .domain-diff__findings {
+    display: grid;
+    gap: var(--space-sm);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .domain-evidence__setup li {
+    align-items: start;
+    display: grid;
+    gap: var(--space-sm);
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .domain-evidence__setup li + li {
+    border-block-start: var(--rule) solid var(--color-line);
+    padding-block-start: var(--space-sm);
+  }
+
+  .domain-evidence__setup p {
+    color: var(--color-text);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .domain-evidence__profile {
+    border-block: var(--rule) solid var(--color-line);
+    display: grid;
+    gap: var(--space-sm);
+    margin: 0;
+  }
+
+  .domain-evidence__profile > div {
+    display: grid;
+    gap: var(--space-xs);
+    grid-template-columns: minmax(8rem, 0.6fr) minmax(0, 1.4fr);
+    padding-block: var(--space-sm);
+  }
+
+  .domain-evidence__profile > div + div {
+    border-block-start: var(--rule) solid var(--color-line);
+  }
+
+  .domain-evidence__profile dt,
+  .domain-evidence__profile dd {
+    margin: 0;
+  }
+
+  .domain-evidence__profile dt {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .domain-evidence__profile dd {
+    color: var(--color-text);
+    font-size: var(--text-sm);
+    overflow-wrap: anywhere;
+  }
+
+  .domain-evidence__current {
+    align-items: center;
+    color: var(--color-success);
+    display: flex;
+    flex-wrap: wrap;
+    font-size: var(--text-sm);
+    gap: var(--space-sm);
+    margin: 0;
+  }
+
+  .domain-evidence__error {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    justify-content: space-between;
+  }
+
+  .domain-history__toolbar {
+    align-items: end;
+  }
+
+  .domain-history__count {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    margin: 0;
+  }
+
+  .domain-history__actions {
+    display: flex;
+    flex: 1 1 15rem;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    justify-content: flex-end;
+  }
+
+  .domain-history__actions .ds-button {
+    flex: 1 1 auto;
+  }
+
+  .domain-history__table-wrap {
+    min-inline-size: 0;
+  }
+
+  .domain-history__table {
+    border-collapse: collapse;
+    inline-size: 100%;
+    table-layout: fixed;
+  }
+
+  .domain-history__table thead {
+    block-size: 1px;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+  }
+
+  .domain-history__table tbody {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .domain-history__table tr {
+    background: var(--color-surface);
+    border: var(--rule) solid var(--color-line);
+    border-radius: var(--radius-tight);
+    display: grid;
+    overflow: hidden;
+  }
+
+  .domain-history__table tr.is-selected {
+    background: var(--color-surface-selected);
+    border-color: var(--color-brand);
+  }
+
+  .domain-history__table td {
+    align-items: baseline;
+    border-block-end: var(--rule) solid var(--color-line);
+    color: var(--color-text);
+    display: grid;
+    font-size: var(--text-sm);
+    gap: var(--space-sm);
+    grid-template-columns: minmax(5rem, 0.55fr) minmax(0, 1.45fr);
+    overflow-wrap: anywhere;
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .domain-history__table td:last-child {
+    border-block-end: 0;
+  }
+
+  .domain-history__table td::before {
+    color: var(--color-muted);
+    content: attr(data-label);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .domain-history__selection {
+    accent-color: var(--color-brand);
+    block-size: 2.75rem;
+    inline-size: 2.75rem;
+    margin: 0;
+  }
+
+  .domain-history__mono {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .domain-history__scope {
+    color: var(--color-muted);
+    font-size: var(--text-xs);
+  }
+
+  .domain-history__error,
+  .domain-history__loading {
+    border: var(--rule) solid var(--color-line);
+    border-radius: var(--radius-tight);
+    font-size: var(--text-sm);
+    padding: var(--space-md);
+  }
+
+  .domain-diff__header {
+    align-items: start;
+  }
+
+  .domain-diff__snapshots,
+  .domain-diff__summary {
+    display: grid;
+    gap: var(--space-sm);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .domain-diff__snapshot,
+  .domain-diff__summary-card,
+  .domain-diff__notice {
+    display: grid;
+    gap: var(--space-xs);
+    padding: var(--space-md);
+  }
+
+  .domain-diff__snapshot {
+    min-inline-size: 0;
+  }
+
+  .domain-diff__snapshot p,
+  .domain-diff__notice p {
+    color: var(--color-ink);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    margin: 0;
+  }
+
+  .domain-diff__snapshot code {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    overflow-wrap: anywhere;
+  }
+
+  .domain-diff__notice {
+    border: var(--rule) solid var(--color-line);
+    border-radius: var(--radius-tight);
+    color: var(--color-text);
+    font-size: var(--text-sm);
+  }
+
+  .domain-diff__notice--warning {
+    background: var(--color-warning-surface);
+    border-color: var(--color-warning);
+  }
+
+  .domain-diff__notice--info {
+    background: var(--color-info-surface);
+    border-color: var(--color-info);
+  }
+
+  .domain-diff__summary {
+    margin-block-start: var(--space-sm);
+  }
+
+  .domain-diff__summary-card {
+    background: var(--color-surface-muted);
+    border: var(--rule) solid var(--color-line);
+    border-radius: var(--radius-tight);
+    text-align: center;
+  }
+
+  .domain-diff__summary-card strong {
+    color: var(--color-ink);
+    font-size: var(--text-xl);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .domain-diff__summary-card span {
+    color: var(--color-muted);
+    font-size: var(--text-xs);
+  }
+
+  .domain-diff__summary-card--success {
+    background: var(--color-success-surface);
+  }
+
+  .domain-diff__summary-card--danger {
+    background: var(--color-danger-surface);
+  }
+
+  .domain-diff__summary-card--warning {
+    background: var(--color-warning-surface);
+  }
+
+  .domain-diff__section {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .domain-diff__section h4 {
+    font-size: var(--text-base);
+  }
+
+  .domain-change-badge {
+    align-items: center;
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-pill);
+    color: var(--color-text);
+    display: inline-flex;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    inline-size: 1.5rem;
+    justify-content: center;
+    min-block-size: 1.5rem;
+  }
+
+  .domain-change-badge--added,
+  .domain-diff__added {
+    color: var(--color-success);
+  }
+
+  .domain-change-badge--added {
+    background: var(--color-success-surface);
+  }
+
+  .domain-change-badge--removed,
+  .domain-diff__removed {
+    color: var(--color-danger);
+  }
+
+  .domain-change-badge--removed {
+    background: var(--color-danger-surface);
+  }
+
+  .domain-change-badge--modified {
+    background: var(--color-warning-surface);
+    color: var(--color-warning);
+  }
+
+  .domain-diff__removed {
+    text-decoration: line-through;
+  }
+
+  .domain-diff__finding-summary {
+    color: var(--color-muted);
+    display: flex;
+    flex-wrap: wrap;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    gap: var(--space-md);
+  }
+
+  .domain-diff__findings li {
+    align-items: start;
+    border: var(--rule) solid var(--color-line);
+    border-radius: var(--radius-tight);
+    display: grid;
+    gap: var(--space-sm);
+    grid-template-columns: auto minmax(0, 1fr);
+    padding: var(--space-sm);
+  }
+
+  .domain-diff__findings strong {
+    color: var(--color-ink);
+    font-size: var(--text-sm);
+    overflow-wrap: anywhere;
+  }
+
+  .domain-diff__findings p,
+  .domain-diff__findings small,
+  .domain-diff__empty {
+    color: var(--color-muted);
+    display: block;
+    font-size: var(--text-xs);
+    margin: var(--space-2xs) 0 0;
+    overflow-wrap: anywhere;
+  }
+
+  .domain-diff__empty {
+    margin: 0;
+    text-align: center;
+  }
+}
+
+@media (min-width: 40rem) {
+  .domain-history__actions {
+    flex: 0 1 auto;
+  }
+
+  .domain-history__actions .ds-button {
+    flex: 0 1 auto;
+  }
+
+  .domain-history__table thead {
+    block-size: auto;
+    clip: auto;
+    clip-path: none;
+    overflow: visible;
+    position: static;
+    white-space: normal;
+  }
+
+  .domain-history__table tbody {
+    display: table-row-group;
+  }
+
+  .domain-history__table tr {
+    border: 0;
+    border-block-end: var(--rule) solid var(--color-line);
+    border-radius: 0;
+    display: table-row;
+  }
+
+  .domain-history__table tr:first-child {
+    border-block-start: var(--rule) solid var(--color-line);
+  }
+
+  .domain-history__table th,
+  .domain-history__table td {
+    display: table-cell;
+    padding: var(--space-sm);
+    text-align: start;
+    vertical-align: top;
+  }
+
+  .domain-history__table th {
+    background: var(--color-surface-muted);
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 500;
+  }
+
+  .domain-history__table td {
+    border-block-end: 0;
+  }
+
+  .domain-history__table td::before {
+    content: none;
+  }
+
+  .domain-history__table tr:hover {
+    background: var(--color-surface-muted);
+  }
+
+  .domain-diff__summary {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 60rem) {
+  .domain-360__header {
+    align-items: start;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .domain-360__metadata,
+  .domain-360__alert,
+  .domain-360__state {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 24rem) {
+  .domain-evidence__setup li,
+  .domain-evidence__profile > div,
+  .domain-diff__snapshots {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@layer components {
+  .domain-stat-grid {
+    display: grid;
+    gap: var(--space-sm);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .domain-stat-card {
+    background: var(--color-surface-muted);
+    border: var(--rule) solid var(--color-line);
+    border-radius: var(--radius-tight);
+    display: grid;
+    gap: var(--space-2xs);
+    min-inline-size: 0;
+    padding: var(--space-md);
+    text-align: center;
+  }
+
+  .domain-stat-card strong {
+    color: var(--color-ink);
+    font-size: var(--text-2xl);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .domain-stat-card span {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+    overflow-wrap: anywhere;
+  }
+
+  .domain-stat-card--green {
+    background: var(--color-success-surface);
+  }
+
+  .domain-stat-card--red {
+    background: var(--color-danger-surface);
+  }
+
+  .domain-scope,
+  .domain-metadata {
+    display: grid;
+    gap: var(--space-md);
+    padding: var(--space-lg);
+  }
+
+  .domain-scope h3,
+  .domain-metadata h3 {
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    letter-spacing: -0.02em;
+    line-height: var(--leading-tight);
+    margin: var(--space-2xs) 0 0;
+  }
+
+  .domain-scope__lists {
+    display: grid;
+    gap: var(--space-md);
+  }
+
+  .domain-scope__list {
+    display: grid;
+    gap: var(--space-xs);
+  }
+
+  .domain-scope__list > p {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    margin: 0;
+  }
+
+  .domain-scope__list > div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  .domain-scope__empty,
+  .domain-scope__notice {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+  }
+
+  .domain-scope__notice {
+    border-block-start: var(--rule) solid var(--color-line);
+    margin: 0;
+    padding-block-start: var(--space-sm);
+  }
+
+  .domain-metadata {
+    border-block: var(--rule) solid var(--color-line);
+    padding-inline: 0;
+  }
+
+  .domain-metadata dl {
+    display: grid;
+    gap: var(--space-sm);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin: 0;
+  }
+
+  .domain-metadata dl > div {
+    display: grid;
+    gap: var(--space-2xs);
+    min-inline-size: 0;
+  }
+
+  .domain-metadata dt {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .domain-metadata dd {
+    color: var(--color-text);
+    font-size: var(--text-sm);
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+}
+
+@media (max-width: 24rem) {
+  .domain-stat-grid,
+  .domain-metadata dl {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/web/e2e/domain-signal-room.spec.ts
+++ b/apps/web/e2e/domain-signal-room.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test } from '@playwright/test';
+import { mockDomainSnapshot, waitForDomainPageReady } from './support/domain-fixtures.js';
+
+const DOMAIN = 'signal-room.example.test';
+
+async function mockSignalRoomDomain(page: import('@playwright/test').Page): Promise<void> {
+  await mockDomainSnapshot(page, { domain: DOMAIN, snapshotId: 'current-snapshot' });
+
+  await page.route(`**/api/domains/${DOMAIN}/profile`, (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        profile: { purpose: 'PUBLIC_WEB', criticality: 'HIGH' },
+        setup: null,
+      }),
+    })
+  );
+  await page.route(`**/api/domains/${DOMAIN}/evidence`, (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        snapshotId: 'current-snapshot',
+        evidence: [
+          {
+            id: 'tls-missing-baseline',
+            probeType: 'tls_cert',
+            status: 'success',
+            success: true,
+            errorMessage: null,
+            freshness: 'MISSING_BASELINE',
+            probeData: { status: 'OBSERVED' },
+          },
+          {
+            id: 'dns-current',
+            probeType: 'dns',
+            status: 'success',
+            success: true,
+            errorMessage: null,
+            freshness: 'CURRENT',
+            probeData: { status: 'OBSERVED' },
+          },
+        ],
+      }),
+    })
+  );
+  await page.route(`**/api/snapshots/${DOMAIN}?limit=50`, (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        snapshots: [
+          {
+            id: 'snapshot-older',
+            createdAt: '2026-08-01T12:00:00.000Z',
+            rulesetVersionId: 'ruleset-older',
+            findingsEvaluated: true,
+            evaluationCoverage: { state: 'COMPLETE', errors: [] },
+            queryScope: { names: [DOMAIN], types: ['A', 'MX'], vantages: ['default'] },
+          },
+          {
+            id: 'snapshot-newer',
+            createdAt: '2026-08-02T12:00:00.000Z',
+            rulesetVersionId: 'ruleset-newer',
+            findingsEvaluated: false,
+            evaluationCoverage: {
+              state: 'PARTIAL',
+              errors: [
+                {
+                  unknown: {
+                    explanation: 'The collector did not complete all checks.',
+                    actionLabel: 'Run a fresh scan',
+                  },
+                },
+              ],
+            },
+            queryScope: { names: [DOMAIN], types: ['A'], vantages: ['default'] },
+          },
+        ],
+      }),
+    })
+  );
+  await page.route(`**/api/snapshots/${DOMAIN}/compare-latest`, (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        diff: {
+          snapshotA: {
+            id: 'snapshot-older',
+            createdAt: '2026-08-01T12:00:00.000Z',
+            rulesetVersion: 'ruleset-older',
+          },
+          snapshotB: {
+            id: 'snapshot-newer',
+            createdAt: '2026-08-02T12:00:00.000Z',
+            rulesetVersion: 'ruleset-newer',
+          },
+          comparison: {
+            recordChanges: [
+              {
+                type: 'modified',
+                name: DOMAIN,
+                recordType: 'A',
+                diff: { added: ['192.0.2.2'], removed: ['192.0.2.1'] },
+              },
+            ],
+            ttlChanges: [],
+            findingChanges: [],
+            scopeChanges: null,
+            rulesetChange: null,
+          },
+          summary: { totalChanges: 1, additions: 0, deletions: 0, modifications: 1, unchanged: 0 },
+          findingsSummary: {
+            totalChanges: 0,
+            added: 0,
+            removed: 0,
+            modified: 0,
+            unchanged: 0,
+            severityChanges: 0,
+          },
+        },
+      }),
+    })
+  );
+}
+
+test.describe('Domain 360 Signal Room', () => {
+  test('uses semantic evidence and baseline surfaces without presenting UNKNOWN as healthy', async ({
+    page,
+  }) => {
+    await mockSignalRoomDomain(page);
+    await page.goto(`/domain/${DOMAIN}`);
+    await waitForDomainPageReady(page);
+
+    const evidence = page.locator('section.domain-evidence');
+    await expect(evidence).toHaveClass(/ds-panel/);
+    await expect(page.getByTestId('domain-needs-setup-evidence')).toHaveClass(/ds-panel--muted/);
+    await expect(
+      page.getByTestId('domain-needs-setup-evidence').getByText('Accept baseline')
+    ).toHaveClass(/ds-badge--unknown/);
+    await expect(page.getByTestId('domain-current-evidence').getByText('Current')).toHaveClass(
+      /ds-badge--success/
+    );
+  });
+
+  test('keeps evidence history usable without root overflow at supported widths', async ({
+    page,
+  }) => {
+    await mockSignalRoomDomain(page);
+    await page.goto(`/domain/${DOMAIN}`);
+    await waitForDomainPageReady(page);
+    await page.getByRole('tab', { name: 'History' }).click();
+    await expect(page.getByTestId('snapshot-history-panel')).toBeVisible();
+
+    await page.getByTestId('compare-latest-btn').click();
+    await expect(page.getByTestId('diff-result')).toBeVisible();
+    await expect(page.getByTestId('record-changes')).toContainText('192.0.2.2');
+
+    for (const width of [320, 375, 414, 768]) {
+      await page.setViewportSize({ width, height: 900 });
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () => document.documentElement.scrollWidth <= document.documentElement.clientWidth
+          )
+        )
+        .toBe(true);
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const controls = document.querySelectorAll(
+              '.domain-360__tab, .domain-history__actions .ds-button > span'
+            );
+            return [...controls].every((control) => {
+              const range = document.createRange();
+              range.selectNodeContents(control);
+              return range.getClientRects().length <= 1;
+            });
+          })
+        )
+        .toBe(true);
+    }
+  });
+});

--- a/apps/web/e2e/domain-states.spec.ts
+++ b/apps/web/e2e/domain-states.spec.ts
@@ -10,6 +10,26 @@ import { mockRefresh, waitForDomainPageReady } from './support/domain-fixtures.j
 
 const TEST_DOMAIN = 'new-untested-domain.example.com';
 
+async function expectSignalRoomWarningSurface(
+  page: import('@playwright/test').Page,
+  testId: string
+): Promise<void> {
+  await expect(page.getByTestId(testId)).toHaveAttribute('data-state', 'warning');
+  await expect(page.getByTestId(testId)).toHaveClass(/domain-360__state--warning/);
+  const colors = await page.getByTestId(testId).evaluate((element) => {
+    const tokenSample = document.createElement('div');
+    tokenSample.style.backgroundColor = 'var(--color-warning-surface)';
+    document.body.append(tokenSample);
+    const result = {
+      surface: getComputedStyle(element).backgroundColor,
+      token: getComputedStyle(tokenSample).backgroundColor,
+    };
+    tokenSample.remove();
+    return result;
+  });
+  expect(colors.surface).toBe(colors.token);
+}
+
 async function mockNoSnapshot(page: import('@playwright/test').Page): Promise<void> {
   await page.route(`**/api/domain/${TEST_DOMAIN}/latest`, (route) => {
     route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
@@ -19,22 +39,21 @@ async function mockNoSnapshot(page: import('@playwright/test').Page): Promise<vo
 
 /**
  * Tests for empty DB state
- * The empty state should show a yellow warning (not an error)
+ * The empty state must expose the Signal Room warning state (not an error).
  */
 test.describe('Empty DB State', () => {
-  test('shows yellow warning for domain without snapshot', async ({ page }) => {
+  test('shows a semantic warning for a domain without snapshot', async ({ page }) => {
     // Mock API to return 404 (no snapshot) for this unknown domain
     await mockNoSnapshot(page);
     await page.goto(`/domain/${TEST_DOMAIN}`);
     await waitForDomainPageReady(page);
 
-    // Should show yellow "no snapshot" warning, not an error
+    // A 404 is a recoverable warning, never an error or healthy state.
     const noSnapshotWarning = page.getByTestId('domain-no-data-banner');
     await expect(noSnapshotWarning).toBeVisible();
     await expect(noSnapshotWarning).toContainText(/no dns data/i);
 
-    // The warning should be yellow-ish (has yellow background)
-    await expect(noSnapshotWarning).toHaveClass(/yellow/);
+    await expectSignalRoomWarningSurface(page, 'domain-no-data-banner');
   });
 
   test('shows notes and tags panels even without snapshot', async ({ page }) => {

--- a/apps/web/e2e/tanstack-query-migration.spec.ts
+++ b/apps/web/e2e/tanstack-query-migration.spec.ts
@@ -17,6 +17,26 @@ import {
 const TEST_DOMAIN = 'tanstack-query-test.com';
 const SNAPSHOT_ID = 'snap-tq-001';
 
+async function expectSignalRoomWarningSurface(
+  page: import('@playwright/test').Page,
+  testId: string
+): Promise<void> {
+  await expect(page.getByTestId(testId)).toHaveAttribute('data-state', 'warning');
+  await expect(page.getByTestId(testId)).toHaveClass(/domain-360__state--warning/);
+  const colors = await page.getByTestId(testId).evaluate((element) => {
+    const tokenSample = document.createElement('div');
+    tokenSample.style.backgroundColor = 'var(--color-warning-surface)';
+    document.body.append(tokenSample);
+    const result = {
+      surface: getComputedStyle(element).backgroundColor,
+      token: getComputedStyle(tokenSample).backgroundColor,
+    };
+    tokenSample.remove();
+    return result;
+  });
+  expect(colors.surface).toBe(colors.token);
+}
+
 test.describe.configure({ mode: 'parallel' });
 
 // ---------------------------------------------------------------------------
@@ -95,10 +115,7 @@ test.describe('Simulation Panel Cache', () => {
 
 test.describe('Error Banner Retry', () => {
   test('portfolio search error shows retry button', async ({ page }) => {
-    await page.goto('/portfolio');
-    await expect(page.getByText('Portfolio workflows')).toBeVisible();
-
-    // Intercept the search endpoint to always return an error
+    // Register before navigation so the initial reactive search cannot escape the fixture.
     await page.route('**/api/portfolio/search', async (route) => {
       await route.fulfill({
         status: 503,
@@ -106,12 +123,11 @@ test.describe('Error Banner Retry', () => {
       });
     });
 
-    // Trigger a search by typing in the query field
-    const queryInput = page.getByLabel(/Query/i);
-    await queryInput.fill('test');
-    await page.keyboard.press('Enter');
+    await page.goto('/portfolio');
+    await expect(page.getByText('Portfolio workflows')).toBeVisible();
 
-    // Wait for error banner (TanStack Query retries 3x with backoff, so this takes time)
+    // The Portfolio search is reactive, so the initial query exercises the retry state.
+    // Wait for the error banner after TanStack Query's bounded retries complete.
     const errorBanner = page.getByText('Service unavailable');
     await expect(errorBanner).toBeVisible({ timeout: 15000 });
 
@@ -185,7 +201,7 @@ test.describe('Domain 360 Error States', () => {
     await page.unroute(`**/api/domain/${TEST_DOMAIN}/latest`);
   });
 
-  test('shows yellow banner for 404 (no snapshot)', async ({ page }) => {
+  test('shows a Signal Room warning surface for 404 (no snapshot)', async ({ page }) => {
     await page.route(`**/api/domain/${TEST_DOMAIN}/latest`, async (route) => {
       await route.fulfill({ status: 404, body: JSON.stringify({ error: 'Not found' }) });
     });
@@ -193,10 +209,10 @@ test.describe('Domain 360 Error States', () => {
     await page.goto(`/domain/${TEST_DOMAIN}`);
     await waitForDomainPageReady(page);
 
-    // Should show yellow "no data" banner
+    // A missing snapshot is recoverable and must retain warning-token treatment.
     const banner = page.getByTestId('domain-no-data-banner');
     await expect(banner).toBeVisible();
-    await expect(banner).toHaveClass(/bg-yellow-50/);
+    await expectSignalRoomWarningSurface(page, 'domain-no-data-banner');
 
     await page.unroute(`**/api/domain/${TEST_DOMAIN}/latest`);
   });

--- a/sessions/2026-08-08_session-runtime-remediation-release-handoff.md
+++ b/sessions/2026-08-08_session-runtime-remediation-release-handoff.md
@@ -1,0 +1,170 @@
+# Session Closeout — 2026-08-08 — Runtime Remediation and Release Handoff
+
+## 1) TL;DR
+
+- Completed and merged RT-1 through RT-4 runtime remediation into `master`; the remote tip is `0eb77ec`.
+- Fixed compiled-ESM DNS/DNSSEC collection failures, BullMQ-invalid queue names, false-green readiness, and request-time schema mutation.
+- All four remediation PRs passed GitHub CI and are merged: #35, #36, #37, and #39.
+- RT-4 adds forward migration `0021_repair_schema_parity.sql`; it has **not** been applied to any shared or production database in this session.
+- Railway access was verified, but no DNS Ops application staging/release target was linked or discoverable. Do not deploy the unrelated `dnsops-live-fixtures` production service without explicit authorization.
+
+## 2) Goals vs Outcome
+
+**Planned goals**
+
+- Preserve unrelated local work while validating and remediating RT-1–RT-4 in isolated worktrees.
+- Merge reviewed, CI-green remediation work.
+- Continue release-readiness validation when an authorized deployment target is available.
+
+**What actually happened**
+
+- Created isolated worktrees for each remediation, used independent implementation/review passes, rebased sequentially, and merged all four PRs.
+- Ran local isolated PostgreSQL/Redis validation and browser/runtime evidence gathering before implementation.
+- Verified Railway authentication and enumerated accessible projects after the user asked to continue release work. No matching DNS Ops web/collector/Postgres/Redis environment was available through the local Railway context or project list.
+- Did not deploy, apply a shared migration, change Railway configuration, contact providers, or operate controlled fixture assets.
+
+## 3) Key decisions (with rationale)
+
+- **Decision:** Treat reproduced runtime failures as authoritative over prior checkpoint claims.
+  - **Why:** Direct evidence showed ESM `require` failure, DNSSEC record encoding failure, BullMQ queue-name rejection, false-green health, and request-time migration replay.
+  - **Tradeoff:** Required four focused remediation streams and sequential integration rather than accepting the existing readiness status.
+  - **Status:** confirmed.
+
+- **Decision:** Keep remediation implementation out of the dirty canonical checkout until reviewed.
+  - **Why:** The canonical checkout initially contained unrelated user work.
+  - **Tradeoff:** Required worktree/rebase coordination.
+  - **Status:** confirmed.
+
+- **Decision:** Make release migrations the only automatic schema writer; retain schema repair only as explicit operator functionality.
+  - **Why:** Request traffic must not create migration ledgers or issue DDL.
+  - **Tradeoff:** Fresh local/dev databases now require the documented release migration runner rather than implicit first-request bootstrapping.
+  - **Status:** confirmed.
+
+- **Decision:** Do not infer a Railway target from `dnsops-live-fixtures`.
+  - **Why:** It exposes only a production controlled-fixture web service, not a verified DNS Ops staging/release stack.
+  - **Tradeoff:** Staging deployment, shared migration application, Redis rollout inventory, and live readiness proof remain pending.
+  - **Status:** confirmed.
+
+## 4) Work completed (concrete)
+
+- RT-1 DNS runtime remediation, merged as PR [#35](https://github.com/computindev/dns-ops/pull/35).
+  - Merge commit: `04d0ba9dfc0bcc96784af78fe082d69fcf751f64` — `fix(collector): restore DNS runtime compatibility`.
+  - Removed compiled-ESM-incompatible transport loading and corrected DNSKEY/DS DNS-packet formatting.
+  - Key areas: `apps/collector/src/dns/dnssec-resolver.ts`, focused DNS tests, live-DNS test script metadata.
+
+- RT-2 BullMQ remediation, merged as PR [#36](https://github.com/computindev/dns-ops/pull/36).
+  - Merge commit: `c061744c731d9a1ea201074315c5e5e5d4b5723f` — `fix(collector): use BullMQ-compatible queue names`.
+  - Replaced colon-containing queue names rejected by BullMQ 5 and gated real Redis queue proof behind explicit integration settings.
+  - Key area: `apps/collector/src/jobs/queue.ts` and collector queue tests.
+
+- RT-3 honest readiness remediation, merged as PR [#37](https://github.com/computindev/dns-ops/pull/37).
+  - Merge commit: `408b30491274c5d7a2e8fe8b03ad70ff4b5c4bc6` — `fix(runtime): make readiness dependency-aware`.
+  - Added bounded dependency probes, strict TLS-policy alignment, sanitized public readiness errors, and `HYPERDRIVE_URL`-aware web health URL resolution.
+  - Key areas: `packages/db/src/ping.ts`, `apps/web/hono/routes/api.ts`, `apps/collector/src/index.ts`, `apps/collector/src/middleware/db.ts`, Railway/Docker health config, smoke tests, readiness tests.
+
+- RT-4 schema ownership remediation, merged as PR [#39](https://github.com/computindev/dns-ops/pull/39).
+  - Merge commit: `0eb77ec12380751619fa755e1c28dee0e66a710a` — `fix(schema): make release migrations the sole schema writer`.
+  - Added `packages/db/src/migrations/0021_repair_schema_parity.sql` to supply the 12 previously request-repaired columns.
+  - Removed automatic `runMigrations`/`repairSchema` behavior from `apps/web/hono/middleware/db.ts`.
+  - Added fresh-schema parity and no-request-DDL tests; removed the dead second migration ledger implementation.
+  - Made HTTP reset/rebuild recovery endpoints explicitly return a release-pipeline-only response rather than claiming first-request recovery.
+
+- Repository and remote state at closeout:
+  - Current branch: `feat/issue-34-domain-360-signal-room`.
+  - `HEAD`, local `master`, and `origin/master`: `0eb77ec` at inspection time.
+  - `git status --porcelain`: clean.
+  - No open pull requests at the end of the remediation merge sequence.
+
+## 5) Changes summary (diff-level, not raw)
+
+- **Added:** Bounded DB readiness probe library/tests; web and collector readiness coverage; schema parity/no-request-DDL coverage; idempotent migration `0021_repair_schema_parity.sql`.
+- **Changed:** DNSSEC transport/record encoding; BullMQ queue naming; web and collector health semantics; Docker/Railway healthcheck targets; smoke-test readiness behavior; deployment/migration guidance.
+- **Removed:** Request-time schema migration/repair execution and the unused alternate migration ledger implementation.
+- **Behavioral impact:**
+  - DNS collection can run in compiled ESM and DNSSEC record extraction no longer passes numeric record types to `dns-packet`.
+  - BullMQ workers use valid queue names; rollout must account for any existing legacy Redis queue keys.
+  - `/api/health` and collector `/readyz` return 503 on unavailable dependencies rather than false 200; collector liveness remains process-only.
+  - Web traffic no longer writes schema or creates `__drizzle_migrations`.
+- **Migration/rollout notes:** Migration `0021` is additive and uses `ADD COLUMN IF NOT EXISTS`; it is safe for databases that had historical repair columns, but shared/staging/production application was intentionally not performed.
+
+## 6) Open items / Next steps (actionable)
+
+- **Task:** Identify the authorized DNS Ops Railway project, environment, and service IDs/URLs for web, collector, PostgreSQL, and Redis.
+  - **Owner:** user
+  - **Priority:** P0
+  - **Suggested approach:** Provide the Railway project URL or exact project/environment/service names. Do not use `dnsops-live-fixtures` production as a substitute.
+  - **Blockers/Dependencies:** No linked/discoverable DNS Ops deployment target; Railway CLI context was unlinked.
+
+- **Task:** Run the release migration and readiness validation in the authorized staging environment.
+  - **Owner:** agent after target authorization
+  - **Priority:** P0
+  - **Suggested approach:** Use the release command (`node scripts/run-migrations.mjs`) in the intended release path, then verify web `/api/health`, collector `/healthz`/`/readyz`, deployment status, and bounded logs. Confirm the latest deployment reaches Railway `SUCCESS`.
+  - **Blockers/Dependencies:** Authorized target and a staging database/Redis configuration.
+
+- **Task:** Inventory and drain/migrate legacy colon-named BullMQ queue keys before enabling the new worker in a shared environment.
+  - **Owner:** agent after target authorization
+  - **Priority:** P0
+  - **Suggested approach:** Perform read-only Redis key inventory first; decide whether legacy jobs are drained, replayed, or retained under a compatibility plan before rollout.
+  - **Blockers/Dependencies:** Authorized Redis service and confirmation of acceptable handling for queued jobs.
+
+- **Task:** Complete blocked controlled-assets/review gate.
+  - **Owner:** user / designated reviewers
+  - **Priority:** P1
+  - **Suggested approach:** Resolve GitHub issue [#4](https://github.com/computindev/dns-ops/issues/4) with controlled assets, authority, and final review inputs, then run the approved live verification procedure.
+  - **Blockers/Dependencies:** Controlled assets and explicit authority.
+
+- **Task:** Continue separate UI/product work.
+  - **Owner:** other branch owners
+  - **Priority:** P1
+  - **Suggested approach:** Continue on the existing UI branches; current checkout is `feat/issue-34-domain-360-signal-room`, with issue [#34](https://github.com/computindev/dns-ops/issues/34) open.
+  - **Blockers/Dependencies:** Independent of RT-1–RT-4 code now present on `master`.
+
+## 7) Risks & gotchas
+
+- A worker rollout without a legacy Redis queue inventory can strand jobs under pre-RT-2 colon-named keys.
+- `0021_repair_schema_parity.sql` is merged but not applied outside disposable local databases; environments remain schema-incomplete until the authorized release runner executes it.
+- The readiness endpoints establish dependency checks per platform probe. This is correct for readiness but should be monitored for connection churn if exposed to unbounded public traffic.
+- RT-3 intentionally causes worker bootstrap to fail when required Redis setup fails, preventing a transient falsely-ready service; deployment restart policy behavior should be verified in staging.
+- Railway project discovery found `dnsops-live-fixtures` only; touching it would risk controlled production fixtures and was deliberately avoided.
+- There was an attempted `gh issue view ... --comments` query that exited due GitHub Projects classic deprecation output; no issue was mutated.
+
+## 8) Testing & verification
+
+- Local isolated evidence gathered before implementation:
+  - Disposable PostgreSQL and Redis were used for migration, queue, runtime, authentication, browser E2E, and collection persistence checks.
+  - Fresh-schema release migration proof found 32/32 expected tables and demonstrated the historical 12-column repair gap.
+  - Reproduced compiled ESM DNS transport failure, DNSSEC numeric-type failure, BullMQ colon-name rejection, false-green health behavior, worker crash, and request-time migration replay.
+
+- Implementation/review validation:
+  - RT-1 and RT-2: focused tests, lint/typecheck/build passed; PR CI passed.
+  - RT-3: independent review approved; focused post-rebase suite passed (`25 passed`, `3 skipped` integration tests); PR CI passed.
+  - RT-4: independent review found and the follow-up fixed unsafe HTTP reset/rebuild semantics; focused post-rebase suite passed (`11 passed`, `6 skipped` opt-in integration tests); PR CI passed.
+  - RT-4 local proof: fresh release migrations applied 22 files including `0021`; second run skipped all 22; parity and no-request-DDL tests passed.
+
+- Key commands run during final merge sequence:
+  - `gh pr checks 37 --watch --interval 10`
+  - `gh pr checks 39 --watch --interval 10`
+  - `bunx vitest run ...` for focused RT-3 and RT-4 suites
+  - `git pull --rebase`, `git push`, `git remote prune origin`
+  - `railway whoami --json`, `railway project list --json`
+
+- Suggested next-session test plan:
+  - Confirm staging deploy terminal success, then make authenticated/unauthed HTTP checks to web health and collector liveness/readiness endpoints.
+  - Run release migration through the actual service release pipeline, verify `_migrations_applied`, and confirm no request creates `__drizzle_migrations`.
+  - Read-only inventory of Redis queue keys before enabling worker rollout.
+
+## 9) Notes for the next agent
+
+- **If you only read one thing:** RT-1–RT-4 are already merged to `master` at `0eb77ec`; the next critical work is authorized-environment rollout validation, not more implementation.
+- Start by obtaining an explicit Railway target. The local directory is not Railway-linked, and the enumerated `dnsops-live-fixtures` project is not an approved app staging target.
+- Relevant runtime files now on `master`:
+  - `apps/collector/src/dns/dnssec-resolver.ts`
+  - `apps/collector/src/jobs/queue.ts`
+  - `packages/db/src/ping.ts`
+  - `apps/web/hono/routes/api.ts`
+  - `apps/collector/src/index.ts`
+  - `apps/web/hono/middleware/db.ts`
+  - `packages/db/src/migrations/0021_repair_schema_parity.sql`
+  - `scripts/schema-parity-repair.test.ts`
+- The release runner is the only automatic schema writer. Do not restore request-time migrations/DDL or invoke the retired HTTP reset/rebuild path as a recovery mechanism.
+- Prior coordination ledger: `DNS Ops Completion Control Plane — 2026-08-07` at `https://workbench.md/d/WvKeMspiKS` (not updated during the final Railway-target discovery because no valid target was found).


### PR DESCRIPTION
## Summary
- migrate Domain 360 evidence, baseline-required evidence, query scope, snapshot metadata, and history/comparison surfaces to Signal Room semantic primitives and tokens
- keep UNKNOWN baseline evidence visibly distinct from current evidence without introducing an unbacked acceptance interaction
- make snapshot tables render as accessible cards on narrow screens and preserve tab, auth, route, and API behavior
- add browser coverage for evidence state, comparison behavior, and 320/375/414/768px overflow and single-line control checks

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run --filter @dns-ops/web e2e -- e2e/domain-signal-room.spec.ts`

## Scope
This is the Domain 360 vertical slice of #34. Portfolio remains tracked by #34 for follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Signal Room primitives in Domain 360 to improve clarity, accessibility, and small‑screen usability across evidence, snapshot history, and page chrome. Part of Linear #34; no API changes, adds semantic warning surfaces and updated E2E coverage.

- **New Features**
  - Evidence panel uses DS headers/badges; UNKNOWN baseline stays visually distinct; retry uses `Button`.
  - Snapshot history adds DS toolbar with “Compare latest/selected”, radio selection, and responsive table→card layout.
  - Diff view adds summary cards, change badges, scope/ruleset notices, and a quiet “Close” action.
  - Domain 360 header, tabs, alerts, scope, and metadata adopt DS semantics; 404/no‑snapshot now shows a token‑backed warning surface (`data-state="warning"`).
  - E2E (`apps/web/e2e/domain-signal-room.spec.ts` + updates) asserts evidence states, comparisons, 320/375/414/768px overflow, and warning token parity; portfolio search retry test stabilized by pre‑routing.

- **Refactors**
  - Added DS/Domain CSS (`apps/web/app/styles/app.css`) with `.domain-*` and `.ds-*` classes.
  - `Button` now sets `aria-busy` consistently; replaced ad‑hoc buttons in Domain 360.
  - Hardened error/loading/empty states in panels; behavior and routes unchanged.

<sup>Written for commit e07e4d9c1fa43048ccfe94816a824abbbf22e844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

