### PR TITLE
docs: align README and runtime docs with Railway Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # DNS Ops Workbench
 
-DNS + mail operations platform with deterministic rules engine, DNS change simulation, and multi-tenant operator workflows.
+DNS + mail operations platform with deterministic rules engine, guidance-only DNS change simulation, and multi-tenant operator workflows.
 
 ## Architecture
 
-Split runtime:
+Split runtime. Railway Node is the configured web deployment target, not a currently linked live DNS Ops project.
 
-- **`apps/web`** — TanStack Start + Hono on Railway Node (UI + API). Vinxi preset `node-server` in `apps/web/app.config.ts`; deploy via `apps/web/railway.toml`.
+- **`apps/web`** — TanStack Start + Hono configured for Railway Node (UI + API). Vinxi preset `node-server` in `apps/web/app.config.ts`; deploy via `apps/web/railway.toml` after an authorized project/environment/service is identified.
 - **`apps/collector`** — Node.js + PostgreSQL + Redis for DNS collection, probes, and background jobs
 - **`packages/db`** — PostgreSQL/Drizzle schema + repositories
 - **`packages/rules`** — Deterministic rules engine (DNS + mail rules, simulation engine)
@@ -56,18 +56,19 @@ DNS change simulation UI is gated by `VITE_FEATURE_SIMULATION` (default `false`)
 
 ### DNS Change Simulation Engine
 
-Simulation is available as an API; the Domain 360 panel stays off unless `VITE_FEATURE_SIMULATION=true`.
+Simulation is a **guidance-only API**. It does not emit executable mutations or dry-run provider-aware record changes. `packages/rules/src/simulation/index.ts` returns `mode: 'GUIDANCE_ONLY'`, `detectedProvider: 'unknown'`, and `proposedChanges: []`.
 
-- `POST /api/simulate` — takes a snapshot or finding, generates concrete DNS record mutations, dry-runs them through the rules engine
-- `GET /api/simulate/actionable-types` — returns fixable finding types
-- Provider-aware fixes for Google Workspace, Microsoft 365, Amazon SES, SendGrid, Mailgun
-- Supports 8 finding types: SPF, DMARC, MX, MTA-STS, TLS-RPT, DKIM, SPF malformed, CNAME conflicts
-- Deterministic — no AI/LLM, reuses existing rules engine + provider templates
+The Domain 360 simulation panel stays off unless `VITE_FEATURE_SIMULATION=true`.
+
+- `POST /api/simulate` — returns non-executable guidance for supported finding types
+- `GET /api/simulate/actionable-types` — lists finding types that have guidance
+- Guidance covers SPF, DMARC, MX, MTA-STS, TLS-RPT, DKIM, SPF malformed, and CNAME conflicts
+- No executable mutations, provider-confirmed change sets, or dry-run record writes
 
 ### Backend
 
 - Authoritative datastore: **PostgreSQL only**
-- Web runtime: Railway Node (`node apps/web/.output/server/index.mjs`) + PostgreSQL
+- Web runtime: configured Railway Node target (`node apps/web/.output/server/index.mjs`) + PostgreSQL
 - Collector runtime: Node.js + PostgreSQL + Redis (queue-backed jobs)
 - Collector health: `/healthz` liveness (process-only), `/readyz` dependency-aware (DB/queues; 503 when not ready)
 - Web health: `GET /api/health` returns 503 if the DB is down
@@ -163,7 +164,7 @@ Live DNS fixture env vars:
 
 ## API routes
 
-`apps/web` applies `requireAuthMiddleware` to `/api/*` except `/api/health` and `/api/auth/*`. Snapshot, finding, and delegation reads are not public.
+`apps/web` applies `requireAuthMiddleware` to `/api/*` except `/api/health` and `/api/auth/*`. Snapshot, finding, delegation, and shared-report reads are not public.
 
 | Route group | Path prefix | Auth | Description |
 |---|---|---|---|
@@ -172,11 +173,11 @@ Live DNS fixture env vars:
 | Snapshots | `/api/snapshots` | Required | DNS snapshot CRUD, latest, diff |
 | Findings | `/api/findings` | Required | Rule evaluation, acknowledge, false-positive |
 | Selectors | `/api/selectors` | Required | Persisted DNS selectors |
-| Simulation | `/api/simulate` | Required | DNS change simulation + dry-run (UI flag off by default) |
+| Simulation | `/api/simulate` | Required | Guidance-only simulation; no executable mutations (UI flag off by default) |
 | Mail | `/api/mail` | Required | Mail diagnostics, remediation |
 | Monitoring | `/api/monitoring` | Required | Domain monitoring CRUD + toggle |
 | Alerts | `/api/alerts` | Required | Alert lifecycle (ack/resolve/suppress) |
-| Shared reports | `/api/alerts/reports/shared/:token` | Token | Unauthenticated token read of a shared report |
+| Shared reports | `/api/alerts/reports/shared/:token` | Required | Session-auth read of a shared report (token is not a public exemption) |
 | Portfolio | `/api/portfolio` | Required | Search, filters, tags, reports, overrides, audit |
 | Fleet reports | `/api/fleet-report` | Required | Collector proxy for fleet reports |
 | Shadow comparison | `/api/shadow` | Required | Provider shadow comparison (API only, no UI) |

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ DNS + mail operations platform with deterministic rules engine, DNS change simul
 
 Split runtime:
 
-- **`apps/web`** — TanStack Start + Hono on Cloudflare Workers (UI + API)
-- **`apps/collector`** — Node.js service for DNS collection, probes, and background jobs
+- **`apps/web`** — TanStack Start + Hono on Railway Node (UI + API). Vinxi preset `node-server` in `apps/web/app.config.ts`; deploy via `apps/web/railway.toml`.
+- **`apps/collector`** — Node.js + PostgreSQL + Redis for DNS collection, probes, and background jobs
 - **`packages/db`** — PostgreSQL/Drizzle schema + repositories
 - **`packages/rules`** — Deterministic rules engine (DNS + mail rules, simulation engine)
 - **`packages/contracts`** — Shared TypeScript types, DTOs, enums
@@ -20,7 +20,7 @@ Split runtime:
 ```text
 dns-ops/
 ├── apps/
-│   ├── web/              # Workers-based web app + API
+│   ├── web/              # Railway Node web app + API
 │   └── collector/        # Node.js DNS collection service
 ├── packages/
 │   ├── contracts/        # Shared types and DTOs
@@ -30,16 +30,18 @@ dns-ops/
 │   ├── logging/          # Structured logging
 │   └── testkit/          # Test fixtures
 ├── docs/
-└── beads/
+└── beads/                # Historical specs only
 ```
 
 ## Current product truth
 
 ### Domain 360 (`/domain/:domain`)
 
-- **Overview** — stat cards, query scope, notes, tags, DNS change simulation panel
+- **Overview** — stat cards, query scope, notes, tags
 - **DNS** — delegation evidence, snapshots, findings, selectors
 - **Mail** — mail findings (persisted), DKIM selectors with provider detection, preview badge, live diagnostics
+
+DNS change simulation UI is gated by `VITE_FEATURE_SIMULATION` (default `false`). The `/api/simulate` API may exist; it is not a default operator panel.
 
 ### Portfolio (`/portfolio`)
 
@@ -54,20 +56,21 @@ dns-ops/
 
 ### DNS Change Simulation Engine
 
-The simulation engine closes the operational loop: **finding detected → fix proposed → dry-run verified → operator sees impact before acting**.
+Simulation is available as an API; the Domain 360 panel stays off unless `VITE_FEATURE_SIMULATION=true`.
 
 - `POST /api/simulate` — takes a snapshot or finding, generates concrete DNS record mutations, dry-runs them through the rules engine
 - `GET /api/simulate/actionable-types` — returns fixable finding types
 - Provider-aware fixes for Google Workspace, Microsoft 365, Amazon SES, SendGrid, Mailgun
 - Supports 8 finding types: SPF, DMARC, MX, MTA-STS, TLS-RPT, DKIM, SPF malformed, CNAME conflicts
-- 100% deterministic — no AI/LLM, reuses existing rules engine + provider templates
+- Deterministic — no AI/LLM, reuses existing rules engine + provider templates
 
 ### Backend
 
 - Authoritative datastore: **PostgreSQL only**
-- Web runtime: Cloudflare Workers + PostgreSQL connection config
-- Collector runtime: Node.js + direct PostgreSQL + Redis (queue-backed jobs)
-- Collector public health: `/health`, `/healthz`, `/readyz`
+- Web runtime: Railway Node (`node apps/web/.output/server/index.mjs`) + PostgreSQL
+- Collector runtime: Node.js + PostgreSQL + Redis (queue-backed jobs)
+- Collector health: `/healthz` liveness (process-only), `/readyz` dependency-aware (DB/queues; 503 when not ready)
+- Web health: `GET /api/health` returns 503 if the DB is down
 - Collector `/api/*` requires service auth
 - All write paths tenant-scoped with actor attribution
 - Monitoring, alert, remediation, shared-report mutations emit persisted audit events
@@ -75,11 +78,14 @@ The simulation engine closes the operational loop: **finding detected → fix pr
 
 ### Test coverage
 
-- **2212 tests** (114 test files) — tenant isolation, auth, and integration tests comprehensive
-- **58 E2E tests** (5 spec files) — Domain 360 states, delegation, selectors, write flows, smoke
-- Well-covered: rules engine, auth, monitoring, alerts, portfolio, parsing
-- All write paths require auth with tenant isolation enforced at schema, repository, and route layers
-- Runtime route tests follow mock-DB + `app.request()` pattern
+Do not treat hardcoded counts as current truth. Run:
+
+```bash
+bun run test
+bun run --filter @dns-ops/web e2e
+```
+
+Default `bun run test` covers unit/integration plus harness and migration checks. E2E needs a running dev server (see Validation). Coverage emphasis: rules engine, auth, monitoring, alerts, portfolio, parsing. Write paths require auth with tenant isolation at schema, repository, and route layers. Runtime route tests follow mock-DB + `app.request()`.
 
 ## Setup
 
@@ -96,7 +102,7 @@ cp .env.example .env
 
 ## Database
 
-Schema ownership is the **release migration runner** (`scripts/run-migrations.mjs`), invoked automatically as the web service Railway `releaseCommand`. Request-path traffic never applies DDL. Destructive HTTP recovery routes (`POST /api/migrate/reset`, `POST /api/migrate/rebuild`) are unavailable (410) and direct operators back to this runner.
+Schema ownership is the **release migration runner** (`scripts/run-migrations.mjs`) only, invoked automatically as the web service Railway `releaseCommand`. Request-path traffic never applies DDL. Destructive HTTP recovery routes (`POST /api/migrate/reset`, `POST /api/migrate/rebuild`) return 410 and direct operators back to this runner.
 
 Local / disposable DB:
 
@@ -113,7 +119,7 @@ DATABASE_URL=postgres://... bun run migrate
 DATABASE_URL=postgres://... node scripts/run-migrations.mjs
 ```
 
-Do **not** use app HTTP endpoints to reset/rebuild schema in hope of request-time recovery — that path was removed in RT-4.
+Do **not** use app HTTP endpoints to reset/rebuild schema — that path was removed in RT-4.
 
 ## Run
 
@@ -157,34 +163,33 @@ Live DNS fixture env vars:
 
 ## API routes
 
+`apps/web` applies `requireAuthMiddleware` to `/api/*` except `/api/health` and `/api/auth/*`. Snapshot, finding, and delegation reads are not public.
+
 | Route group | Path prefix | Auth | Description |
 |---|---|---|---|
-| Snapshots | `/api/snapshots` | Tenant-scoped | DNS snapshot CRUD, latest, diff |
-| Findings | `/api/findings` | Tenant-scoped | Rule evaluation, acknowledge, false-positive |
-| Selectors | `/api/selectors` | Tenant-scoped | Persisted DNS selectors |
-| Simulation | `/api/simulate` | Tenant-scoped | DNS change simulation + dry-run |
-| Mail | `/api/mail` | Tenant-scoped | Mail diagnostics, remediation |
-| Monitoring | `/api/monitoring` | Tenant-scoped | Domain monitoring CRUD + toggle |
-| Alerts | `/api/alerts` | Tenant-scoped | Alert lifecycle (ack/resolve/suppress) |
-| Portfolio | `/api/portfolio` | Tenant-scoped | Search, filters, tags, reports, overrides, audit |
-| Fleet reports | `/api/fleet-report` | Tenant-scoped | Collector proxy for fleet reports |
-| Shadow comparison | `/api/shadow` | Tenant-scoped | Provider shadow comparison (API only, no UI) |
-| Legacy tools | `/api/legacy-tools` | Tenant-scoped | DMARC/DKIM deeplinks, shadow stats |
-| Delegation | `/api/delegation` | Public reads | NS delegation + DNSSEC evidence |
-| Domain reads | `/api/snapshots`, `/api/findings` | Public reads | Unscoped domain reads |
+| Health | `/api/health` | Public | Web readiness; 503 if DB down |
+| Auth | `/api/auth` | Public login | Session login/logout/me |
+| Snapshots | `/api/snapshots` | Required | DNS snapshot CRUD, latest, diff |
+| Findings | `/api/findings` | Required | Rule evaluation, acknowledge, false-positive |
+| Selectors | `/api/selectors` | Required | Persisted DNS selectors |
+| Simulation | `/api/simulate` | Required | DNS change simulation + dry-run (UI flag off by default) |
+| Mail | `/api/mail` | Required | Mail diagnostics, remediation |
+| Monitoring | `/api/monitoring` | Required | Domain monitoring CRUD + toggle |
+| Alerts | `/api/alerts` | Required | Alert lifecycle (ack/resolve/suppress) |
+| Shared reports | `/api/alerts/reports/shared/:token` | Token | Unauthenticated token read of a shared report |
+| Portfolio | `/api/portfolio` | Required | Search, filters, tags, reports, overrides, audit |
+| Fleet reports | `/api/fleet-report` | Required | Collector proxy for fleet reports |
+| Shadow comparison | `/api/shadow` | Required | Provider shadow comparison (API only, no UI) |
+| Legacy tools | `/api/legacy-tools` | Required | DMARC/DKIM deeplinks, shadow stats |
+| Delegation | `/api/delegation` | Required | NS delegation + DNSSEC evidence |
 
-## Beads
+## Tracking
 
-This repo uses `br` for issue tracking:
-
-```bash
-br sync --flush-only
-```
+Live work is tracked in **GitHub issues**. `beads/` is historical specs, not the live tracker.
 
 ## Key docs
 
-- `STATUS_REPORT.md` — current validation truth
 - `docs/architecture/runtime-topology.md`
+- `docs/guides/railway-deploy.md`
 - `docs/rules/query-scope.md`
 - `docs/rules/trust-boundary.md`
-- `packages/contracts/docs/API_REFERENCE.md`

--- a/beads/README.md
+++ b/beads/README.md
@@ -1,11 +1,5 @@
-# Bead Files — STALE
+# beads/ — historical specs
 
-These individual bead files reflect the **older v1 plan** and have not been regenerated
-from the authoritative `IMPLEMENTATION_BEADS.md` at the repo root.
+These files are **historical specifications**, not live tracking.
 
-**Do not use these files for planning or status assessment.**
-
-The authoritative bead definitions, dependency order, and scope are in:
-→ [`IMPLEMENTATION_BEADS.md`](../IMPLEMENTATION_BEADS.md)
-
-These files are retained for historical reference only.
+Live work is tracked in **GitHub issues**. Do not treat this directory (or `docs/plans/IMPLEMENTATION_BEADS.md`) as the tracker.

--- a/docs/architecture/runtime-topology.md
+++ b/docs/architecture/runtime-topology.md
@@ -1,6 +1,6 @@
 # Runtime Topology
 
-**Status:** Authoritative for current deploy shape
+**Status:** Authoritative for configured runtime shape
 
 ## Overview
 
@@ -33,7 +33,7 @@ This document defines the runtime topology for the DNS Ops Workbench: where prod
 
 | Property | Value |
 |----------|-------|
-| Runtime | Railway Node (`node-server`) |
+| Runtime | Configured Railway Node target (`node-server`) |
 | Framework | TanStack Start + Hono |
 | Database Access | Direct PostgreSQL (`DATABASE_URL`) |
 | Start | `node apps/web/.output/server/index.mjs` |
@@ -47,7 +47,7 @@ This document defines the runtime topology for the DNS Ops Workbench: where prod
 Railway Node (apps/web) → PostgreSQL
 ```
 
-Current deploy is Railway Node. Edge-worker bindings are not in use.
+Railway Node is the configured deployment target, not a currently linked live DNS Ops project. Edge-worker bindings are not in use.
 
 ### Collector (apps/collector)
 
@@ -215,5 +215,5 @@ This is a known limitation tracked as DNS-001.
 
 - [Query Scope](../rules/query-scope.md) - DNS query policies
 - [Trust Boundary](../rules/trust-boundary.md) - Probe policies
-- [Railway deploy](../guides/railway-deploy.md) - Current deploy shape
+- [Railway deploy](../guides/railway-deploy.md) - Configured Railway Node target; requires an authorized project/environment/service
 - [README](../../README.md) - Operator entrypoint

--- a/docs/architecture/runtime-topology.md
+++ b/docs/architecture/runtime-topology.md
@@ -1,12 +1,10 @@
 # Runtime Topology
 
-**Version:** 1.0
-**Effective Date:** 2026-03-20
-**Status:** Authoritative
+**Status:** Authoritative for current deploy shape
 
 ## Overview
 
-This document defines the authoritative runtime topology for the DNS Ops Workbench. It resolves all ambiguity about where product data lives and how different runtimes interact.
+This document defines the runtime topology for the DNS Ops Workbench: where product data lives and how the two Node services interact.
 
 ## Authoritative Data Store
 
@@ -27,7 +25,7 @@ This document defines the authoritative runtime topology for the DNS Ops Workben
 1. **Consistency**: Both web and collector need the same data
 2. **Transactions**: Complex writes require ACID guarantees
 3. **Schema**: Drizzle ORM works identically for both runtimes
-4. **Scalability**: Managed PostgreSQL (Neon/Supabase/RDS) handles our scale
+4. **Scalability**: Managed PostgreSQL handles our scale
 
 ## Runtime Contracts
 
@@ -35,30 +33,38 @@ This document defines the authoritative runtime topology for the DNS Ops Workben
 
 | Property | Value |
 |----------|-------|
-| Runtime | Cloudflare Workers |
+| Runtime | Railway Node (`node-server`) |
 | Framework | TanStack Start + Hono |
-| Database Access | Hyperdrive → PostgreSQL |
-| Primary Role | Read-heavy dashboard, API endpoints |
+| Database Access | Direct PostgreSQL (`DATABASE_URL`) |
+| Start | `node apps/web/.output/server/index.mjs` |
+| Health | `GET /api/health` — 503 if DB down |
+| Schema | `node scripts/run-migrations.mjs` as Railway `releaseCommand` only |
+| Primary Role | Dashboard + API |
 | Write Scope | Operator-triggered collection requests, portfolio management |
 
 **Connection Flow:**
 ```
-Cloudflare Worker → Hyperdrive (connection pooling) → PostgreSQL
+Railway Node (apps/web) → PostgreSQL
 ```
+
+Current deploy is Railway Node. Edge-worker bindings are not in use.
 
 ### Collector (apps/collector)
 
 | Property | Value |
 |----------|-------|
-| Runtime | Node.js (Docker container) |
+| Runtime | Node.js (Docker on Railway) |
 | Framework | Hono |
-| Database Access | Direct PostgreSQL connection |
+| Database Access | Direct PostgreSQL |
+| Queue | Redis (BullMQ) |
+| Health | `/healthz` liveness (process-only); `/readyz` dependency-aware (DB/queues, 503 when not ready) |
 | Primary Role | DNS collection, rules evaluation, probe execution |
 | Write Scope | Snapshots, observations, findings, suggestions |
 
 **Connection Flow:**
 ```
-Node.js Container → PostgreSQL (direct/pooled)
+Node.js Container → PostgreSQL
+Node.js Container → Redis (queue-backed jobs)
 ```
 
 ## Environment Matrix
@@ -69,129 +75,70 @@ Node.js Container → PostgreSQL (direct/pooled)
 |----------|-------|---------|
 | `DATABASE_URL` | `postgresql://user@localhost:5432/dns_ops` | Both |
 | `COLLECTOR_URL` | `http://localhost:3001` | Web |
+| `REDIS_URL` | `redis://localhost:6379` | Collector queues |
 | `NODE_ENV` | `development` | Both |
 
-### Staging
+### Staging / Production
 
 | Variable | Value | Used By |
 |----------|-------|---------|
-| `DATABASE_URL` | `postgresql://.../dns_ops_staging` | Collector |
-| `HYPERDRIVE_URL` | `hyperdrive://staging-id` | Web |
-| `COLLECTOR_URL` | `https://collector-staging.example.com` | Web |
-| `NODE_ENV` | `staging` | Both |
+| `DATABASE_URL` | Managed Postgres URL | Both |
+| `COLLECTOR_URL` | Collector public URL | Web |
+| `REDIS_URL` | Managed Redis URL | Collector queues |
+| `INTERNAL_SECRET` | Shared service secret | Both |
+| `NODE_ENV` | `staging` / `production` | Both |
 
-### Production
+## Railway Configuration
 
-| Variable | Value | Used By |
-|----------|-------|---------|
-| `DATABASE_URL` | `postgresql://.../dns_ops_prod` | Collector |
-| `HYPERDRIVE_URL` | `hyperdrive://prod-id` | Web |
-| `COLLECTOR_URL` | `https://collector.example.com` | Web |
-| `NODE_ENV` | `production` | Both |
+Web (`apps/web/railway.toml`): Dockerfile `apps/web/Dockerfile.railway`, `releaseCommand = node scripts/run-migrations.mjs`, `startCommand = node apps/web/.output/server/index.mjs`, `healthcheckPath = /api/health`.
 
-## Wrangler Configuration (Production)
+Collector (`apps/collector/railway.toml`): Dockerfile `apps/collector/Dockerfile.railway`, `healthcheckPath = /readyz`.
 
-```jsonc
-{
-  "name": "dns-ops-web",
-  "compatibility_date": "2024-01-01",
-  "compatibility_flags": ["nodejs_compat"],
-  "hyperdrive": [
-    {
-      "binding": "HYPERDRIVE",
-      "id": "your-hyperdrive-id-here"
-    }
-  ],
-  "vars": {
-    "ENVIRONMENT": "production",
-    "COLLECTOR_URL": "https://collector.example.com"
-  }
-}
-```
+HTTP `POST /api/migrate/reset` and `POST /api/migrate/rebuild` return 410.
 
-## D1 Status
+## Unused edge bindings
 
-**D1 is NOT used for product data.**
-
-D1 may be used for:
-- Edge caching (read-only replicas, if needed)
-- Session storage (non-critical)
-- Rate limiting state
-
-Any D1 usage must be explicitly documented and must not create data inconsistency with PostgreSQL.
+Product data is PostgreSQL only. There is no edge-worker config in this repo.
 
 ## Invariants
 
 1. **Single Source of Truth**: All product data reads and writes go to PostgreSQL
-2. **No Silent Drift**: If PostgreSQL is unavailable, operations fail explicitly
+2. **No Silent Drift**: If PostgreSQL is unavailable, operations fail explicitly (`/api/health` and collector `/readyz` return 503)
 3. **Consistent Schema**: Both runtimes use the same Drizzle schema from `@dns-ops/db`
-4. **Explicit Fallbacks**: No automatic fallback to D1 or other stores
+4. **No request-path DDL**: Schema changes go through `scripts/run-migrations.mjs` only
 
 ## Startup Validation
 
 Both web and collector must validate their configuration at startup:
 
 ```typescript
-// Pseudo-code for startup validation
 function validateConfig(config: RuntimeConfig): void {
-  if (!config.databaseUrl && !config.hyperdriveBinding) {
-    throw new Error('DATABASE_URL or Hyperdrive binding required');
+  if (!config.databaseUrl) {
+    throw new Error('DATABASE_URL required');
   }
 
   if (config.environment === 'production' && !config.collectorUrl) {
     throw new Error('COLLECTOR_URL required in production');
   }
-
-  // Test database connection
-  await testDatabaseConnection(config);
 }
 ```
-
-## Migration Path
-
-### Current State (Pre-Bead 02)
-
-- Web app has D1 binding in wrangler.jsonc
-- Collector uses PostgreSQL
-- Local dev uses PostgreSQL
-
-### Target State (Post-Bead 02)
-
-- Web app uses Hyperdrive → PostgreSQL
-- Collector uses PostgreSQL (unchanged)
-- Local dev uses PostgreSQL (unchanged)
-- D1 bindings removed from wrangler.jsonc
 
 ## Deployment Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                      Cloudflare Edge                            │
-│  ┌─────────────┐                                                │
-│  │  Workers    │──── Hyperdrive ────┐                          │
-│  │ (dns-ops-  │                     │                          │
-│  │    web)    │                     │                          │
-│  └─────────────┘                     │                          │
-└─────────────────────────────────────────────────────────────────┘
-                                       │
-                                       ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    PostgreSQL (Neon/Supabase/RDS)               │
-│                                                                 │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐           │
-│  │ domains  │ │snapshots │ │findings  │ │portfolios│           │
-│  └──────────┘ └──────────┘ └──────────┘ └──────────┘           │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-                                       ▲
-                                       │
-┌─────────────────────────────────────────────────────────────────┐
-│                    Container Runtime                            │
-│  ┌─────────────┐                                                │
-│  │  Collector  │──── Direct Connection ─────────────────────────┘
-│  │ (Node.js)  │                                                 │
-│  └─────────────┘                                                │
-└─────────────────────────────────────────────────────────────────┘
+│                    Railway                                      │
+│  ┌─────────────┐         ┌─────────────┐                        │
+│  │  Web        │         │  Collector  │                        │
+│  │  Node       │──SQL──┐ │  Node       │──SQL──┐                │
+│  │  (TanStack  │       │ │  + Redis    │       │                │
+│  │   Start)    │       │ └─────────────┘       │                │
+│  └─────────────┘       │                       │                │
+└────────────────────────┼───────────────────────┼────────────────┘
+                         ▼                       ▼
+              ┌─────────────────────────────────────────┐
+              │           PostgreSQL                    │
+              └─────────────────────────────────────────┘
 ```
 
 ## Collection Patterns
@@ -254,46 +201,6 @@ To enable true authoritative querying with AA flag detection:
 2. **Parse response flags directly**: Extract AA, AD, TC bits from response
 3. **Implement EDNS0 support**: Handle larger responses and DNSSEC
 
-```typescript
-// Future implementation sketch
-import * as dnsPacket from 'dns-packet';
-import * as dgram from 'node:dgram';
-
-function queryAuthoritative(
-  name: string,
-  type: string,
-  nameserver: string
-): Promise<DNSQueryResult> {
-  const socket = dgram.createSocket('udp4');
-  const query = dnsPacket.encode({
-    type: 'query',
-    id: Math.floor(Math.random() * 65535),
-    flags: dnsPacket.RECURSION_DESIRED,
-    questions: [{ name, type }],
-  });
-
-  return new Promise((resolve, reject) => {
-    socket.send(query, 53, nameserver, (err) => {
-      if (err) reject(err);
-    });
-
-    socket.once('message', (response) => {
-      const decoded = dnsPacket.decode(response);
-      resolve({
-        ...,
-        flags: {
-          aa: decoded.flags & dnsPacket.AUTHORITATIVE_ANSWER !== 0,
-          ad: decoded.flags & dnsPacket.AUTHENTIC_DATA !== 0,
-          // ... other flags
-        },
-      });
-    });
-  });
-}
-```
-
-### Impact on Delegation Detection
-
 Until true authoritative querying is implemented:
 
 - `DelegationCollector.detectLameDelegation()` only reports actual failures
@@ -308,4 +215,5 @@ This is a known limitation tracked as DNS-001.
 
 - [Query Scope](../rules/query-scope.md) - DNS query policies
 - [Trust Boundary](../rules/trust-boundary.md) - Probe policies
-- [REPO_STRUCTURE.md](../../REPO_STRUCTURE.md) - Monorepo layout
+- [Railway deploy](../guides/railway-deploy.md) - Current deploy shape
+- [README](../../README.md) - Operator entrypoint

--- a/docs/guides/railway-deploy.md
+++ b/docs/guides/railway-deploy.md
@@ -1,66 +1,70 @@
 # Railway Deployment Guide
 
-Deploy the DNS Ops collector + Postgres on Railway, web app on Cloudflare Pages.
+Deploy the DNS Ops web app, collector, Postgres, and Redis on Railway.
+
+Web is TanStack Start + Hono on Railway Node (`apps/web/app.config.ts` preset `node-server`, `apps/web/railway.toml`).
 
 ## Architecture
 
 ```
-User → Cloudflare Pages (apps/web)
+User → Railway (apps/web, Node)
             ↓ COLLECTOR_URL
-       Railway (apps/collector + Postgres)
+       Railway (apps/collector + Postgres + Redis)
 ```
 
 ## How Railway builds this repo
 
-Railway uses [Railpack](https://railpack.com) to auto-detect the monorepo:
-- Detects `bun.lock` → uses Bun as package manager
-- Reads `railway.toml` for build/start commands
-- Falls back to `railpack.json` if using Railpack directly
-- Handles workspace resolution automatically
+Each service uses its own Dockerfile:
 
-Both config files are provided. Railway uses whichever it detects first.
+- Web: `apps/web/Dockerfile.railway` + `apps/web/railway.toml`
+- Collector: `apps/collector/Dockerfile.railway` + `apps/collector/railway.toml`
 
 ## 1. Create Railway Project
 
 1. Go to [railway.app](https://railway.app) → New Project
 2. Choose "Deploy from GitHub repo" → select `dns-ops`
-3. Railway reads `railway.toml` and configures the build automatically
+3. Add **two** services from the same repo (web and collector), each with its Dockerfile path above
 
-## 2. Add Postgres
+## 2. Add Postgres and Redis
 
 1. In the Railway project dashboard → "New" → "Database" → "PostgreSQL"
-2. Railway creates the DB and exposes `DATABASE_URL` as a variable
-3. Link it to the collector service: Variables → Add Reference → `${{Postgres.DATABASE_URL}}`
+2. Link `DATABASE_URL` to both web and collector: Variables → Add Reference → `${{Postgres.DATABASE_URL}}`
+3. Add Redis and link `REDIS_URL` to the collector
 
 ## 3. Set Environment Variables
 
-In the collector service settings → Variables:
+Collector:
 
 | Variable | Value | Required |
 |----------|-------|----------|
-| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | ✅ Auto from Postgres plugin |
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | ✅ |
+| `REDIS_URL` | `${{Redis.REDIS_URL}}` | ✅ for queue-backed jobs |
 | `NODE_ENV` | `production` | ✅ |
-| `PORT` | `3001` | ✅ (Railway maps to public URL) |
+| `PORT` | `3001` | ✅ |
 | `INTERNAL_SECRET` | Generate: `openssl rand -hex 16` | ✅ |
-| `REDIS_URL` | (skip — optional) | ❌ |
 | `ENABLE_ACTIVE_PROBES` | `false` | Default |
+
+Web:
+
+| Variable | Value | Required |
+|----------|-------|----------|
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | ✅ |
+| `COLLECTOR_URL` | Collector public URL | ✅ |
+| `INTERNAL_SECRET` | Same value as collector | ✅ |
+| `NODE_ENV` | `production` | ✅ |
+| `BETTER_AUTH_SECRET` | `openssl rand -hex 16` | ✅ |
+| `WEB_DOMAIN` | Public web origin | ✅ |
 
 ## 4. Deploy
 
-Railway auto-deploys on push to master. The build:
+Railway auto-deploys on push to master.
 
-```
-bun install --frozen-lockfile
-bun run build --filter=@dns-ops/collector...
-```
-
-This installs all workspace deps and builds the collector + its package dependencies (contracts, db, logging, parsing, rules) via turbo.
-
-Start: `node apps/collector/dist/index.js`
+Web start: `node apps/web/.output/server/index.mjs`  
+Collector start: `node apps/collector/dist/index.js` (image `CMD`; `apps/collector/railway.toml` also sets a start command)
 
 ## 5. DB Schema (release runner)
 
-The web service `releaseCommand` runs `node scripts/run-migrations.mjs` on every deploy. That runner is the **sole automatic schema writer** (`_migrations_applied` ledger). App request routes do not migrate, and `POST /api/migrate/reset` / `POST /api/migrate/rebuild` return 410 directing operators here.
+The web service `releaseCommand` runs `node scripts/run-migrations.mjs` on every deploy. That runner is the **sole automatic schema writer**. App request routes do not migrate, and `POST /api/migrate/reset` / `POST /api/migrate/rebuild` return 410 directing operators here.
 
 After first deploy, schema should already be applied by release. To run the same runner out-of-band against a disposable/target DB:
 
@@ -74,58 +78,22 @@ DATABASE_URL="postgresql://..." node scripts/run-migrations.mjs
 
 Prefer forward SQL migrations under `packages/db/src/migrations` over `drizzle-kit push` for environments that must match production deploy semantics.
 
-## 6. Deploy Web App (Cloudflare Pages)
+## 6. Verify
 
 ```bash
-cd apps/web
-bun run build
-wrangler pages deploy dist
-```
-
-Set secrets in Cloudflare:
-
-```bash
-wrangler pages secret put COLLECTOR_URL    # → Railway collector public URL
-wrangler pages secret put INTERNAL_SECRET  # → same value as Railway
-wrangler pages secret put DATABASE_URL     # → Railway Postgres URL (or use Hyperdrive)
-```
-
-### Optional: Hyperdrive (recommended for production)
-
-Cloudflare Hyperdrive pools connections to Postgres:
-
-```bash
-npx wrangler hyperdrive create dns-ops-db \
-  --connection-string="postgresql://..."
-```
-
-Update `wrangler.jsonc` with the Hyperdrive binding ID. The app reads `HYPERDRIVE_URL` over `DATABASE_URL` automatically.
-
-## 7. Verify
-
-```bash
-WEB_URL=https://your-app.pages.dev \
+WEB_URL=https://your-web.up.railway.app \
 COLLECTOR_URL=https://your-collector.up.railway.app \
 bun run smoke-test
 ```
 
 Expected:
+
 ```
-✅ Web Health Check
+✅ Web Health Check          # GET /api/health — 503 if DB down
 ✅ Web Homepage
-✅ Collector /health
-✅ Collector /healthz
-✅ Collector /readyz
+✅ Collector /healthz        # liveness
+✅ Collector /readyz         # dependency-aware
 ```
-
-## Costs
-
-| Service | Plan | Monthly |
-|---------|------|---------|
-| Cloudflare Pages | Free | $0 |
-| Railway Hobby | $5 credit | ~$5 |
-| Railway Postgres | Included | $0 |
-| **Total** | | **~$5/mo** |
 
 ## Troubleshooting
 
@@ -135,6 +103,6 @@ Expected:
 
 **Schema not applied** — Confirm the web service release command ran `node scripts/run-migrations.mjs` successfully, or run it out-of-band with the target `DATABASE_URL`. Do not use `/api/migrate/reset` or `/rebuild` (they are unavailable).
 
-**Health check failing** — `/healthz` = liveness (process alive). `/readyz` = readiness (DB connected, may 503 if DB unreachable).
+**Health check failing** — Collector `/healthz` = liveness (process alive). Collector `/readyz` = readiness (DB/queues; 503 if dependencies are down). Web `/api/health` = 503 if DB is down.
 
-**Build fails** — Railway needs Node ≥20. The repo specifies `"engines": { "node": ">=20" }`. Railpack auto-selects Node 22.
+**Build fails** — Railway needs Node ≥20. The repo specifies `"engines": { "node": ">=20" }`.

--- a/docs/guides/railway-deploy.md
+++ b/docs/guides/railway-deploy.md
@@ -1,8 +1,10 @@
 # Railway Deployment Guide
 
-Deploy the DNS Ops web app, collector, Postgres, and Redis on Railway.
+Railway Node is the **configured deployment target** for the DNS Ops web app, collector, Postgres, and Redis. It is not a currently linked live DNS Ops deploy.
 
-Web is TanStack Start + Hono on Railway Node (`apps/web/app.config.ts` preset `node-server`, `apps/web/railway.toml`).
+Do not run deploy or migration commands until an authorized Railway project, environment, and service are identified. Never use `dnsops-live-fixtures` as the app target.
+
+Web is TanStack Start + Hono configured for Railway Node (`apps/web/app.config.ts` preset `node-server`, `apps/web/railway.toml`).
 
 ## Architecture
 
@@ -42,6 +44,7 @@ Collector:
 | `NODE_ENV` | `production` | ✅ |
 | `PORT` | `3001` | ✅ |
 | `INTERNAL_SECRET` | Generate: `openssl rand -hex 16` | ✅ |
+| `WORKER_ENABLED` | `true` | ✅ starts workers/schedules |
 | `ENABLE_ACTIVE_PROBES` | `false` | Default |
 
 Web:
@@ -52,12 +55,10 @@ Web:
 | `COLLECTOR_URL` | Collector public URL | ✅ |
 | `INTERNAL_SECRET` | Same value as collector | ✅ |
 | `NODE_ENV` | `production` | ✅ |
-| `BETTER_AUTH_SECRET` | `openssl rand -hex 16` | ✅ |
-| `WEB_DOMAIN` | Public web origin | ✅ |
 
 ## 4. Deploy
 
-Railway auto-deploys on push to master.
+Only after an authorized project, environment, and service are linked. Railway can auto-deploy on push to master for that authorized target.
 
 Web start: `node apps/web/.output/server/index.mjs`  
 Collector start: `node apps/collector/dist/index.js` (image `CMD`; `apps/collector/railway.toml` also sets a start command)
@@ -66,13 +67,13 @@ Collector start: `node apps/collector/dist/index.js` (image `CMD`; `apps/collect
 
 The web service `releaseCommand` runs `node scripts/run-migrations.mjs` on every deploy. That runner is the **sole automatic schema writer**. App request routes do not migrate, and `POST /api/migrate/reset` / `POST /api/migrate/rebuild` return 410 directing operators here.
 
-After first deploy, schema should already be applied by release. To run the same runner out-of-band against a disposable/target DB:
+After first deploy, schema should already be applied by release. To run the same runner out-of-band, first confirm the authorized Railway project, environment, and service. Never point this at `dnsops-live-fixtures`.
 
 ```bash
-# Using Railway CLI (web service context)
+# Using Railway CLI (authorized web service context only)
 railway run node scripts/run-migrations.mjs
 
-# Or locally with the target DATABASE_URL
+# Or locally with the authorized target DATABASE_URL
 DATABASE_URL="postgresql://..." node scripts/run-migrations.mjs
 ```
 

--- a/packages/contracts/docs/API_REFERENCE.md
+++ b/packages/contracts/docs/API_REFERENCE.md
@@ -1,15 +1,15 @@
 # DNS Ops API Reference
 
 > **Source of Truth**: This document is derived from the actual route definitions in the codebase.
-> Last updated: 2026-03-22
+> Last updated: 2026-08-30
 
 ## Overview
 
 DNS Ops consists of two services:
-- **Web App** (`apps/web`): TanStack Start + Hono on Railway Node; UI and primary API at port 3000
+- **Web App** (`apps/web`): TanStack Start + Hono configured for Railway Node; UI and primary API at port 3000
 - **Collector** (`apps/collector`): Node.js + PostgreSQL + Redis; DNS/mail collection at port 3001
 
-`apps/web` applies `requireAuthMiddleware` to `/api/*` except `/api/health` and `/api/auth/*`. Snapshot, finding, and delegation reads are not public.
+`apps/web` applies `requireAuthMiddleware` to `/api/*` except `/api/health` and `/api/auth/*`. Snapshot, finding, delegation, and shared-report reads are not public. There is no token-only exemption for `/alerts/reports/shared/:token`.
 
 ---
 
@@ -89,7 +89,7 @@ Base URL: `http://localhost:3000/api`
 | GET | `/alerts/reports` | Yes | List shared reports |
 | POST | `/alerts/reports` | Yes | Create shared report |
 | POST | `/alerts/reports/:id/expire` | Yes | Expire shared report |
-| GET | `/alerts/reports/shared/:token` | No | Read public shared report |
+| GET | `/alerts/reports/shared/:token` | Yes | Read shared report (session auth required; token is not a public exemption) |
 
 ### Mail & Remediation
 

--- a/packages/contracts/docs/API_REFERENCE.md
+++ b/packages/contracts/docs/API_REFERENCE.md
@@ -6,10 +6,10 @@
 ## Overview
 
 DNS Ops consists of two services:
-- **Web App** (`apps/web`): UI and primary API at port 3000
-- **Collector** (`apps/collector`): DNS/mail collection service at port 4000
+- **Web App** (`apps/web`): TanStack Start + Hono on Railway Node; UI and primary API at port 3000
+- **Collector** (`apps/collector`): Node.js + PostgreSQL + Redis; DNS/mail collection at port 3001
 
-Both services require authentication for most endpoints.
+`apps/web` applies `requireAuthMiddleware` to `/api/*` except `/api/health` and `/api/auth/*`. Snapshot, finding, and delegation reads are not public.
 
 ---
 
@@ -21,37 +21,37 @@ Base URL: `http://localhost:3000/api`
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/health` | No | Service health check |
+| GET | `/health` | No | Service health check; 503 if DB down |
 
 ### Domain Operations
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/domain/:domain/latest` | No | Get latest snapshot for a domain |
+| GET | `/domain/:domain/latest` | Yes | Get latest snapshot for a domain |
 | POST | `/collect/domain` | Yes | Trigger DNS collection for a domain |
 
 ### Snapshot Data
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/snapshot/:snapshotId/observations` | No | Get raw DNS observations |
-| GET | `/snapshot/:snapshotId/recordsets` | No | Get aggregated record sets |
-| GET | `/snapshot/:snapshotId/delegation` | No | Get delegation data |
-| GET | `/snapshot/:snapshotId/delegation/issues` | No | Get delegation issues |
-| GET | `/snapshot/:snapshotId/findings` | No | Get findings for a snapshot |
-| GET | `/snapshot/:snapshotId/findings/mail` | No | Get mail-specific findings |
-| GET | `/snapshot/:snapshotId/selectors` | No | Get discovered DKIM selectors |
-| GET | `/snapshot/:snapshotId/mail/check` | No | Get mail check results |
-| GET | `/domain/:domain/delegation/latest` | No | Get latest delegation for domain |
+| GET | `/snapshot/:snapshotId/observations` | Yes | Get raw DNS observations |
+| GET | `/snapshot/:snapshotId/recordsets` | Yes | Get aggregated record sets |
+| GET | `/snapshot/:snapshotId/delegation` | Yes | Get delegation data |
+| GET | `/snapshot/:snapshotId/delegation/issues` | Yes | Get delegation issues |
+| GET | `/snapshot/:snapshotId/findings` | Yes | Get findings for a snapshot |
+| GET | `/snapshot/:snapshotId/findings/mail` | Yes | Get mail-specific findings |
+| GET | `/snapshot/:snapshotId/selectors` | Yes | Get discovered DKIM selectors |
+| GET | `/snapshot/:snapshotId/mail/check` | Yes | Get mail check results |
+| GET | `/domain/:domain/delegation/latest` | Yes | Get latest delegation for domain |
 
 ### Snapshots Management (`/snapshots`)
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/snapshots` | No | List all snapshots (paginated) |
-| GET | `/snapshots/:id` | No | Get snapshot by ID |
-| GET | `/snapshots/domain/:domain` | No | Get snapshots for a domain |
-| GET | `/snapshots/:id1/diff/:id2` | No | Compare two snapshots |
+| GET | `/snapshots` | Yes | List all snapshots (paginated) |
+| GET | `/snapshots/:id` | Yes | Get snapshot by ID |
+| GET | `/snapshots/domain/:domain` | Yes | Get snapshots for a domain |
+| GET | `/snapshots/:id1/diff/:id2` | Yes | Compare two snapshots |
 
 ### Portfolio APIs (`/portfolio`)
 
@@ -107,16 +107,16 @@ Base URL: `http://localhost:3000/api`
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/findings/:snapshotId` | No | Get findings (alias) |
-| GET | `/findings/:snapshotId/summary` | No | Get findings summary |
+| GET | `/findings/:snapshotId` | Yes | Get findings (alias) |
+| GET | `/findings/:snapshotId/summary` | Yes | Get findings summary |
 
 ### Ruleset Versions (`/ruleset-versions`)
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/ruleset-versions` | No | List ruleset versions |
-| GET | `/ruleset-versions/current` | No | Get current ruleset version |
-| GET | `/ruleset-versions/:id` | No | Get specific version |
+| GET | `/ruleset-versions` | Yes | List ruleset versions |
+| GET | `/ruleset-versions/current` | Yes | Get current ruleset version |
+| GET | `/ruleset-versions/:id` | Yes | Get specific version |
 
 ### Shadow Comparison (`/shadow-comparison`)
 
@@ -130,15 +130,15 @@ Base URL: `http://localhost:3000/api`
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/mail/templates` | No | List provider templates |
-| GET | `/mail/templates/:provider` | No | Get template for provider |
+| GET | `/mail/templates` | Yes | List provider templates |
+| GET | `/mail/templates/:provider` | Yes | Get template for provider |
 
 ### Legacy Tools
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | POST | `/legacy/log` | Yes | Log legacy tool usage |
-| GET | `/legacy/config` | No | Get legacy config |
+| GET | `/legacy/config` | Yes | Get legacy config |
 | GET | `/legacy/dmarc/deeplink` | Yes | Generate DMARC deeplink |
 | GET | `/legacy/dkim/deeplink` | Yes | Generate DKIM deeplink |
 | POST | `/legacy/bulk-deeplinks` | Yes | Generate bulk deeplinks |


### PR DESCRIPTION
Closes #46

Docs truth-sync from origin/master `c311e0a`. Isolated worktree. Does not reopen #4.

## Changes
- README/runtime docs: Railway Node, not Cloudflare Workers
- GitHub issues as live tracker; `beads/` historical
- API reads require auth (shared reports included)
- Simulation documented as GUIDANCE_ONLY
- Railway deploy guide: authorized project required; never `dnsops-live-fixtures`; `WORKER_ENABLED=true`

## Validation
- Independent Terra review on `28182ba`: ACCEPT, no findings
- README greps for Workers/wrangler/Hyperdrive/STATUS_REPORT/2212/`br ` fail (absent)

Head: `28182ba839e5666636e14708fb1a63a4e59f1e10`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the README and runtime docs with the current Railway Node deployment, stricter API auth, and guidance-only simulation so operators follow correct instructions. Docs-only change; no runtime behavior changes.

- Replaces Cloudflare Workers/wrangler/Hyperdrive references with the configured Railway Node target and release migration runner.
- Documents that all `/api/*` reads require session auth except `/api/health` and `/api/auth/*`; shared-report tokens are not a public exemption.
- Documents simulation as guidance-only (`mode: 'GUIDANCE_ONLY'`, no executable mutations) and gated by `VITE_FEATURE_SIMULATION`, off by default.
- Marks `beads/` as historical specs; GitHub issues are the live tracker.
- Railway deploy guide now requires an authorized project, forbids `dnsops-live-fixtures` as a target, and adds collector `WORKER_ENABLED=true`.

Closes #46.

<sup>Written for commit 28182ba839e5666636e14708fb1a63a4e59f1e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

