### PR TITLE
feat(native-ci): add native-ci-gate/v1

### DIFF
--- a/infrastructure/native-ci-gate.toml
+++ b/infrastructure/native-ci-gate.toml
@@ -1,0 +1,21 @@
+schema = "native-ci-gate/v1"
+repository = "computindev/dns-ops"
+source_remote = "https://github.com/computindev/dns-ops.git"
+default_ref = "refs/heads/master"
+source_ref_required = true
+gate = "native-ci-gate/v1"
+gate_path = "scripts/ci-gate"
+
+[[jobs]]
+id = "shellcheck"
+required = true
+image = "ghcr.io/computindev/custom-buzz-ci/shellcheck"
+image_digest = "sha256:3390e53888f915ca7b956612c397a19f11146f30a57d02c56d51d9bdb08527d5"
+command = ["/workspace/scripts/ci-gate", "shellcheck"]
+
+[terminal]
+field = "type"
+value = "run.finish"
+conclusion_field = "conclusion"
+success_value = "success"
+failure_value = "failure"

--- a/scripts/ci-gate
+++ b/scripts/ci-gate
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Repository-owned Native CI gate. Offline: no package install, no network.
+set -euo pipefail
+case "${1:-}" in
+  shellcheck)
+    command -v shellcheck >/dev/null 2>&1 || { echo "FAIL: shellcheck missing" >&2; exit 74; }
+    shellcheck -S warning -- "$0"
+    ;;
+  *)
+    echo "usage: $0 shellcheck" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Closes #42

Minimal shellcheck gate on `master` using the CBC shellcheck image. No VPS, no webhook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal shellcheck gate on `master` via Native CI, using a pinned shellcheck image so the gate runs without a VPS or webhook. Closes #42.

- Requires the source ref to be `master` and runs the repository-owned `scripts/ci-gate` script, which only checks that `shellcheck` exists, so it needs no network or package installs.

<sup>Written for commit a1517b23b0b9b4eeece3abadbff544b6298c9543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

