### PR TITLE
feat(web): adopt Signal Room in Portfolio

### DIFF
--- a/apps/web/app/components/AlertsPanel.tsx
+++ b/apps/web/app/components/AlertsPanel.tsx
@@ -55,19 +55,19 @@ const SEVERITY_OPTIONS: Array<{ value: 'all' | AlertSeverity; label: string }> =
 ];
 
 const SEVERITY_BADGES: Record<AlertSeverity, string> = {
-  critical: 'bg-red-100 text-red-800',
-  high: 'bg-orange-100 text-orange-800',
-  medium: 'bg-yellow-100 text-yellow-800',
-  low: 'bg-blue-100 text-blue-800',
-  info: 'bg-gray-100 text-gray-700',
+  critical: 'ds-badge ds-badge--danger',
+  high: 'ds-badge ds-badge--warning',
+  medium: 'ds-badge ds-badge--warning',
+  low: 'ds-badge ds-badge--info',
+  info: 'ds-badge ds-badge--neutral',
 };
 
 const STATUS_BADGES: Record<AlertStatus, string> = {
-  pending: 'bg-red-50 text-red-700',
-  sent: 'bg-blue-50 text-blue-700',
-  suppressed: 'bg-gray-100 text-gray-700',
-  acknowledged: 'bg-amber-100 text-amber-800',
-  resolved: 'bg-green-100 text-green-800',
+  pending: 'ds-badge ds-badge--danger',
+  sent: 'ds-badge ds-badge--info',
+  suppressed: 'ds-badge ds-badge--neutral',
+  acknowledged: 'ds-badge ds-badge--warning',
+  resolved: 'ds-badge ds-badge--success',
 };
 
 function canAcknowledge(status: AlertStatus): boolean {
@@ -251,23 +251,23 @@ export function AlertsPanel() {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200">
-      <div className="px-4 py-3 border-b border-gray-200 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div className="ds-panel portfolio-panel">
+      <div className="px-4 py-3 border-b border-line flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h3 className="text-lg font-medium text-gray-900">Alerts</h3>
-          <p className="text-sm text-gray-500">
+          <h3 className="text-lg font-medium text-ink">Alerts</h3>
+          <p className="text-sm text-muted">
             Review alert state, triage, and resolve operator-visible issues
           </p>
         </div>
 
         <div className="flex flex-col gap-2 sm:flex-row">
-          <label className="text-sm text-gray-600">
+          <label className="text-sm text-text">
             <span className="sr-only">Filter by status</span>
             <select
               value={statusFilter}
               onChange={(event) => handleStatusChange(event.target.value as 'all' | AlertStatus)}
               disabled={authRequired}
-              className="rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-100 disabled:text-gray-500"
+              className="rounded-lg border border-line px-3 py-2 text-sm disabled:bg-surface-muted disabled:text-muted"
             >
               {STATUS_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -277,7 +277,7 @@ export function AlertsPanel() {
             </select>
           </label>
 
-          <label className="text-sm text-gray-600">
+          <label className="text-sm text-text">
             <span className="sr-only">Filter by severity</span>
             <select
               value={severityFilter}
@@ -285,7 +285,7 @@ export function AlertsPanel() {
                 handleSeverityChange(event.target.value as 'all' | AlertSeverity)
               }
               disabled={authRequired}
-              className="rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-100 disabled:text-gray-500"
+              className="rounded-lg border border-line px-3 py-2 text-sm disabled:bg-surface-muted disabled:text-muted"
             >
               {SEVERITY_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -299,7 +299,7 @@ export function AlertsPanel() {
 
       <div className="p-4 space-y-4">
         {authRequired ? (
-          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to review or mutate tenant alerts.
           </div>
         ) : null}
@@ -314,7 +314,7 @@ export function AlertsPanel() {
         ) : null}
 
         {actionError ? (
-          <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <div className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
             {actionError}
           </div>
         ) : null}
@@ -343,7 +343,7 @@ export function AlertsPanel() {
           />
         ) : (
           <div className="space-y-3">
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-muted">
               Showing {alerts.length} of {total} alerts
             </div>
             {alerts.map((alert) => {
@@ -352,7 +352,7 @@ export function AlertsPanel() {
               const resolveExpanded = expandedResolveAlertId === alert.id;
 
               return (
-                <div key={alert.id} className="rounded-lg border border-gray-200 p-4 space-y-3">
+                <div key={alert.id} className="rounded-lg border border-line p-4 space-y-3">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
@@ -360,12 +360,12 @@ export function AlertsPanel() {
                           <Link
                             to="/domain/$domain"
                             params={{ domain: alert.domainName.toLowerCase() }}
-                            className="font-medium text-blue-600 hover:text-blue-700"
+                            className="font-medium text-brand hover:text-brand"
                           >
                             {alert.domainName}
                           </Link>
                         ) : (
-                          <h4 className="font-medium text-gray-900">Unknown domain</h4>
+                          <h4 className="font-medium text-ink">Unknown domain</h4>
                         )}
                         <span
                           className={`rounded-full px-2 py-0.5 text-xs font-medium ${SEVERITY_BADGES[alert.severity]}`}
@@ -378,10 +378,10 @@ export function AlertsPanel() {
                           {alert.status}
                         </span>
                       </div>
-                      <p className="mt-1 text-sm font-medium text-gray-800">{alert.title}</p>
-                      <p className="mt-1 text-sm text-gray-600">{alert.description}</p>
+                      <p className="mt-1 text-sm font-medium text-text">{alert.title}</p>
+                      <p className="mt-1 text-sm text-text">{alert.description}</p>
                     </div>
-                    <div className="text-xs text-gray-500 text-left sm:text-right">
+                    <div className="text-xs text-muted text-left sm:text-right">
                       <div>Created {formatTimestamp(alert.createdAt)}</div>
                       {alert.acknowledgedAt ? (
                         <div>Acknowledged {formatTimestamp(alert.acknowledgedAt)}</div>
@@ -393,7 +393,7 @@ export function AlertsPanel() {
                   </div>
 
                   {alert.resolutionNote ? (
-                    <div className="rounded bg-gray-50 px-3 py-2 text-sm text-gray-600">
+                    <div className="rounded bg-surface-muted px-3 py-2 text-sm text-text">
                       Resolution note: {alert.resolutionNote}
                     </div>
                   ) : null}
@@ -404,7 +404,7 @@ export function AlertsPanel() {
                         type="button"
                         disabled={!!actionInFlight || authRequired}
                         onClick={() => runAlertAction(alert.id, 'acknowledge')}
-                        className="focus-ring rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:bg-gray-100 disabled:text-gray-400"
+                        className="focus-ring rounded-lg border border-line px-3 py-2 text-sm text-text hover:bg-surface-muted disabled:bg-surface-muted disabled:text-faint"
                       >
                         {actionInFlight === 'acknowledge' ? 'Acknowledging...' : 'Acknowledge'}
                       </button>
@@ -415,7 +415,7 @@ export function AlertsPanel() {
                         type="button"
                         disabled={!!actionInFlight || authRequired}
                         onClick={() => runAlertAction(alert.id, 'suppress')}
-                        className="focus-ring rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:bg-gray-100 disabled:text-gray-400"
+                        className="focus-ring rounded-lg border border-line px-3 py-2 text-sm text-text hover:bg-surface-muted disabled:bg-surface-muted disabled:text-faint"
                       >
                         {actionInFlight === 'suppress' ? 'Suppressing...' : 'Suppress'}
                       </button>
@@ -432,7 +432,7 @@ export function AlertsPanel() {
                             [alert.id]: current[alert.id] ?? alert.resolutionNote ?? '',
                           }));
                         }}
-                        className="focus-ring rounded-lg bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:bg-gray-400"
+                        className="ds-button ds-button--primary ds-button--sm"
                       >
                         Resolve
                       </button>
@@ -440,8 +440,8 @@ export function AlertsPanel() {
                   </div>
 
                   {resolveExpanded ? (
-                    <div className="rounded-lg border border-blue-100 bg-blue-50 p-3 space-y-2">
-                      <label className="block text-sm font-medium text-gray-700">
+                    <div className="rounded-lg border border-brand bg-info-surface p-3 space-y-2">
+                      <label className="block text-sm font-medium text-text">
                         Resolution note
                         <textarea
                           value={resolveDraft}
@@ -453,7 +453,7 @@ export function AlertsPanel() {
                           }
                           rows={3}
                           disabled={!!actionInFlight || authRequired}
-                          className="focus-ring mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
+                          className="ds-input mt-1 block w-full rounded-md border-line disabled:bg-surface-muted"
                           placeholder="Describe how this alert was resolved"
                         />
                       </label>
@@ -464,7 +464,7 @@ export function AlertsPanel() {
                           onClick={() =>
                             runAlertAction(alert.id, 'resolve', resolveDraft.trim() || undefined)
                           }
-                          className="focus-ring rounded-lg bg-green-600 px-3 py-2 text-sm text-white hover:bg-green-700 disabled:bg-gray-400"
+                          className="ds-button ds-button--primary ds-button--sm"
                         >
                           {actionInFlight === 'resolve' ? 'Resolving...' : 'Confirm Resolve'}
                         </button>
@@ -472,7 +472,7 @@ export function AlertsPanel() {
                           type="button"
                           disabled={!!actionInFlight}
                           onClick={() => setExpandedResolveAlertId(null)}
-                          className="focus-ring rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                          className="focus-ring rounded-lg border border-line px-3 py-2 text-sm text-text hover:bg-surface-muted"
                         >
                           Cancel
                         </button>
@@ -488,7 +488,7 @@ export function AlertsPanel() {
                 type="button"
                 disabled={isFetchingNextPage || authRequired}
                 onClick={() => fetchNextPage()}
-                className="focus-ring rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:bg-gray-100 disabled:text-gray-400"
+                className="focus-ring rounded-lg border border-line px-4 py-2 text-sm text-text hover:bg-surface-muted disabled:bg-surface-muted disabled:text-faint"
               >
                 {isFetchingNextPage ? 'Loading more...' : 'Load more alerts'}
               </button>

--- a/apps/web/app/components/AuditLogPanel.tsx
+++ b/apps/web/app/components/AuditLogPanel.tsx
@@ -89,11 +89,11 @@ const ACTION_ICONS: Record<string, string> = {
 
 // Color for each action category
 const ACTION_COLORS: Record<string, string> = {
-  created: 'text-green-600 bg-green-50',
-  updated: 'text-blue-600 bg-blue-50',
-  deleted: 'text-red-600 bg-red-50',
-  added: 'text-green-600 bg-green-50',
-  removed: 'text-red-600 bg-red-50',
+  created: 'text-success bg-success-surface',
+  updated: 'text-brand bg-info-surface',
+  deleted: 'text-danger bg-danger-surface',
+  added: 'text-success bg-success-surface',
+  removed: 'text-danger bg-danger-surface',
 };
 
 async function fetchAuditLog(limit: number): Promise<AuditEvent[]> {
@@ -157,14 +157,14 @@ export function AuditLogPanel() {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200">
-      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-        <h3 className="text-lg font-medium text-gray-900">Audit Log</h3>
+    <div className="ds-panel portfolio-panel">
+      <div className="px-4 py-3 border-b border-line flex items-center justify-between">
+        <h3 className="text-lg font-medium text-ink">Audit Log</h3>
         <button
           type="button"
           onClick={() => refetch()}
           disabled={isLoading || authRequired}
-          className="text-sm text-blue-600 hover:text-blue-700 font-medium disabled:opacity-50"
+          className="text-sm text-brand hover:text-brand font-medium disabled:opacity-50"
         >
           Refresh
         </button>
@@ -172,25 +172,23 @@ export function AuditLogPanel() {
 
       <div className="p-4">
         {authRequired && (
-          <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="mb-4 rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to view the tenant audit log.
           </div>
         )}
 
         {loadError && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-800 text-sm">
+          <div className="mb-4 p-3 bg-danger-surface border border-danger rounded-lg text-danger text-sm">
             {loadError}
           </div>
         )}
 
         {isLoading ? (
-          <div className="text-center text-gray-500 py-8">Loading audit log...</div>
+          <div className="text-center text-muted py-8">Loading audit log...</div>
         ) : authRequired ? (
-          <div className="text-center text-gray-500 py-8">
-            Sign in to view the tenant audit log.
-          </div>
+          <div className="text-center text-muted py-8">Sign in to view the tenant audit log.</div>
         ) : events.length === 0 ? (
-          <div className="text-center text-gray-500 py-8">No audit events found</div>
+          <div className="text-center text-muted py-8">No audit events found</div>
         ) : (
           <div className="space-y-3">
             {events.map((event) => (
@@ -209,7 +207,7 @@ export function AuditLogPanel() {
                 <button
                   type="button"
                   onClick={() => setLimit(limit + 20)}
-                  className="text-sm text-blue-600 hover:text-blue-700"
+                  className="text-sm text-brand hover:text-brand"
                 >
                   Load more events
                 </button>
@@ -236,7 +234,7 @@ interface AuditEventCardProps {
 
 function AuditEventCard({ event, isExpanded, onToggle, category, colorKey }: AuditEventCardProps) {
   const iconPath = ACTION_ICONS[category] || ACTION_ICONS.note;
-  const colorClass = ACTION_COLORS[colorKey] || 'text-gray-600 bg-gray-50';
+  const colorClass = ACTION_COLORS[colorKey] || 'text-text bg-surface-muted';
 
   const formatTime = (dateString: string): string => {
     const date = new Date(dateString);
@@ -272,17 +270,15 @@ function AuditEventCard({ event, isExpanded, onToggle, category, colorKey }: Aud
       <div className="flex-1 min-w-0">
         <div className="flex items-start justify-between">
           <div>
-            <span className="font-medium text-gray-900">
+            <span className="font-medium text-ink">
               {ACTION_LABELS[event.action] || event.action}
             </span>
-            <span className="text-gray-500 text-sm ml-2">
-              by {event.actorEmail || event.actorId}
-            </span>
+            <span className="text-muted text-sm ml-2">by {event.actorEmail || event.actorId}</span>
           </div>
-          <span className="text-xs text-gray-400 flex-shrink-0">{formatTime(event.createdAt)}</span>
+          <span className="text-xs text-faint flex-shrink-0">{formatTime(event.createdAt)}</span>
         </div>
 
-        <p className="text-sm text-gray-600 mt-0.5">
+        <p className="text-sm text-text mt-0.5">
           {event.entityType}{' '}
           <span className="font-mono text-xs">{event.entityId.slice(0, 8)}...</span>
         </p>
@@ -291,7 +287,7 @@ function AuditEventCard({ event, isExpanded, onToggle, category, colorKey }: Aud
           <button
             type="button"
             onClick={onToggle}
-            className="mt-1 text-xs text-gray-500 hover:text-gray-700"
+            className="mt-1 text-xs text-muted hover:text-text"
           >
             {isExpanded ? 'Hide details' : 'Show details'}
           </button>
@@ -301,16 +297,16 @@ function AuditEventCard({ event, isExpanded, onToggle, category, colorKey }: Aud
           <div className="mt-2 space-y-2">
             {event.previousValue && (
               <div>
-                <p className="text-xs font-medium text-gray-500">Before:</p>
-                <pre className="mt-1 bg-red-50 p-2 rounded text-xs text-red-800 overflow-x-auto">
+                <p className="text-xs font-medium text-muted">Before:</p>
+                <pre className="mt-1 bg-danger-surface p-2 rounded text-xs text-danger overflow-x-auto">
                   {JSON.stringify(event.previousValue, null, 2)}
                 </pre>
               </div>
             )}
             {event.newValue && (
               <div>
-                <p className="text-xs font-medium text-gray-500">After:</p>
-                <pre className="mt-1 bg-green-50 p-2 rounded text-xs text-green-800 overflow-x-auto">
+                <p className="text-xs font-medium text-muted">After:</p>
+                <pre className="mt-1 bg-success-surface p-2 rounded text-xs text-success overflow-x-auto">
                   {JSON.stringify(event.newValue, null, 2)}
                 </pre>
               </div>

--- a/apps/web/app/components/FleetReportsPanel.tsx
+++ b/apps/web/app/components/FleetReportsPanel.tsx
@@ -171,27 +171,27 @@ export function FleetReportsPanel() {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200">
-      <div className="px-4 py-3 border-b border-gray-200">
-        <h3 className="text-lg font-medium text-gray-900">Fleet Reports</h3>
-        <p className="text-sm text-gray-500">Run bulk checks across your domain inventory</p>
+    <div className="ds-panel portfolio-panel">
+      <div className="px-4 py-3 border-b border-line">
+        <h3 className="text-lg font-medium text-ink">Fleet Reports</h3>
+        <p className="text-sm text-muted">Run bulk checks across your domain inventory</p>
       </div>
 
       <div className="p-4 space-y-4">
         {authRequired && (
-          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to import inventory or run tenant fleet reports.
           </div>
         )}
 
         {/* Error message */}
         {error && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-800 text-sm">
+          <div className="p-3 bg-danger-surface border border-danger rounded-lg text-danger text-sm">
             {error}
             <button
               type="button"
               onClick={() => setError(null)}
-              className="ml-2 text-red-600 hover:text-red-800"
+              className="ml-2 text-danger hover:text-danger"
             >
               Dismiss
             </button>
@@ -200,7 +200,7 @@ export function FleetReportsPanel() {
 
         {/* Template Selection */}
         <div>
-          <p className="block text-sm font-medium text-gray-700 mb-2">Report Template</p>
+          <p className="block text-sm font-medium text-text mb-2">Report Template</p>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             {templates.map((template) => (
               <button
@@ -209,17 +209,17 @@ export function FleetReportsPanel() {
                 onClick={() => setSelectedTemplate(template)}
                 className={`p-3 text-left rounded-lg border-2 transition-colors ${
                   selectedTemplate?.id === template.id
-                    ? 'border-blue-500 bg-blue-50'
-                    : 'border-gray-200 hover:border-gray-300'
+                    ? 'border-brand bg-info-surface'
+                    : 'border-line hover:border-line'
                 }`}
               >
-                <div className="font-medium text-gray-900">{template.name}</div>
-                <p className="text-xs text-gray-500 mt-1">{template.description}</p>
+                <div className="font-medium text-ink">{template.name}</div>
+                <p className="text-xs text-muted mt-1">{template.description}</p>
                 <div className="mt-2 flex flex-wrap gap-1">
                   {template.checks.map((check) => (
                     <span
                       key={check}
-                      className="px-1.5 py-0.5 bg-gray-100 rounded text-xs text-gray-600 uppercase"
+                      className="px-1.5 py-0.5 bg-surface-muted rounded text-xs text-text uppercase"
                     >
                       {check}
                     </span>
@@ -232,10 +232,7 @@ export function FleetReportsPanel() {
 
         {/* Inventory Input */}
         <div>
-          <label
-            htmlFor={inventoryFieldId}
-            className="block text-sm font-medium text-gray-700 mb-1"
-          >
+          <label htmlFor={inventoryFieldId} className="block text-sm font-medium text-text mb-1">
             Domain Inventory
           </label>
           <textarea
@@ -246,13 +243,13 @@ export function FleetReportsPanel() {
             placeholder="Enter domain names, one per line or comma-separated:
 example.com
 example.org, example.net"
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
+            className="ds-input w-full px-3 py-2 border border-line rounded-lg focus:ring-2 focus:ring-focus focus:border-brand font-mono text-sm"
           />
           <div className="mt-2 flex items-center gap-4">
-            <span className="text-xs text-gray-500">
+            <span className="text-xs text-muted">
               {parseInventory(inventoryInput).length} domains
             </span>
-            <label className="text-xs text-blue-600 hover:text-blue-700 cursor-pointer">
+            <label className="text-xs text-brand hover:text-brand cursor-pointer">
               <input
                 type="file"
                 accept=".csv"
@@ -279,7 +276,7 @@ example.org, example.net"
               !selectedTemplate ||
               parseInventory(inventoryInput).length === 0
             }
-            className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="ds-button ds-button--primary ds-button--md"
           >
             {running ? 'Running Report...' : 'Run Report'}
           </button>
@@ -289,8 +286,8 @@ example.org, example.net"
         {report && (
           <div className="border-t pt-4 mt-4 space-y-4">
             <div className="flex items-center justify-between">
-              <h4 className="font-medium text-gray-900">Report Results</h4>
-              <span className="text-sm text-gray-500">
+              <h4 className="font-medium text-ink">Report Results</h4>
+              <span className="text-sm text-muted">
                 Generated {new Date(report.reportGeneratedAt).toLocaleString()}
               </span>
             </div>
@@ -317,25 +314,25 @@ example.org, example.net"
 
             {/* High Priority Issues */}
             {report.highPriorityIssues && report.highPriorityIssues.length > 0 && (
-              <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-                <h5 className="font-medium text-red-900 mb-2">High Priority Issues</h5>
+              <div className="bg-danger-surface border border-danger rounded-lg p-4">
+                <h5 className="font-medium text-danger mb-2">High Priority Issues</h5>
                 <div className="space-y-2">
                   {report.highPriorityIssues.slice(0, 10).map((issue) => (
                     <div key={`${issue.severity}-${issue.message}`} className="text-sm">
                       <span
                         className={`inline-block w-16 px-1.5 py-0.5 rounded text-xs text-center font-medium ${
                           issue.severity === 'critical'
-                            ? 'bg-red-600 text-white'
-                            : 'bg-orange-500 text-white'
+                            ? 'bg-danger text-brand-ink'
+                            : 'bg-warning text-brand-ink'
                         }`}
                       >
                         {issue.severity}
                       </span>
-                      <span className="ml-2 text-gray-700">{issue.message}</span>
+                      <span className="ml-2 text-text">{issue.message}</span>
                     </div>
                   ))}
                   {report.highPriorityIssues.length > 10 && (
-                    <p className="text-xs text-red-700">
+                    <p className="text-xs text-danger">
                       ...and {report.highPriorityIssues.length - 10} more
                     </p>
                   )}
@@ -349,7 +346,7 @@ example.org, example.net"
                 <button
                   type="button"
                   onClick={() => setShowResultDetails(!showResultDetails)}
-                  className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+                  className="text-sm text-brand hover:text-brand font-medium"
                 >
                   {showResultDetails ? 'Hide Details' : 'Show Domain Details'}
                 </button>
@@ -366,9 +363,9 @@ example.org, example.net"
 
             {/* Errors */}
             {report.errors && report.errors.length > 0 && (
-              <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
-                <h5 className="font-medium text-orange-900 mb-2">Errors</h5>
-                <div className="space-y-1 text-sm text-orange-800">
+              <div className="bg-warning-surface border border-warning rounded-lg p-4">
+                <h5 className="font-medium text-warning mb-2">Errors</h5>
+                <div className="space-y-1 text-sm text-warning">
                   {report.errors.slice(0, 10).map((err) => (
                     <div key={`${err.domain}-${err.error}`}>
                       <span className="font-mono">{err.domain}</span>: {err.error}
@@ -401,11 +398,11 @@ function SummaryCard({
   color: 'blue' | 'green' | 'yellow' | 'red' | 'orange';
 }) {
   const colorClasses = {
-    blue: 'bg-blue-50 text-blue-900',
-    green: 'bg-green-50 text-green-900',
-    yellow: 'bg-yellow-50 text-yellow-900',
-    red: 'bg-red-50 text-red-900',
-    orange: 'bg-orange-50 text-orange-900',
+    blue: 'bg-info-surface text-brand',
+    green: 'bg-success-surface text-success',
+    yellow: 'bg-warning-surface text-warning',
+    red: 'bg-danger-surface text-danger',
+    orange: 'bg-warning-surface text-warning',
   };
 
   return (
@@ -423,18 +420,18 @@ function DomainResultCard({ result }: { result: FleetReportResult }) {
   return (
     <div
       className={`p-3 rounded-lg border ${
-        hasIssues ? 'border-yellow-200 bg-yellow-50' : 'border-gray-200 bg-gray-50'
+        hasIssues ? 'border-warning bg-warning-surface' : 'border-line bg-surface-muted'
       }`}
     >
       <div className="flex items-center justify-between">
         <div>
-          <span className="font-medium text-gray-900">{result.domain}</span>
-          <span className="ml-2 text-xs text-gray-500">{result.findingsCount} findings</span>
+          <span className="font-medium text-ink">{result.domain}</span>
+          <span className="ml-2 text-xs text-muted">{result.findingsCount} findings</span>
         </div>
         <button
           type="button"
           onClick={() => setExpanded(!expanded)}
-          className="text-sm text-gray-500 hover:text-gray-700"
+          className="text-sm text-muted hover:text-text"
         >
           {expanded ? 'Hide' : 'Show'} checks
         </button>
@@ -448,10 +445,8 @@ function DomainResultCard({ result }: { result: FleetReportResult }) {
               className="flex items-center gap-2 text-sm"
             >
               <StatusBadge status={check.status} />
-              <span className="uppercase text-xs font-medium text-gray-600 w-20">
-                {check.check}
-              </span>
-              <span className="text-gray-700">{check.message}</span>
+              <span className="uppercase text-xs font-medium text-text w-20">{check.check}</span>
+              <span className="text-text">{check.message}</span>
             </div>
           ))}
         </div>
@@ -462,10 +457,10 @@ function DomainResultCard({ result }: { result: FleetReportResult }) {
 
 function StatusBadge({ status }: { status: CheckResult['status'] }) {
   const styles = {
-    pass: 'bg-green-100 text-green-700',
-    fail: 'bg-red-100 text-red-700',
-    warning: 'bg-yellow-100 text-yellow-700',
-    missing: 'bg-gray-100 text-gray-600',
+    pass: 'ds-badge--success',
+    fail: 'ds-badge--danger',
+    warning: 'ds-badge--warning',
+    missing: 'ds-badge--unknown',
   };
 
   const icons = {
@@ -475,11 +470,5 @@ function StatusBadge({ status }: { status: CheckResult['status'] }) {
     missing: '?',
   };
 
-  return (
-    <span
-      className={`w-5 h-5 flex items-center justify-center rounded text-xs font-bold ${styles[status]}`}
-    >
-      {icons[status]}
-    </span>
-  );
+  return <span className={`ds-badge ${styles[status]}`}>{icons[status]}</span>;
 }

--- a/apps/web/app/components/MonitoredDomainsPanel.tsx
+++ b/apps/web/app/components/MonitoredDomainsPanel.tsx
@@ -121,17 +121,17 @@ export function MonitoredDomainsPanel() {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200">
-      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+    <div className="ds-panel portfolio-panel">
+      <div className="px-4 py-3 border-b border-line flex items-center justify-between">
         <div>
-          <h3 className="text-lg font-medium text-gray-900">Monitored Domains</h3>
-          <p className="text-sm text-gray-500">Configure automatic monitoring and alerts</p>
+          <h3 className="text-lg font-medium text-ink">Monitored Domains</h3>
+          <p className="text-sm text-muted">Configure automatic monitoring and alerts</p>
         </div>
         <button
           type="button"
           onClick={() => setShowAddDialog(true)}
           disabled={authRequired}
-          className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400"
+          className="ds-button ds-button--primary ds-button--sm"
         >
           + Add Domain
         </button>
@@ -139,18 +139,18 @@ export function MonitoredDomainsPanel() {
 
       <div className="p-4">
         {authRequired && (
-          <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="mb-4 rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to view or change monitored domains.
           </div>
         )}
 
         {localError && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-800 text-sm">
+          <div className="mb-4 p-3 bg-danger-surface border border-danger rounded-lg text-danger text-sm">
             {localError}
             <button
               type="button"
               onClick={() => setLocalError(null)}
-              className="ml-2 text-red-600 hover:text-red-800"
+              className="ml-2 text-danger hover:text-danger"
             >
               Dismiss
             </button>
@@ -177,14 +177,14 @@ export function MonitoredDomainsPanel() {
         )}
 
         {isLoading ? (
-          <div className="text-center text-gray-500 py-8">Loading monitored domains...</div>
+          <div className="text-center text-muted py-8">Loading monitored domains...</div>
         ) : authRequired ? (
-          <div className="text-center py-8 text-gray-500">
+          <div className="text-center py-8 text-muted">
             Sign in to view and manage tenant monitoring configuration.
           </div>
         ) : domains.length === 0 ? (
           <div className="text-center py-8">
-            <div className="text-gray-400 mb-2">
+            <div className="text-faint mb-2">
               <svg
                 className="w-12 h-12 mx-auto"
                 fill="none"
@@ -200,12 +200,12 @@ export function MonitoredDomainsPanel() {
                 />
               </svg>
             </div>
-            <p className="text-gray-500">No domains are being monitored yet.</p>
+            <p className="text-muted">No domains are being monitored yet.</p>
             <button
               type="button"
               onClick={() => setShowAddDialog(true)}
               disabled={authRequired}
-              className="mt-3 text-blue-600 hover:text-blue-700 text-sm font-medium disabled:text-gray-400"
+              className="mt-3 text-brand hover:text-brand text-sm font-medium disabled:text-faint"
             >
               Add your first domain
             </button>
@@ -281,7 +281,7 @@ function MonitoredDomainCard({
   return (
     <div
       className={`p-4 rounded-lg border ${
-        domain.isActive ? 'border-gray-200 bg-white' : 'border-gray-200 bg-gray-50 opacity-75'
+        domain.isActive ? 'border-line bg-surface' : 'border-line bg-surface-muted opacity-75'
       }`}
     >
       <div className="flex items-start justify-between">
@@ -290,38 +290,36 @@ function MonitoredDomainCard({
             <Link
               to="/domain/$domain"
               params={{ domain: domain.domainName.toLowerCase() }}
-              className="font-medium text-blue-600 hover:text-blue-700"
+              className="font-medium text-brand hover:text-brand"
             >
               {domain.domainName}
             </Link>
             <span
-              className={`px-2 py-0.5 rounded text-xs font-medium ${
-                domain.isActive ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-600'
-              }`}
+              className={`ds-badge ${domain.isActive ? 'ds-badge--success' : 'ds-badge--neutral'}`}
             >
               {domain.isActive ? 'Active' : 'Paused'}
             </span>
-            <span className="px-2 py-0.5 rounded bg-blue-100 text-blue-700 text-xs font-medium capitalize">
+            <span className="px-2 py-0.5 rounded bg-info-surface text-brand text-xs font-medium capitalize">
               {domain.schedule}
             </span>
           </div>
 
           <div className="mt-2 grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-1 text-sm">
             <div>
-              <span className="text-gray-500">Last check:</span>{' '}
-              <span className="text-gray-700">{formatTime(domain.lastCheckAt)}</span>
+              <span className="text-muted">Last check:</span>{' '}
+              <span className="text-text">{formatTime(domain.lastCheckAt)}</span>
             </div>
             <div>
-              <span className="text-gray-500">Last alert:</span>{' '}
-              <span className="text-gray-700">{formatTime(domain.lastAlertAt)}</span>
+              <span className="text-muted">Last alert:</span>{' '}
+              <span className="text-text">{formatTime(domain.lastAlertAt)}</span>
             </div>
             <div>
-              <span className="text-gray-500">Max alerts/day:</span>{' '}
-              <span className="text-gray-700">{domain.maxAlertsPerDay}</span>
+              <span className="text-muted">Max alerts/day:</span>{' '}
+              <span className="text-text">{domain.maxAlertsPerDay}</span>
             </div>
             <div>
-              <span className="text-gray-500">Channels:</span>{' '}
-              <span className="text-gray-700">{getAlertChannelsSummary()}</span>
+              <span className="text-muted">Channels:</span>{' '}
+              <span className="text-text">{getAlertChannelsSummary()}</span>
             </div>
           </div>
         </div>
@@ -330,7 +328,7 @@ function MonitoredDomainCard({
           <button
             type="button"
             onClick={onToggle}
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded disabled:text-gray-300 disabled:hover:bg-transparent"
+            className="p-2 text-muted hover:text-text hover:bg-surface-muted rounded disabled:text-faint disabled:hover:bg-transparent"
             title={domain.isActive ? 'Pause monitoring' : 'Resume monitoring'}
             disabled={disabled}
           >
@@ -375,7 +373,7 @@ function MonitoredDomainCard({
           <button
             type="button"
             onClick={onEdit}
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded disabled:text-gray-300 disabled:hover:bg-transparent"
+            className="p-2 text-muted hover:text-text hover:bg-surface-muted rounded disabled:text-faint disabled:hover:bg-transparent"
             title="Edit"
             disabled={disabled}
           >
@@ -397,7 +395,7 @@ function MonitoredDomainCard({
           <button
             type="button"
             onClick={onDelete}
-            className="p-2 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded disabled:text-gray-300 disabled:hover:bg-transparent"
+            className="p-2 text-muted hover:text-danger hover:bg-danger-surface rounded disabled:text-faint disabled:hover:bg-transparent"
             title="Remove from monitoring"
             disabled={disabled}
           >
@@ -527,14 +525,14 @@ function MonitoredDomainDialog({
   };
 
   return (
-    <div className="mb-4 p-4 bg-gray-50 rounded-lg border border-gray-200">
+    <div className="mb-4 p-4 bg-surface-muted rounded-lg border border-line">
       <form onSubmit={handleSubmit}>
-        <h4 className="font-medium text-gray-900 mb-3">
+        <h4 className="font-medium text-ink mb-3">
           {editingDomain ? `Edit ${editingDomain.domainName}` : 'Add Domain to Monitoring'}
         </h4>
 
         {error && (
-          <div className="mb-3 p-2 bg-red-50 border border-red-200 rounded text-red-800 text-sm">
+          <div className="mb-3 p-2 bg-danger-surface border border-danger rounded text-danger text-sm">
             {error}
           </div>
         )}
@@ -542,11 +540,8 @@ function MonitoredDomainDialog({
         <div className="space-y-3">
           {!editingDomain && (
             <div>
-              <label
-                htmlFor={domainNameId}
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                Domain Name <span className="text-red-500">*</span>
+              <label htmlFor={domainNameId} className="block text-sm font-medium text-text mb-1">
+                Domain Name <span className="text-danger">*</span>
               </label>
               <input
                 type="text"
@@ -554,21 +549,21 @@ function MonitoredDomainDialog({
                 value={domainName}
                 onChange={(e) => setDomainName(e.target.value)}
                 placeholder="example.com"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
+                className="ds-input w-full px-3 py-2 border border-line rounded-lg focus:ring-2 focus:ring-focus focus:border-brand disabled:bg-surface-muted"
                 disabled={authRequired}
               />
             </div>
           )}
 
           <div>
-            <label htmlFor={scheduleId} className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor={scheduleId} className="block text-sm font-medium text-text mb-1">
               Check Schedule
             </label>
             <select
               id={scheduleId}
               value={schedule}
               onChange={(e) => setSchedule(e.target.value as 'hourly' | 'daily' | 'weekly')}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
+              className="ds-input w-full px-3 py-2 border border-line rounded-lg focus:ring-2 focus:ring-focus focus:border-brand disabled:bg-surface-muted"
               disabled={authRequired}
             >
               {SCHEDULE_OPTIONS.map((opt) => (
@@ -580,11 +575,11 @@ function MonitoredDomainDialog({
           </div>
 
           <div className="border-t pt-3">
-            <h5 className="text-sm font-medium text-gray-700 mb-2">Alert Channels</h5>
+            <h5 className="text-sm font-medium text-text mb-2">Alert Channels</h5>
 
             <div className="space-y-2">
               <div>
-                <label htmlFor={emailsId} className="block text-xs text-gray-500 mb-1">
+                <label htmlFor={emailsId} className="block text-xs text-muted mb-1">
                   Email addresses (comma-separated)
                 </label>
                 <input
@@ -593,13 +588,13 @@ function MonitoredDomainDialog({
                   value={emailsInput}
                   onChange={(e) => setEmailsInput(e.target.value)}
                   placeholder="admin@example.com, ops@example.com"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm disabled:bg-gray-100"
+                  className="ds-input w-full px-3 py-2 border border-line rounded-lg focus:ring-2 focus:ring-focus focus:border-brand text-sm disabled:bg-surface-muted"
                   disabled={authRequired}
                 />
               </div>
 
               <div>
-                <label htmlFor={webhookId} className="block text-xs text-gray-500 mb-1">
+                <label htmlFor={webhookId} className="block text-xs text-muted mb-1">
                   Webhook URL
                 </label>
                 <input
@@ -608,13 +603,13 @@ function MonitoredDomainDialog({
                   value={webhook}
                   onChange={(e) => setWebhook(e.target.value)}
                   placeholder="https://..."
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm disabled:bg-gray-100"
+                  className="ds-input w-full px-3 py-2 border border-line rounded-lg focus:ring-2 focus:ring-focus focus:border-brand text-sm disabled:bg-surface-muted"
                   disabled={authRequired}
                 />
               </div>
 
               <div>
-                <label htmlFor={slackId} className="block text-xs text-gray-500 mb-1">
+                <label htmlFor={slackId} className="block text-xs text-muted mb-1">
                   Slack Channel
                 </label>
                 <input
@@ -623,7 +618,7 @@ function MonitoredDomainDialog({
                   value={slack}
                   onChange={(e) => setSlack(e.target.value)}
                   placeholder="#dns-alerts"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm disabled:bg-gray-100"
+                  className="ds-input w-full px-3 py-2 border border-line rounded-lg focus:ring-2 focus:ring-focus focus:border-brand text-sm disabled:bg-surface-muted"
                   disabled={authRequired}
                 />
               </div>
@@ -631,11 +626,11 @@ function MonitoredDomainDialog({
           </div>
 
           <div className="border-t pt-3">
-            <h5 className="text-sm font-medium text-gray-700 mb-2">Noise Budget</h5>
+            <h5 className="text-sm font-medium text-text mb-2">Noise Budget</h5>
 
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label htmlFor={maxAlertsId} className="block text-xs text-gray-500 mb-1">
+                <label htmlFor={maxAlertsId} className="block text-xs text-muted mb-1">
                   Max alerts per day
                 </label>
                 <input
@@ -645,12 +640,12 @@ function MonitoredDomainDialog({
                   onChange={(e) => setMaxAlertsPerDay(e.target.value)}
                   min="1"
                   max="100"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm disabled:bg-gray-100"
+                  className="ds-input w-full px-3 py-2 border border-line rounded-lg focus:ring-2 focus:ring-focus focus:border-brand text-sm disabled:bg-surface-muted"
                   disabled={authRequired}
                 />
               </div>
               <div>
-                <label htmlFor={suppressionId} className="block text-xs text-gray-500 mb-1">
+                <label htmlFor={suppressionId} className="block text-xs text-muted mb-1">
                   Suppression window (minutes)
                 </label>
                 <input
@@ -660,7 +655,7 @@ function MonitoredDomainDialog({
                   onChange={(e) => setSuppressionWindow(e.target.value)}
                   min="1"
                   max="1440"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm disabled:bg-gray-100"
+                  className="ds-input w-full px-3 py-2 border border-line rounded-lg focus:ring-2 focus:ring-focus focus:border-brand text-sm disabled:bg-surface-muted"
                   disabled={authRequired}
                 />
               </div>
@@ -672,7 +667,7 @@ function MonitoredDomainDialog({
           <button
             type="button"
             onClick={onClose}
-            className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800"
+            className="px-3 py-1.5 text-sm text-text hover:text-text"
             disabled={saving || authRequired}
           >
             Cancel
@@ -680,7 +675,7 @@ function MonitoredDomainDialog({
           <button
             type="submit"
             disabled={saving || authRequired || (!editingDomain && !domainName.trim())}
-            className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+            className="ds-button ds-button--primary ds-button--sm"
           >
             {saving ? 'Saving...' : editingDomain ? 'Update' : 'Add Domain'}
           </button>

--- a/apps/web/app/components/PortfolioSearchPanel.tsx
+++ b/apps/web/app/components/PortfolioSearchPanel.tsx
@@ -148,28 +148,28 @@ export function PortfolioSearchPanel({
   };
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
-      <div className="border-b border-gray-200 px-4 py-3">
-        <h3 className="text-lg font-medium text-gray-900">Portfolio Search</h3>
-        <p className="text-sm text-gray-500">
+    <div className="ds-panel portfolio-panel">
+      <div className="border-b border-line px-4 py-3">
+        <h3 className="text-lg font-medium text-ink">Portfolio Search</h3>
+        <p className="text-sm text-muted">
           Search tenant domains by name, tag, severity, and zone-management state.
         </p>
       </div>
 
       <div className="space-y-4 p-4">
         {authRequired && (
-          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to search tenant domains and load saved filters.
           </div>
         )}
 
         {searchError && (
-          <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          <div className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
             {searchError}
             <button
               type="button"
               onClick={() => queryClient.invalidateQueries({ queryKey: ['portfolio-search'] })}
-              className="ml-2 text-red-600 hover:text-red-800"
+              className="ml-2 text-danger hover:text-danger"
             >
               Retry
             </button>
@@ -177,7 +177,7 @@ export function PortfolioSearchPanel({
         )}
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor={queryId}>
+          <label className="mb-1 block text-sm font-medium text-text" htmlFor={queryId}>
             Query
           </label>
           <input
@@ -187,12 +187,12 @@ export function PortfolioSearchPanel({
             onChange={(e) => updateFilters({ query: e.target.value })}
             disabled={authRequired}
             placeholder="example.com"
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+            className="ds-input w-full rounded-lg border border-line px-3 py-2 focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
           />
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor={tagsId}>
+          <label className="mb-1 block text-sm font-medium text-text" htmlFor={tagsId}>
             Tags
           </label>
           <div className="flex gap-2">
@@ -209,13 +209,13 @@ export function PortfolioSearchPanel({
               }}
               disabled={authRequired}
               placeholder="Add a tag"
-              className="flex-1 rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+              className="ds-input flex-1"
             />
             <button
               type="button"
               onClick={() => addTag(tagDraft)}
-              disabled={authRequired || tagDraft.trim().length === 0}
-              className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+              disabled={authRequired || !tagDraft.trim().length}
+              className="ds-button ds-button--primary ds-button--sm"
             >
               Add
             </button>
@@ -228,7 +228,7 @@ export function PortfolioSearchPanel({
                   type="button"
                   onClick={() => removeTag(tag)}
                   disabled={authRequired}
-                  className="rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800 disabled:opacity-60"
+                  className="rounded-full bg-info-surface px-3 py-1 text-sm text-brand disabled:opacity-60"
                 >
                   {tag} ×
                 </button>
@@ -243,7 +243,7 @@ export function PortfolioSearchPanel({
                   type="button"
                   onClick={() => addTag(tag)}
                   disabled={authRequired}
-                  className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-700 disabled:opacity-60"
+                  className="rounded bg-surface-muted px-2 py-1 text-xs text-text disabled:opacity-60"
                 >
                   {tag}
                 </button>
@@ -253,10 +253,10 @@ export function PortfolioSearchPanel({
         </div>
 
         <fieldset>
-          <legend className="mb-1 text-sm font-medium text-gray-700">Severity</legend>
+          <legend className="mb-1 text-sm font-medium text-text">Severity</legend>
           <div className="flex flex-wrap gap-3">
             {SEVERITIES.map((severity) => (
-              <label key={severity} className="flex items-center gap-2 text-sm text-gray-700">
+              <label key={severity} className="flex items-center gap-2 text-sm text-text">
                 <input
                   type="checkbox"
                   checked={normalizedFilters.severities.includes(severity)}
@@ -270,10 +270,10 @@ export function PortfolioSearchPanel({
         </fieldset>
 
         <fieldset>
-          <legend className="mb-1 text-sm font-medium text-gray-700">Zone Management</legend>
+          <legend className="mb-1 text-sm font-medium text-text">Zone Management</legend>
           <div className="flex flex-wrap gap-3">
             {ZONE_MANAGEMENT.map((zoneManagement) => (
-              <label key={zoneManagement} className="flex items-center gap-2 text-sm text-gray-700">
+              <label key={zoneManagement} className="flex items-center gap-2 text-sm text-text">
                 <input
                   type="checkbox"
                   checked={normalizedFilters.zoneManagement.includes(zoneManagement)}
@@ -291,17 +291,17 @@ export function PortfolioSearchPanel({
             type="button"
             onClick={clearFilters}
             disabled={authRequired}
-            className="text-sm text-gray-600 hover:text-gray-800 disabled:text-gray-400"
+            className="ds-button ds-button--quiet ds-button--sm"
           >
             Clear filters
           </button>
         </div>
 
-        <div className="border-t border-gray-200 pt-4">
+        <div className="border-t border-line pt-4">
           <div className="mb-3 flex items-center justify-between">
-            <h4 className="font-medium text-gray-900">Results</h4>
+            <h4 className="font-medium text-ink">Results</h4>
             {!isLoading && hasSearched && !authRequired && (
-              <span className="text-sm text-gray-500">
+              <span className="text-sm text-muted">
                 {results.length === 20
                   ? 'Showing first 20 matching domains. Refine filters to narrow results.'
                   : `Showing ${results.length} matching domain${results.length === 1 ? '' : 's'}`}
@@ -310,13 +310,13 @@ export function PortfolioSearchPanel({
           </div>
 
           {isLoading ? (
-            <div className="py-8 text-center text-gray-500">Searching portfolio...</div>
+            <div className="py-8 text-center text-muted">Searching portfolio...</div>
           ) : authRequired ? (
-            <div className="py-8 text-center text-gray-500">Sign in to search tenant domains.</div>
+            <div className="py-8 text-center text-muted">Sign in to search tenant domains.</div>
           ) : searchError ? (
-            <div className="py-8 text-center text-gray-500">Search is unavailable right now.</div>
+            <div className="py-8 text-center text-muted">Search is unavailable right now.</div>
           ) : results.length === 0 ? (
-            <div className="py-8 text-center text-gray-500">
+            <div className="py-8 text-center text-muted">
               No tenant domains matched the current filters.
             </div>
           ) : (
@@ -342,18 +342,18 @@ function SearchResultCard({ result }: { result: SearchResult }) {
   );
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+    <div className="rounded-lg border border-line bg-surface-muted p-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <Link
             to="/domain/$domain"
             params={{ domain: result.normalizedName }}
-            className="text-base font-medium text-blue-600 hover:text-blue-700"
+            className="text-base font-medium text-brand hover:text-brand"
           >
             {result.name}
           </Link>
-          <div className="mt-1 flex flex-wrap gap-2 text-xs text-gray-500">
-            <span className="rounded bg-white px-2 py-0.5 text-gray-700">
+          <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted">
+            <span className="rounded bg-surface px-2 py-0.5 text-text">
               {result.zoneManagement}
             </span>
             {result.latestSnapshot ? (
@@ -368,9 +368,9 @@ function SearchResultCard({ result }: { result: SearchResult }) {
         </div>
       </div>
 
-      <div className="mt-3 text-sm text-gray-600">
+      <div className="mt-3 text-sm text-text">
         {!result.findingsEvaluated ? (
-          <span>
+          <span className="ds-badge ds-badge--unknown">
             Needs setup/evidence. {result.evaluationCoverage.errors[0]?.unknown.explanation}{' '}
             <strong>
               {result.evaluationCoverage.errors[0]?.unknown.actionLabel ?? 'Run a fresh scan'}.
@@ -381,7 +381,7 @@ function SearchResultCard({ result }: { result: SearchResult }) {
         ) : (
           <div className="flex flex-wrap gap-2">
             {SEVERITIES.filter((severity) => counts[severity] > 0).map((severity) => (
-              <span key={severity} className="rounded bg-white px-2 py-0.5 text-xs text-gray-700">
+              <span key={severity} className="rounded bg-surface px-2 py-0.5 text-xs text-text">
                 {severity}: {counts[severity]}
               </span>
             ))}

--- a/apps/web/app/components/SavedFiltersPanel.tsx
+++ b/apps/web/app/components/SavedFiltersPanel.tsx
@@ -140,15 +140,15 @@ export function SavedFiltersPanel({
   };
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
-      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-        <h3 className="text-lg font-medium text-gray-900">Saved Filters</h3>
+    <div className="ds-panel portfolio-panel">
+      <div className="flex items-center justify-between border-b border-line px-4 py-3">
+        <h3 className="text-lg font-medium text-ink">Saved Filters</h3>
         {activeFilters && (
           <button
             type="button"
             onClick={() => setShowSaveDialog(true)}
             disabled={controlsDisabled}
-            className="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:text-gray-400"
+            className="text-sm font-medium text-brand hover:text-brand disabled:text-faint"
           >
             + Save Current
           </button>
@@ -157,18 +157,18 @@ export function SavedFiltersPanel({
 
       <div className="p-4">
         {authRequired && (
-          <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="mb-4 rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to view or manage saved filters.
           </div>
         )}
 
         {localError && (
-          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          <div className="mb-4 rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
             {localError}
             <button
               type="button"
               onClick={() => setLocalError(null)}
-              className="ml-2 text-red-600 hover:text-red-800"
+              className="ml-2 text-danger hover:text-danger"
             >
               Dismiss
             </button>
@@ -199,13 +199,11 @@ export function SavedFiltersPanel({
         )}
 
         {isLoading ? (
-          <div className="py-4 text-center text-gray-500">Loading saved filters...</div>
+          <div className="py-4 text-center text-muted">Loading saved filters...</div>
         ) : authRequired ? (
-          <div className="py-4 text-center text-gray-500">
-            Sign in to view tenant saved filters.
-          </div>
+          <div className="py-4 text-center text-muted">Sign in to view tenant saved filters.</div>
         ) : savedFilters.length === 0 ? (
-          <div className="py-4 text-center text-gray-500">
+          <div className="py-4 text-center text-muted">
             No saved filters yet.
             {activeFilters && (
               <>
@@ -213,7 +211,7 @@ export function SavedFiltersPanel({
                 <button
                   type="button"
                   onClick={() => setShowSaveDialog(true)}
-                  className="text-blue-600 hover:text-blue-700 disabled:text-gray-400"
+                  className="text-brand hover:text-brand disabled:text-faint"
                   disabled={controlsDisabled}
                 >
                   Save current filters
@@ -266,37 +264,27 @@ function SavedFilterCard({
   return (
     <div
       className={`rounded-lg border p-3 ${
-        isActive ? 'border-blue-500 bg-blue-50' : 'border-gray-200 bg-gray-50'
+        isActive ? 'border-brand bg-info-surface' : 'border-line bg-surface-muted'
       }`}
     >
       <div className="flex items-start justify-between">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <span className="truncate font-medium text-gray-900">{filter.name}</span>
-            {filter.isShared && (
-              <span className="rounded bg-green-100 px-1.5 py-0.5 text-xs text-green-700">
-                Shared
-              </span>
-            )}
-            {isActive && (
-              <span className="rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-700">
-                Active
-              </span>
-            )}
+            <span className="truncate font-medium text-ink">{filter.name}</span>
+            {filter.isShared && <span className="ds-badge ds-badge--success">Shared</span>}
+            {isActive && <span className="ds-badge ds-badge--info">Active</span>}
             {!compatibility.supported && (
-              <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-xs text-yellow-800">
-                Partial
-              </span>
+              <span className="ds-badge ds-badge--unknown">Partial</span>
             )}
           </div>
           {filter.description && (
-            <p className="mt-1 truncate text-sm text-gray-600">{filter.description}</p>
+            <p className="mt-1 truncate text-sm text-text">{filter.description}</p>
           )}
-          <div className="mt-1 text-xs text-gray-500">
+          <div className="mt-1 text-xs text-muted">
             {criteriaCount} filter{criteriaCount !== 1 ? 's' : ''} · owner {filter.createdBy}
           </div>
           {!compatibility.supported && (
-            <p className="mt-1 text-xs text-yellow-700">
+            <p className="mt-1 text-xs text-warning">
               Unsupported criteria: {compatibility.reasons.join(', ')}
             </p>
           )}
@@ -307,7 +295,7 @@ function SavedFilterCard({
             type="button"
             onClick={onLoad}
             disabled={!compatibility.supported}
-            className="rounded p-1.5 text-gray-500 hover:bg-blue-50 hover:text-blue-600 disabled:text-gray-300 disabled:hover:bg-transparent"
+            className="rounded p-1.5 text-muted hover:bg-info-surface hover:text-brand disabled:text-faint disabled:hover:bg-transparent"
             title={compatibility.supported ? 'Load filter' : 'Filter uses unsupported criteria'}
           >
             <svg
@@ -329,7 +317,7 @@ function SavedFilterCard({
             type="button"
             onClick={onEdit}
             disabled={!filter.canManage}
-            className="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700 disabled:text-gray-300 disabled:hover:bg-transparent"
+            className="rounded p-1.5 text-muted hover:bg-surface-muted hover:text-text disabled:text-faint disabled:hover:bg-transparent"
             title={filter.canManage ? 'Edit filter' : 'Only the creator can edit this filter'}
           >
             <svg
@@ -351,10 +339,10 @@ function SavedFilterCard({
             type="button"
             onClick={onToggleShare}
             disabled={!filter.canManage}
-            className={`rounded p-1.5 disabled:text-gray-300 disabled:hover:bg-transparent ${
+            className={`rounded p-1.5 disabled:text-faint disabled:hover:bg-transparent ${
               filter.isShared
-                ? 'text-green-600 hover:bg-green-50 hover:text-green-700'
-                : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
+                ? 'text-success hover:bg-success-surface hover:text-success'
+                : 'text-muted hover:bg-surface-muted hover:text-text'
             }`}
             title={
               filter.canManage
@@ -383,7 +371,7 @@ function SavedFilterCard({
             type="button"
             onClick={onDelete}
             disabled={!filter.canManage}
-            className="rounded p-1.5 text-gray-500 hover:bg-red-50 hover:text-red-600 disabled:text-gray-300 disabled:hover:bg-transparent"
+            className="rounded p-1.5 text-muted hover:bg-danger-surface hover:text-danger disabled:text-faint disabled:hover:bg-transparent"
             title={filter.canManage ? 'Delete filter' : 'Only the creator can delete this filter'}
           >
             <svg
@@ -492,29 +480,29 @@ function SaveFilterDialog({
   const criteriaPreview = editingFilter?.criteria || currentFiltersToSavedCriteria(currentFilters);
 
   return (
-    <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+    <div className="mb-4 rounded-lg border border-line bg-surface-muted p-4">
       <form onSubmit={handleSubmit}>
-        <h4 className="mb-3 font-medium text-gray-900">
+        <h4 className="mb-3 font-medium text-ink">
           {editingFilter ? 'Edit Filter Metadata' : 'Save Filter'}
         </h4>
 
         {editingFilter && (
-          <p className="mb-3 text-sm text-gray-600">
+          <p className="mb-3 text-sm text-text">
             Editing updates name, description, and sharing only. Stored filter criteria stay
             unchanged.
           </p>
         )}
 
         {error && (
-          <div className="mb-3 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-800">
+          <div className="mb-3 rounded border border-danger bg-danger-surface p-2 text-sm text-danger">
             {error}
           </div>
         )}
 
         <div className="space-y-3">
           <div>
-            <label htmlFor={nameId} className="mb-1 block text-sm font-medium text-gray-700">
-              Name <span className="text-red-500">*</span>
+            <label htmlFor={nameId} className="mb-1 block text-sm font-medium text-text">
+              Name <span className="text-danger">*</span>
             </label>
             <input
               type="text"
@@ -523,12 +511,12 @@ function SaveFilterDialog({
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g., Critical Issues"
               disabled={authRequired}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+              className="ds-input w-full rounded-lg border border-line px-3 py-2 focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
             />
           </div>
 
           <div>
-            <label htmlFor={descriptionId} className="mb-1 block text-sm font-medium text-gray-700">
+            <label htmlFor={descriptionId} className="mb-1 block text-sm font-medium text-text">
               Description
             </label>
             <input
@@ -538,7 +526,7 @@ function SaveFilterDialog({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Optional description..."
               disabled={authRequired}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+              className="ds-input w-full rounded-lg border border-line px-3 py-2 focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
             />
           </div>
 
@@ -549,15 +537,15 @@ function SaveFilterDialog({
               checked={isShared}
               onChange={(e) => setIsShared(e.target.checked)}
               disabled={authRequired}
-              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              className="h-4 w-4 rounded border-line text-brand focus:ring-focus"
             />
-            <label htmlFor={sharedId} className="text-sm text-gray-700">
+            <label htmlFor={sharedId} className="text-sm text-text">
               Share with team
             </label>
           </div>
 
-          <div className="rounded border border-gray-200 bg-white p-2">
-            <p className="mb-1 text-xs font-medium text-gray-500">Filter criteria:</p>
+          <div className="rounded border border-line bg-surface p-2">
+            <p className="mb-1 text-xs font-medium text-muted">Filter criteria:</p>
             <CriteriaPreview criteria={criteriaPreview} />
           </div>
         </div>
@@ -566,7 +554,7 @@ function SaveFilterDialog({
           <button
             type="button"
             onClick={onClose}
-            className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800"
+            className="px-3 py-1.5 text-sm text-text hover:text-text"
             disabled={saving || authRequired}
           >
             Cancel
@@ -574,7 +562,7 @@ function SaveFilterDialog({
           <button
             type="submit"
             disabled={saving || authRequired || !name.trim()}
-            className="rounded bg-blue-600 px-4 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            className="ds-button ds-button--primary ds-button--sm"
           >
             {saving ? 'Saving...' : editingFilter ? 'Update' : 'Save'}
           </button>
@@ -610,13 +598,13 @@ function CriteriaPreview({ criteria }: { criteria: FilterCriteria }) {
   }
 
   if (chips.length === 0) {
-    return <span className="text-xs text-gray-400">No filters selected</span>;
+    return <span className="text-xs text-faint">No filters selected</span>;
   }
 
   return (
     <div className="flex flex-wrap gap-1">
       {chips.map((chip) => (
-        <span key={chip} className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-700">
+        <span key={chip} className="rounded bg-surface-muted px-2 py-0.5 text-xs text-text">
           {chip}
         </span>
       ))}
@@ -630,10 +618,9 @@ function isFilterActive(currentFilters: CurrentFilters, filter: SavedFilter): bo
     return false;
   }
 
-  return (
-    JSON.stringify(normalizeCurrentFilters(currentFilters)) ===
-    JSON.stringify(savedCriteriaToCurrentFilters(filter.criteria))
-  );
+  const normalizedCurrent = JSON.stringify(normalizeCurrentFilters(currentFilters));
+  const normalizedSaved = JSON.stringify(savedCriteriaToCurrentFilters(filter.criteria));
+  return Object.is(normalizedCurrent, normalizedSaved);
 }
 
 function getCriteriaCount(criteria: FilterCriteria): number {

--- a/apps/web/app/components/SharedReportsPanel.tsx
+++ b/apps/web/app/components/SharedReportsPanel.tsx
@@ -123,31 +123,31 @@ export function SharedReportsPanel() {
   });
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200">
-      <div className="px-4 py-3 border-b border-gray-200">
-        <h3 className="text-lg font-medium text-gray-900">Shared Reports</h3>
-        <p className="text-sm text-gray-500">
+    <div className="ds-panel portfolio-panel">
+      <div className="px-4 py-3 border-b border-line">
+        <h3 className="text-lg font-medium text-ink">Shared Reports</h3>
+        <p className="text-sm text-muted">
           Create persisted, redacted reports for external stakeholders
         </p>
       </div>
 
       <div className="p-4 space-y-4">
         {localError && (
-          <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <div className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
             {localError}
           </div>
         )}
 
         {authRequired && (
-          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to list or create tenant shared reports. Public share links
             continue to work without sign-in.
           </div>
         )}
 
-        <div className="rounded-lg border border-gray-200 p-4 space-y-3">
+        <div className="rounded-lg border border-line p-4 space-y-3">
           <div>
-            <label htmlFor={reportTitleId} className="block text-sm font-medium text-gray-700">
+            <label htmlFor={reportTitleId} className="block text-sm font-medium text-text">
               Report title
             </label>
             <input
@@ -157,7 +157,7 @@ export function SharedReportsPanel() {
               onChange={(event) => setTitle(event.target.value)}
               placeholder="Weekly stakeholder report"
               disabled={authRequired}
-              className="focus-ring mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100 disabled:text-gray-500"
+              className="ds-input mt-1 block w-full rounded-md border-line disabled:bg-surface-muted disabled:text-muted"
             />
           </div>
 
@@ -165,20 +165,20 @@ export function SharedReportsPanel() {
             type="button"
             onClick={() => createMutation.mutate(title)}
             disabled={createMutation.isPending || authRequired}
-            className="focus-ring min-h-10 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:bg-gray-400"
+            className="ds-button ds-button--primary ds-button--md"
           >
             {createMutation.isPending ? 'Creating...' : 'Create Shared Report'}
           </button>
         </div>
 
         {isLoading ? (
-          <p className="text-sm text-gray-500">Loading reports...</p>
+          <p className="text-sm text-muted">Loading reports...</p>
         ) : authRequired ? (
-          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+          <div className="rounded-lg border border-line bg-surface-muted p-4 text-sm text-text">
             Sign in to list and create tenant shared reports.
           </div>
         ) : reports.length === 0 ? (
-          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+          <div className="rounded-lg border border-line bg-surface-muted p-4 text-sm text-text">
             No shared reports yet.
           </div>
         ) : (
@@ -188,18 +188,16 @@ export function SharedReportsPanel() {
                 ? `${origin}/api/alerts/reports/shared/${report.shareToken}`
                 : null;
               return (
-                <div key={report.id} className="rounded-lg border border-gray-200 p-4 space-y-2">
+                <div key={report.id} className="rounded-lg border border-line p-4 space-y-2">
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
-                      <h4 className="font-medium text-gray-900">{report.title}</h4>
-                      <p className="text-xs text-gray-500">
+                      <h4 className="font-medium text-ink">{report.title}</h4>
+                      <p className="text-xs text-muted">
                         {report.status} · {new Date(report.createdAt).toLocaleString()}
                       </p>
                     </div>
                     <div className="flex items-center gap-2">
-                      <span className="rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">
-                        {report.visibility}
-                      </span>
+                      <span className="ds-badge ds-badge--neutral">{report.visibility}</span>
                       {report.status !== 'expired' && !authRequired && (
                         <button
                           type="button"
@@ -207,7 +205,7 @@ export function SharedReportsPanel() {
                           disabled={
                             expireMutation.isPending && expireMutation.variables === report.id
                           }
-                          className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 disabled:text-gray-400"
+                          className="rounded border border-line px-2 py-1 text-xs text-text hover:bg-surface-muted disabled:text-faint"
                         >
                           {expireMutation.isPending && expireMutation.variables === report.id
                             ? 'Expiring...'
@@ -217,20 +215,17 @@ export function SharedReportsPanel() {
                     </div>
                   </div>
 
-                  <p className="text-sm text-gray-700">
+                  <p className="text-sm text-text">
                     {report.summary.activeAlerts} active alerts across{' '}
                     {report.summary.totalMonitored} monitored domains.
                   </p>
 
                   {shareUrl && (
                     <div>
-                      <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted">
                         Share link
                       </p>
-                      <a
-                        className="text-sm text-blue-600 break-all hover:text-blue-700"
-                        href={shareUrl}
-                      >
+                      <a className="text-sm text-brand break-all hover:text-brand" href={shareUrl}>
                         {shareUrl}
                       </a>
                     </div>

--- a/apps/web/app/components/TemplateOverridesPanel.tsx
+++ b/apps/web/app/components/TemplateOverridesPanel.tsx
@@ -103,14 +103,14 @@ export function TemplateOverridesPanel() {
   const writeControlsDisabled = authRequired || writeBlocked;
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
-      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-        <h3 className="text-lg font-medium text-gray-900">Template Overrides</h3>
+    <div className="ds-panel portfolio-panel">
+      <div className="flex items-center justify-between border-b border-line px-4 py-3">
+        <h3 className="text-lg font-medium text-ink">Template Overrides</h3>
         <button
           type="button"
           onClick={() => setShowCreateDialog(true)}
           disabled={writeControlsDisabled}
-          className="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:text-gray-400"
+          className="text-sm font-medium text-brand hover:text-brand disabled:text-faint"
         >
           + New Override
         </button>
@@ -118,23 +118,20 @@ export function TemplateOverridesPanel() {
 
       <div className="p-4">
         {authRequired && (
-          <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="mb-4 rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to view or edit tenant template overrides.
           </div>
         )}
 
         {writeBlocked && (
-          <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
+          <div className="mb-4 rounded-lg border border-brand bg-info-surface p-4 text-sm text-brand">
             You can view tenant overrides here, but your current role cannot create, edit, or delete
             them.
           </div>
         )}
 
         <div className="mb-4">
-          <label
-            htmlFor={providerSelectId}
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
+          <label htmlFor={providerSelectId} className="mb-1 block text-sm font-medium text-text">
             Select Provider
           </label>
           <select
@@ -142,7 +139,7 @@ export function TemplateOverridesPanel() {
             value={selectedProvider}
             onChange={(e) => setSelectedProvider(e.target.value)}
             disabled={readControlsDisabled}
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+            className="ds-input w-full rounded-lg border border-line px-3 py-2 focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
           >
             <option value="">Choose a provider...</option>
             {Object.entries(PROVIDER_LABELS).map(([key, label]) => (
@@ -154,12 +151,12 @@ export function TemplateOverridesPanel() {
         </div>
 
         {localError && (
-          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          <div className="mb-4 rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
             {localError}
             <button
               type="button"
               onClick={() => setLocalError(null)}
-              className="ml-2 text-red-600 hover:text-red-800"
+              className="ml-2 text-danger hover:text-danger"
             >
               Dismiss
             </button>
@@ -188,22 +185,22 @@ export function TemplateOverridesPanel() {
         )}
 
         {authRequired ? (
-          <div className="py-8 text-center text-gray-500">
+          <div className="py-8 text-center text-muted">
             Sign in to view and manage tenant template overrides.
           </div>
         ) : !selectedProvider ? (
-          <div className="py-8 text-center text-gray-500">
+          <div className="py-8 text-center text-muted">
             Select a provider to view and manage template overrides
           </div>
         ) : isLoading ? (
-          <div className="py-8 text-center text-gray-500">Loading overrides...</div>
+          <div className="py-8 text-center text-muted">Loading overrides...</div>
         ) : overrides.length === 0 ? (
-          <div className="py-8 text-center text-gray-500">
+          <div className="py-8 text-center text-muted">
             No overrides for {PROVIDER_LABELS[selectedProvider] || selectedProvider}.{' '}
             <button
               type="button"
               onClick={() => setShowCreateDialog(true)}
-              className="text-blue-600 hover:text-blue-700 disabled:text-gray-400"
+              className="text-brand hover:text-brand disabled:text-faint"
               disabled={writeControlsDisabled}
             >
               Create one
@@ -238,19 +235,19 @@ function OverrideCard({ override, disabled, onEdit, onDelete }: OverrideCardProp
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+    <div className="rounded-lg border border-line bg-surface-muted p-3">
       <div className="flex items-start justify-between">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <span className="font-mono text-sm text-gray-900">{override.templateKey}</span>
+            <span className="font-mono text-sm text-ink">{override.templateKey}</span>
             {override.appliesToDomains && override.appliesToDomains.length > 0 && (
-              <span className="rounded bg-purple-100 px-1.5 py-0.5 text-xs text-purple-700">
+              <span className="ds-badge ds-badge--info">
                 {override.appliesToDomains.length} domain
                 {override.appliesToDomains.length > 1 ? 's' : ''}
               </span>
             )}
           </div>
-          <p className="mt-1 text-xs text-gray-500">
+          <p className="mt-1 text-xs text-muted">
             Created by {override.createdBy} on {new Date(override.createdAt).toLocaleDateString()}
           </p>
         </div>
@@ -259,7 +256,7 @@ function OverrideCard({ override, disabled, onEdit, onDelete }: OverrideCardProp
           <button
             type="button"
             onClick={() => setExpanded(!expanded)}
-            className="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            className="rounded p-1.5 text-muted hover:bg-surface-muted hover:text-text"
             title={expanded ? 'Collapse' : 'Expand'}
           >
             <svg
@@ -281,7 +278,7 @@ function OverrideCard({ override, disabled, onEdit, onDelete }: OverrideCardProp
             type="button"
             onClick={onEdit}
             disabled={disabled}
-            className="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700 disabled:text-gray-400 disabled:hover:bg-transparent"
+            className="rounded p-1.5 text-muted hover:bg-surface-muted hover:text-text disabled:text-faint disabled:hover:bg-transparent"
             title="Edit"
           >
             <svg
@@ -303,7 +300,7 @@ function OverrideCard({ override, disabled, onEdit, onDelete }: OverrideCardProp
             type="button"
             onClick={onDelete}
             disabled={disabled}
-            className="rounded p-1.5 text-gray-500 hover:bg-red-50 hover:text-red-600 disabled:text-gray-400 disabled:hover:bg-transparent"
+            className="rounded p-1.5 text-muted hover:bg-danger-surface hover:text-danger disabled:text-faint disabled:hover:bg-transparent"
             title="Delete"
           >
             <svg
@@ -325,19 +322,19 @@ function OverrideCard({ override, disabled, onEdit, onDelete }: OverrideCardProp
       </div>
 
       {expanded && (
-        <div className="mt-3 border-t border-gray-200 pt-3">
-          <p className="mb-1 text-xs font-medium text-gray-500">Override Data:</p>
-          <pre className="overflow-x-auto rounded border border-gray-200 bg-white p-2 text-xs text-gray-700">
+        <div className="mt-3 border-t border-line pt-3">
+          <p className="mb-1 text-xs font-medium text-muted">Override Data:</p>
+          <pre className="overflow-x-auto rounded border border-line bg-surface p-2 text-xs text-text">
             {JSON.stringify(override.overrideData, null, 2)}
           </pre>
           {override.appliesToDomains && override.appliesToDomains.length > 0 && (
             <div className="mt-2">
-              <p className="mb-1 text-xs font-medium text-gray-500">Applies to:</p>
+              <p className="mb-1 text-xs font-medium text-muted">Applies to:</p>
               <div className="flex flex-wrap gap-1">
                 {override.appliesToDomains.map((domain) => (
                   <span
                     key={domain}
-                    className="rounded border border-gray-200 bg-white px-2 py-0.5 text-xs text-gray-600"
+                    className="rounded border border-line bg-surface px-2 py-0.5 text-xs text-text"
                   >
                     {domain}
                   </span>
@@ -452,14 +449,14 @@ function OverrideDialog({
   };
 
   return (
-    <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+    <div className="mb-4 rounded-lg border border-line bg-surface-muted p-4">
       <form onSubmit={handleSubmit}>
-        <h4 className="mb-3 font-medium text-gray-900">
+        <h4 className="mb-3 font-medium text-ink">
           {editingOverride ? 'Edit Override' : 'New Override'}
         </h4>
 
         {error && (
-          <div className="mb-3 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-800">
+          <div className="mb-3 rounded border border-danger bg-danger-surface p-2 text-sm text-danger">
             {error}
           </div>
         )}
@@ -467,14 +464,14 @@ function OverrideDialog({
         <div className="space-y-3">
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label htmlFor={providerId} className="mb-1 block text-sm font-medium text-gray-700">
-                Provider Key <span className="text-red-500">*</span>
+              <label htmlFor={providerId} className="mb-1 block text-sm font-medium text-text">
+                Provider Key <span className="text-danger">*</span>
               </label>
               <select
                 id={providerId}
                 value={providerKey}
                 onChange={(e) => setProviderKey(e.target.value)}
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+                className="ds-input w-full rounded-lg border border-line px-3 py-2 focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
                 disabled={!!editingOverride || controlsDisabled}
               >
                 <option value="">Select...</option>
@@ -487,8 +484,8 @@ function OverrideDialog({
             </div>
 
             <div>
-              <label htmlFor={templateId} className="mb-1 block text-sm font-medium text-gray-700">
-                Template Key <span className="text-red-500">*</span>
+              <label htmlFor={templateId} className="mb-1 block text-sm font-medium text-text">
+                Template Key <span className="text-danger">*</span>
               </label>
               <input
                 type="text"
@@ -496,15 +493,15 @@ function OverrideDialog({
                 value={templateKey}
                 onChange={(e) => setTemplateKey(e.target.value)}
                 placeholder="e.g., dkim_record"
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+                className="ds-input w-full rounded-lg border border-line px-3 py-2 focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
                 disabled={!!editingOverride || controlsDisabled}
               />
             </div>
           </div>
 
           <div>
-            <label htmlFor={dataId} className="mb-1 block text-sm font-medium text-gray-700">
-              Override Data (JSON) <span className="text-red-500">*</span>
+            <label htmlFor={dataId} className="mb-1 block text-sm font-medium text-text">
+              Override Data (JSON) <span className="text-danger">*</span>
             </label>
             <textarea
               id={dataId}
@@ -512,13 +509,13 @@ function OverrideDialog({
               onChange={(e) => setOverrideDataJson(e.target.value)}
               rows={5}
               disabled={controlsDisabled}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 font-mono text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+              className="ds-input w-full rounded-lg border border-line px-3 py-2 font-mono text-sm focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
               placeholder='{"key": "value"}'
             />
           </div>
 
           <div>
-            <label htmlFor={domainsId} className="mb-1 block text-sm font-medium text-gray-700">
+            <label htmlFor={domainsId} className="mb-1 block text-sm font-medium text-text">
               Applies to Domains (comma-separated, leave empty for all)
             </label>
             <input
@@ -527,7 +524,7 @@ function OverrideDialog({
               value={appliesToDomains}
               onChange={(e) => setAppliesToDomains(e.target.value)}
               placeholder="example.com, test.com"
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+              className="ds-input w-full rounded-lg border border-line px-3 py-2 focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
               disabled={controlsDisabled}
             />
           </div>
@@ -537,7 +534,7 @@ function OverrideDialog({
           <button
             type="button"
             onClick={onClose}
-            className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800"
+            className="px-3 py-1.5 text-sm text-text hover:text-text"
             disabled={saving || authRequired}
           >
             Cancel
@@ -545,7 +542,7 @@ function OverrideDialog({
           <button
             type="submit"
             disabled={saving || controlsDisabled || !providerKey.trim() || !templateKey.trim()}
-            className="rounded bg-blue-600 px-4 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            className="ds-button ds-button--primary ds-button--sm"
           >
             {saving ? 'Saving...' : editingOverride ? 'Update' : 'Create'}
           </button>

--- a/apps/web/app/routes/portfolio.tsx
+++ b/apps/web/app/routes/portfolio.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { AlertsPanel } from '../components/AlertsPanel.js';
 import { AuditLogPanel } from '../components/AuditLogPanel.js';
 import { AuthPending } from '../components/AuthPending.js';
@@ -21,30 +21,26 @@ export const Route = createFileRoute('/portfolio')({
 });
 
 function PortfolioWorkspace() {
+  const workspaceTitleId = useId();
   const [currentFilters, setCurrentFilters] = useState<CurrentFilters>(EMPTY_CURRENT_FILTERS);
 
   return (
-    <div className="mx-auto max-w-7xl space-y-6">
-      <div className="rounded-2xl border border-blue-200 bg-blue-50 p-8 shadow-sm">
-        <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">
-          Operator workspace
-        </p>
-        <h1 className="mt-2 text-3xl font-bold text-gray-900">Portfolio workflows</h1>
-        <p className="mt-4 text-gray-700">
-          This route now exposes the supported operator surface for monitoring, alert triage, fleet
-          reporting, saved filters, shared reports, and tenant governance workflows.
-        </p>
-        <div className="mt-6 flex flex-wrap gap-3">
-          <Link
-            to="/"
-            className="focus-ring inline-flex min-h-10 items-center rounded-lg bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
-          >
-            Return to Home
-          </Link>
+    <section className="portfolio-workspace" aria-labelledby={workspaceTitleId}>
+      <header className="ds-panel portfolio-workspace__header">
+        <div>
+          <p className="ds-kicker">Operator workspace</p>
+          <h1 id={workspaceTitleId}>Portfolio workflows</h1>
+          <p>
+            This route exposes the supported operator surface for monitoring, alert triage, fleet
+            reporting, saved filters, shared reports, and tenant governance workflows.
+          </p>
         </div>
-      </div>
+        <Link to="/" className="ds-button ds-button--secondary ds-button--md">
+          Return to Home
+        </Link>
+      </header>
 
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,2fr)_minmax(20rem,1fr)]">
+      <div className="portfolio-workspace__search-grid">
         <PortfolioSearchPanel currentFilters={currentFilters} onFiltersChange={setCurrentFilters} />
         <SavedFiltersPanel currentFilters={currentFilters} onLoadFilter={setCurrentFilters} />
       </div>
@@ -56,11 +52,11 @@ function PortfolioWorkspace() {
       <TemplateOverridesPanel />
       <AuditLogPanel />
 
-      <div className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
+      <aside className="ds-panel ds-panel--muted portfolio-workspace__notice">
         Mail diagnostics and remediation requests are available from the Domain 360 mail tab. Domain
-        notes and tags now live on the Domain 360 overview surface. Saved filters now drive the
-        portfolio search workspace directly.
-      </div>
-    </div>
+        notes and tags live on the Domain 360 overview surface. Saved filters drive the portfolio
+        search workspace directly.
+      </aside>
+    </section>
   );
 }

--- a/apps/web/app/styles/app.css
+++ b/apps/web/app/styles/app.css
@@ -1513,3 +1513,149 @@
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+@layer components {
+  .portfolio-workspace {
+    display: grid;
+    gap: var(--space-lg);
+    min-inline-size: 0;
+  }
+
+  .portfolio-workspace__header {
+    align-items: end;
+    display: grid;
+    gap: var(--space-lg);
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: clamp(var(--space-lg), 4vw, var(--space-xl));
+  }
+
+  .portfolio-workspace__header h1,
+  .portfolio-panel h3,
+  .portfolio-panel h4,
+  .portfolio-panel h5 {
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    letter-spacing: -0.03em;
+    line-height: var(--leading-tight);
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .portfolio-workspace__header h1 {
+    font-size: clamp(var(--text-2xl), 5vw, var(--text-3xl));
+    margin: var(--space-xs) 0 0;
+  }
+
+  .portfolio-workspace__header p:not(.ds-kicker) {
+    color: var(--color-muted);
+    line-height: var(--leading-normal);
+    margin: var(--space-sm) 0 0;
+    max-inline-size: 65ch;
+  }
+
+  .portfolio-workspace__search-grid {
+    display: grid;
+    gap: var(--space-lg);
+    grid-template-columns: minmax(0, 2fr) minmax(20rem, 1fr);
+  }
+
+  .portfolio-workspace__notice {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    padding: var(--space-lg);
+  }
+
+  .portfolio-panel {
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .portfolio-panel > :first-child {
+    padding: var(--space-md);
+  }
+
+  .portfolio-panel > :first-child:has(h3) h3 {
+    font-size: var(--text-lg);
+    margin: 0;
+  }
+
+  .portfolio-panel > :first-child:has(h3) p {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+    margin: var(--space-2xs) 0 0;
+  }
+
+  .portfolio-panel > :first-child:has(h3) + * {
+    border-block-start: var(--rule) solid var(--color-line);
+  }
+
+  .portfolio-panel input:not([type='checkbox']):not([type='file']),
+  .portfolio-panel select,
+  .portfolio-panel textarea {
+    background: var(--color-surface);
+    border-color: var(--color-line);
+    color: var(--color-ink);
+    font-family: var(--font-body);
+    min-inline-size: 0;
+  }
+
+  .portfolio-panel input[type='checkbox'] {
+    accent-color: var(--color-brand);
+  }
+
+  .portfolio-panel button,
+  .portfolio-panel a {
+    min-inline-size: 0;
+  }
+
+  .portfolio-panel button:focus-visible,
+  .portfolio-panel a:focus-visible,
+  .portfolio-panel input:focus-visible,
+  .portfolio-panel select:focus-visible,
+  .portfolio-panel textarea:focus-visible {
+    outline: 3px solid var(--color-focus);
+    outline-offset: 2px;
+  }
+
+  .portfolio-panel pre {
+    font-family: var(--font-mono);
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+}
+
+@media (max-width: 60rem) {
+  .portfolio-workspace__search-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 40rem) {
+  .portfolio-workspace__header {
+    align-items: start;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .portfolio-workspace__header .ds-button {
+    justify-self: start;
+  }
+
+  .portfolio-panel .grid-cols-2,
+  .portfolio-panel .sm\\:grid-cols-3,
+  .portfolio-panel .sm\\:grid-cols-4 {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .portfolio-panel .flex.items-start.justify-between,
+  .portfolio-panel .flex.items-center.justify-between {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+  }
+
+  .portfolio-panel .ml-4,
+  .portfolio-panel .ml-2 {
+    margin-inline-start: 0;
+  }
+}

--- a/apps/web/e2e/portfolio-signal-room.spec.ts
+++ b/apps/web/e2e/portfolio-signal-room.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from '@playwright/test';
+
+async function mockPortfolioWorkspace(page: import('@playwright/test').Page): Promise<void> {
+  await page.route('**/api/portfolio/tags', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ tags: ['priority'] }) })
+  );
+  await page.route('**/api/portfolio/search', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        domains: [
+          {
+            id: 'domain-1',
+            name: 'portfolio-signal.example.test',
+            normalizedName: 'portfolio-signal.example.test',
+            zoneManagement: 'managed',
+            findings: [],
+            findingsEvaluated: false,
+            evaluationCoverage: {
+              state: 'PARTIAL',
+              errors: [
+                {
+                  unknown: {
+                    explanation: 'The latest evaluation is incomplete.',
+                    actionLabel: 'Run a fresh scan',
+                  },
+                },
+              ],
+            },
+            latestSnapshot: null,
+          },
+        ],
+      }),
+    })
+  );
+  await page.route('**/api/portfolio/filters', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ filters: [] }) })
+  );
+  await page.route('**/api/monitoring/domains', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ monitoredDomains: [] }),
+    })
+  );
+  await page.route('**/api/portfolio/audit?*', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ events: [] }) })
+  );
+  await page.route('**/api/alerts**', async (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (pathname === '/api/alerts') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          alerts: [
+            {
+              id: 'alert-1',
+              monitoredDomainId: 'domain-1',
+              title: 'TLS evidence needs review',
+              description: 'The latest collector response needs operator review.',
+              severity: 'critical',
+              status: 'pending',
+              createdAt: '2026-08-08T12:00:00.000Z',
+            },
+          ],
+          pagination: { total: 1, offset: 0, hasMore: false },
+        }),
+      });
+      return;
+    }
+    if (pathname.endsWith('/resolve') || pathname.endsWith('/acknowledge')) {
+      await route.fulfill({ status: 204 });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ reports: [] }) });
+  });
+}
+
+test.describe('Portfolio Signal Room', () => {
+  test('uses semantic panels, inputs, and evidence tones while retaining operator actions', async ({
+    page,
+  }) => {
+    await mockPortfolioWorkspace(page);
+    await page.goto('/portfolio');
+
+    const workspace = page.locator('.portfolio-workspace');
+    await expect(workspace).toBeVisible();
+    await expect(workspace.locator('.portfolio-panel')).toHaveCount(8);
+    await expect(page.getByRole('heading', { name: 'Portfolio workflows' })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Portfolio Search' }).locator('xpath=../..')
+    ).toHaveClass(/ds-panel/);
+    await expect(page.getByPlaceholder('example.com').first()).toHaveClass(/ds-input/);
+    await expect(page.getByText('Needs setup/evidence.')).toHaveClass(/ds-badge--unknown/);
+    const alertsPanel = page
+      .locator('.portfolio-panel')
+      .filter({ has: page.getByRole('heading', { name: 'Alerts', exact: true }) });
+    await expect(alertsPanel.getByText('critical', { exact: true })).toHaveClass(
+      /ds-badge--danger/
+    );
+    await expect(alertsPanel.getByText('pending', { exact: true })).toHaveClass(/ds-badge--danger/);
+
+    await alertsPanel.getByRole('button', { name: 'Resolve', exact: true }).click();
+    await page
+      .getByPlaceholder('Describe how this alert was resolved')
+      .fill('Fresh evidence requested');
+    const request = page.waitForRequest(
+      (candidate) =>
+        candidate.url().endsWith('/api/alerts/alert-1/resolve') && candidate.method() === 'POST'
+    );
+    await page.getByRole('button', { name: 'Confirm Resolve' }).click();
+    await request;
+  });
+
+  test('keeps the complete workspace within the viewport at supported widths', async ({ page }) => {
+    await mockPortfolioWorkspace(page);
+    await page.goto('/portfolio');
+    await expect(page.locator('.portfolio-panel')).toHaveCount(8);
+
+    for (const width of [320, 375, 414, 768]) {
+      await page.setViewportSize({ width, height: 900 });
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () => document.documentElement.scrollWidth <= document.documentElement.clientWidth
+          )
+        )
+        .toBe(true);
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const controls = document.querySelectorAll(
+              '.portfolio-workspace > .ds-panel .ds-button, .portfolio-panel .ds-button'
+            );
+            return [...controls].every((control) => {
+              const range = document.createRange();
+              range.selectNodeContents(control);
+              return range.getClientRects().length <= 1;
+            });
+          })
+        )
+        .toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- migrate Portfolio workspace framing and all rendered operational panels to Signal Room panels, semantic tokens, inputs, badges, and actions
- preserve portfolio APIs, auth guard, routes, component ownership, and mutations
- add mocked browser coverage for semantic states, resolve mutation, and 320/375/414/768 px layouts

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test` (957 passed, 24 skipped)
- `bun run build`
- `bun run e2e` (71 passed, 1 skipped)
- `ubs --diff .` and `ubs --staged` (0 critical findings)

Closes #34

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Signal Room across the Portfolio workspace for consistent styling, semantic states, and responsive layouts. Improves accessibility and adds e2e coverage; no API or route changes. Closes #34.

- **Refactors**
  - Migrated Portfolio panels to `ds-panel` and semantic tokens (`ds-badge`, danger/warning/info/neutral/success, brand/muted/ink/line).
  - Unified headers and typography via new `portfolio-workspace` and `portfolio-panel` styles.
  - Kept existing APIs, auth guard, routes, and mutations intact.
  - Added `apps/web/e2e/portfolio-signal-room.spec.ts` using `@playwright/test` with mocked states, resolve mutation, and 320/375/414/768 px layouts.
  - Minor a11y: used `useId` in `portfolio.tsx` for proper heading labeling with `@tanstack/react-router`.

<sup>Written for commit a5505545e7ddfc564db475314ba3c612bef44c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

