### PR TITLE
feat(health): publish git revision and bind Railway GitHub source

### DIFF
--- a/.agents/skills/verify-dns-ops/features/health.public.md
+++ b/.agents/skills/verify-dns-ops/features/health.public.md
@@ -5,6 +5,7 @@ profile: changed
 paths:
   - apps/web/hono/routes/api.ts
   - apps/collector/src/index.ts
+  - .railway/railway.ts
 always_with: []
 ---
 # Public health

--- a/.agents/skills/verify-dns-ops/features/health.public.md
+++ b/.agents/skills/verify-dns-ops/features/health.public.md
@@ -13,7 +13,7 @@ Operators and Railway need an unauthenticated answer that the web process can ta
 
 ## Sub-features
 
-- Web `GET /api/health` — 200 `{"status":"healthy","service":"dns-ops-web"}` when the DB ping succeeds; 503 `{"status":"degraded"}` when it does not.
+- Web `GET /api/health` — 200 `{"status":"healthy","service":"dns-ops-web"}` when the DB ping succeeds; 503 `{"status":"degraded"}` when it does not. Optional `revision` is `GIT_SHA` or `RAILWAY_GIT_COMMIT_SHA` when set.
 - Collector `GET /healthz` — liveness, process only.
 - Collector `GET /readyz` — dependency-aware; 503 when DB/queues are not ready.
 
@@ -41,6 +41,7 @@ await call('web-health', 'GET', '/api/health');
 
 ### Read-back
 - A second GET to the same path returns the same `status` class (healthy vs degraded) without auth headers.
+- When `GIT_SHA` or `RAILWAY_GIT_COMMIT_SHA` is set, `revision` equals that value on web and collector. A passed receipt for a git tree requires live `revision` to match that tree and Railway `commitHash` (or `revision`) on both services.
 
 ## Gotchas
 

--- a/.agents/skills/verify-dns-ops/harness/api.mts
+++ b/.agents/skills/verify-dns-ops/harness/api.mts
@@ -1,5 +1,6 @@
 // harness/api.mts — HTTP driver with exchange capture and read-back.
 // Run: VERIFY_RUN_DIR=… bun .agents/skills/verify-dns-ops/harness/api.mts <feature-id>
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -43,11 +44,12 @@ const drives: Record<string, () => Promise<void>> = {
   'health.public': async () => {
     const first = await call('web-health', 'GET', '/api/health');
     if (![200, 503].includes(first.status)) throw new Error(`expected 200 or 503, got ${first.status}`);
-    const expectRev = (process.env.GIT_SHA || process.env.EXPECT_REVISION || '').trim();
+    const expectRev = (process.env.GIT_SHA || process.env.EXPECT_REVISION || execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' })).trim();
+    if (!expectRev) throw new Error('could not determine expected revision');
     const body = first.json as { status?: string; service?: string; revision?: string };
     if (first.status === 200 && body?.status !== 'healthy') throw new Error(`200 without status=healthy`);
     if (first.status === 503 && body?.status !== 'degraded') throw new Error(`503 without status=degraded`);
-    if (expectRev && body?.revision !== expectRev) throw new Error(`web revision ${body?.revision ?? '(none)'} != ${expectRev}`);
+    if (body?.revision !== expectRev) throw new Error(`web revision ${body?.revision ?? '(none)'} != ${expectRev}`);
     const again = await readback('web-health', '/api/health');
     if (again.status !== first.status) throw new Error(`read-back status ${again.status} != ${first.status}`);
     const live = await fetch(`${COLLECTOR_URL}/healthz`);
@@ -56,14 +58,14 @@ const drives: Record<string, () => Promise<void>> = {
     fs.mkdirSync(path.join(RUN_DIR, 'http'), { recursive: true });
     fs.writeFileSync(path.join(RUN_DIR, 'http', `${String(++n).padStart(2, '0')}-collector-healthz.json`), JSON.stringify(redact({ request: { method: 'GET', url: '/healthz' }, response: { status: live.status, body: liveJson ?? liveText } }), null, 2));
     if (live.status !== 200 || liveJson?.status !== 'ok') throw new Error(`collector /healthz expected 200 ok, got ${live.status} ${liveText.slice(0, 80)}`);
-    if (expectRev && liveJson?.revision !== expectRev) throw new Error(`collector /healthz revision ${liveJson?.revision ?? '(none)'} != ${expectRev}`);
+    if (liveJson?.revision !== expectRev) throw new Error(`collector /healthz revision ${liveJson?.revision ?? '(none)'} != ${expectRev}`);
     const ready = await fetch(`${COLLECTOR_URL}/readyz`);
     const readyText = await ready.text();
     let readyJson: { status?: string; revision?: string } | null = null; try { readyJson = JSON.parse(readyText); } catch {}
     fs.writeFileSync(path.join(RUN_DIR, 'http', `${String(++n).padStart(2, '0')}-collector-readyz.json`), JSON.stringify(redact({ request: { method: 'GET', url: '/readyz' }, response: { status: ready.status, body: readyJson ?? readyText } }), null, 2));
     if (![200, 503].includes(ready.status)) throw new Error(`collector /readyz expected 200 or 503, got ${ready.status}`);
     if (ready.status === 200 && readyJson?.status !== 'ready') throw new Error(`collector /readyz 200 without status=ready`);
-    if (expectRev && readyJson?.revision !== expectRev) throw new Error(`collector /readyz revision ${readyJson?.revision ?? '(none)'} != ${expectRev}`);
+    if (readyJson?.revision !== expectRev) throw new Error(`collector /readyz revision ${readyJson?.revision ?? '(none)'} != ${expectRev}`);
   },
 };
 

--- a/.agents/skills/verify-dns-ops/harness/api.mts
+++ b/.agents/skills/verify-dns-ops/harness/api.mts
@@ -43,23 +43,27 @@ const drives: Record<string, () => Promise<void>> = {
   'health.public': async () => {
     const first = await call('web-health', 'GET', '/api/health');
     if (![200, 503].includes(first.status)) throw new Error(`expected 200 or 503, got ${first.status}`);
-    const body = first.json as { status?: string; service?: string };
+    const expectRev = (process.env.GIT_SHA || process.env.EXPECT_REVISION || '').trim();
+    const body = first.json as { status?: string; service?: string; revision?: string };
     if (first.status === 200 && body?.status !== 'healthy') throw new Error(`200 without status=healthy`);
     if (first.status === 503 && body?.status !== 'degraded') throw new Error(`503 without status=degraded`);
+    if (expectRev && body?.revision !== expectRev) throw new Error(`web revision ${body?.revision ?? '(none)'} != ${expectRev}`);
     const again = await readback('web-health', '/api/health');
     if (again.status !== first.status) throw new Error(`read-back status ${again.status} != ${first.status}`);
     const live = await fetch(`${COLLECTOR_URL}/healthz`);
     const liveText = await live.text();
-    let liveJson: { status?: string } | null = null; try { liveJson = JSON.parse(liveText); } catch {}
+    let liveJson: { status?: string; revision?: string } | null = null; try { liveJson = JSON.parse(liveText); } catch {}
     fs.mkdirSync(path.join(RUN_DIR, 'http'), { recursive: true });
     fs.writeFileSync(path.join(RUN_DIR, 'http', `${String(++n).padStart(2, '0')}-collector-healthz.json`), JSON.stringify(redact({ request: { method: 'GET', url: '/healthz' }, response: { status: live.status, body: liveJson ?? liveText } }), null, 2));
     if (live.status !== 200 || liveJson?.status !== 'ok') throw new Error(`collector /healthz expected 200 ok, got ${live.status} ${liveText.slice(0, 80)}`);
+    if (expectRev && liveJson?.revision !== expectRev) throw new Error(`collector /healthz revision ${liveJson?.revision ?? '(none)'} != ${expectRev}`);
     const ready = await fetch(`${COLLECTOR_URL}/readyz`);
     const readyText = await ready.text();
-    let readyJson: { status?: string } | null = null; try { readyJson = JSON.parse(readyText); } catch {}
+    let readyJson: { status?: string; revision?: string } | null = null; try { readyJson = JSON.parse(readyText); } catch {}
     fs.writeFileSync(path.join(RUN_DIR, 'http', `${String(++n).padStart(2, '0')}-collector-readyz.json`), JSON.stringify(redact({ request: { method: 'GET', url: '/readyz' }, response: { status: ready.status, body: readyJson ?? readyText } }), null, 2));
     if (![200, 503].includes(ready.status)) throw new Error(`collector /readyz expected 200 or 503, got ${ready.status}`);
     if (ready.status === 200 && readyJson?.status !== 'ready') throw new Error(`collector /readyz 200 without status=ready`);
+    if (expectRev && readyJson?.revision !== expectRev) throw new Error(`collector /readyz revision ${readyJson?.revision ?? '(none)'} != ${expectRev}`);
   },
 };
 

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -1,4 +1,4 @@
-import { defineRailway, postgres, preserve, project, redis, service, volume } from "railway/iac";
+import { defineRailway, github, postgres, preserve, project, redis, service, volume } from "railway/iac";
 
 export default defineRailway(() => {
   const Postgres = postgres("Postgres", { region: "us-east4-eqdc4a" });
@@ -10,6 +10,7 @@ export default defineRailway(() => {
   const redisVolume = volume("redis-volume", { alerts: { usage: { "100": {}, "80": {}, "95": {} } }, allowOnlineResize: true, region: "us-east4-eqdc4a", sizeMB: 50000 });
   const postgresVolume = volume("postgres-volume", { alerts: { usage: { "100": {}, "80": {}, "95": {} } }, allowOnlineResize: true, region: "us-east4-eqdc4a", sizeMB: 50000 });
   const collector = service("collector", {
+    source: github("computindev/dns-ops", { branch: "master" }),
     replicas: { "us-east4-eqdc4a": 1 },
     build: {
       builder: "DOCKERFILE",
@@ -31,6 +32,7 @@ export default defineRailway(() => {
     },
   });
   const web = service("web", {
+    source: github("computindev/dns-ops", { branch: "master" }),
     replicas: { "us-east4-eqdc4a": 1 },
     build: {
       builder: "DOCKERFILE",

--- a/apps/collector/src/index.test.ts
+++ b/apps/collector/src/index.test.ts
@@ -104,7 +104,11 @@ describe('Collector onError body', () => {
 describe('Collector liveness (process-only)', () => {
   it('GET /healthz returns 200 without probing DB', async () => {
     const previous = process.env.DATABASE_URL;
+    const prevSha = process.env.GIT_SHA;
+    const prevRailway = process.env.RAILWAY_GIT_COMMIT_SHA;
     delete process.env.DATABASE_URL;
+    delete process.env.GIT_SHA;
+    delete process.env.RAILWAY_GIT_COMMIT_SHA;
     resetSharedDbAdapterForTests();
 
     const res = await app.request('/healthz');
@@ -116,6 +120,10 @@ describe('Collector liveness (process-only)', () => {
 
     if (previous === undefined) delete process.env.DATABASE_URL;
     else process.env.DATABASE_URL = previous;
+    if (prevSha === undefined) delete process.env.GIT_SHA;
+    else process.env.GIT_SHA = prevSha;
+    if (prevRailway === undefined) delete process.env.RAILWAY_GIT_COMMIT_SHA;
+    else process.env.RAILWAY_GIT_COMMIT_SHA = prevRailway;
   });
 
   it('GET /healthz includes revision when GIT_SHA is set', async () => {

--- a/apps/collector/src/index.test.ts
+++ b/apps/collector/src/index.test.ts
@@ -112,9 +112,21 @@ describe('Collector liveness (process-only)', () => {
     const body = (await res.json()) as { status: string; service: string };
     expect(body.status).toBe('ok');
     expect(body.service).toBe('dns-ops-collector');
+    expect(body).not.toHaveProperty('revision');
 
     if (previous === undefined) delete process.env.DATABASE_URL;
     else process.env.DATABASE_URL = previous;
+  });
+
+  it('GET /healthz includes revision when GIT_SHA is set', async () => {
+    const previous = process.env.GIT_SHA;
+    process.env.GIT_SHA = 'abc123deadbeef';
+    const res = await app.request('/healthz');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { revision?: string };
+    expect(body.revision).toBe('abc123deadbeef');
+    if (previous === undefined) delete process.env.GIT_SHA;
+    else process.env.GIT_SHA = previous;
   });
 
   it('GET /health returns 200 without probing DB', async () => {

--- a/apps/collector/src/index.ts
+++ b/apps/collector/src/index.ts
@@ -80,12 +80,18 @@ app.use(
   }) as unknown as MiddlewareHandler
 );
 
+function publicRevision(): { revision?: string } {
+  const revision = process.env.GIT_SHA || process.env.RAILWAY_GIT_COMMIT_SHA;
+  return typeof revision === 'string' && revision.trim() ? { revision: revision.trim() } : {};
+}
+
 // Liveness: process-only. Never probe dependencies here.
 app.get('/healthz', (c) => {
   return c.json({
     status: 'ok',
     service: 'dns-ops-collector',
     timestamp: new Date().toISOString(),
+    ...publicRevision(),
   });
 });
 
@@ -94,6 +100,7 @@ app.get('/health', (c) => {
     status: 'ok',
     service: 'dns-ops-collector',
     timestamp: new Date().toISOString(),
+    ...publicRevision(),
   });
 });
 
@@ -103,6 +110,7 @@ app.get('/api/health', (c) => {
     status: 'ok',
     service: 'dns-ops-collector',
     timestamp: new Date().toISOString(),
+    ...publicRevision(),
   });
 });
 
@@ -160,6 +168,7 @@ app.get('/readyz', async (c) => {
       status: allHealthy ? 'ready' : 'not_ready',
       service: 'dns-ops-collector',
       timestamp: new Date().toISOString(),
+      ...publicRevision(),
       checks,
     },
     allHealthy ? 200 : 503

--- a/apps/web/hono/routes/api.ts
+++ b/apps/web/hono/routes/api.ts
@@ -80,11 +80,15 @@ async function resolveAccessibleSnapshot(
 // Railway readiness endpoint: 200 only after a real DB query succeeds.
 apiRoutes.get('/health', async (c) => {
   const db = c.get('db');
+  const revision = process.env.GIT_SHA || process.env.RAILWAY_GIT_COMMIT_SHA;
+  const publicRevision =
+    typeof revision === 'string' && revision.trim() ? { revision: revision.trim() } : {};
   const degradedBody = {
     status: 'degraded' as const,
     service: 'dns-ops-web',
     timestamp: new Date().toISOString(),
     warning: 'Database connection not available - API functionality limited',
+    ...publicRevision,
   };
 
   // Adapter presence alone is a false-green; require a configured URL and a
@@ -103,6 +107,7 @@ apiRoutes.get('/health', async (c) => {
         status: 'healthy' as const,
         service: 'dns-ops-web',
         timestamp: new Date().toISOString(),
+        ...publicRevision,
       },
       200
     );

--- a/apps/web/hono/routes/health.ready.test.ts
+++ b/apps/web/hono/routes/health.ready.test.ts
@@ -28,6 +28,7 @@ type HealthBody = {
   service: string;
   timestamp: string;
   warning?: string;
+  revision?: string;
 };
 
 function createHealthApp(db: Env['Variables']['db'] | undefined) {
@@ -113,6 +114,18 @@ describe('GET /api/health honest readiness (RT-3, no Docker)', () => {
     expect(body.service).toBe('dns-ops-web');
     expect(body.timestamp).toBeTruthy();
     expect(body.warning).toMatch(/Database connection not available/i);
+    expect(body).not.toHaveProperty('revision');
+    assertNoInternalLeak(body);
+  });
+
+  it('includes revision when GIT_SHA is set', async () => {
+    delete process.env.DATABASE_URL;
+    process.env.GIT_SHA = 'abc123deadbeef';
+    const app = createHealthApp(undefined);
+    const res = await app.request('/api/health');
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as HealthBody;
+    expect(body.revision).toBe('abc123deadbeef');
     assertNoInternalLeak(body);
   });
 

--- a/apps/web/hono/routes/health.ready.test.ts
+++ b/apps/web/hono/routes/health.ready.test.ts
@@ -105,6 +105,8 @@ describe('GET /api/health honest readiness (RT-3, no Docker)', () => {
 
   it('returns 503 when db context is missing', async () => {
     delete process.env.DATABASE_URL;
+    delete process.env.GIT_SHA;
+    delete process.env.RAILWAY_GIT_COMMIT_SHA;
     const app = createHealthApp(undefined);
     const res = await app.request('/api/health');
 

--- a/docs/guides/railway-deploy.md
+++ b/docs/guides/railway-deploy.md
@@ -25,7 +25,7 @@ Each service uses its own Dockerfile:
 
 Never start collector with the web Nitro path.
 
-Neither web nor collector has a GitHub source in `.railway/railway.ts`. Auto-deploy on master is disabled until deliberately enabled. After authorization, deploy with `railway up --service web` / `railway up --service collector`.
+Web and collector `source` is GitHub `computindev/dns-ops` branch `master`. Pushes to master deploy those services. Use `railway up` only when you need a source-less rebuild; that will not set `commitHash`.
 
 ## 1. Existing Railway project
 
@@ -72,7 +72,7 @@ Do not add `COLLECTOR_URL` to collector.
 
 Preview with `railway config plan` against `dns-ops` / `production`. Do not `railway config apply` or `railway up` unless authorized.
 
-Master auto-deploy is disabled until a GitHub source is deliberately added in IaC.
+Master GitHub auto-deploy is enabled for web and collector.
 
 Web start: `node apps/web/.output/server/index.mjs`  
 Collector start: `node apps/collector/dist/index.js`

--- a/packages/contracts/src/responses.ts
+++ b/packages/contracts/src/responses.ts
@@ -1281,6 +1281,7 @@ export interface HealthResponse {
   status: 'healthy' | 'degraded' | 'unhealthy';
   service: string;
   timestamp: string;
+  revision?: string;
 }
 
 /**

--- a/verification/receipts/20260831-202915Z-ff8c939-predeploy--health.public.md
+++ b/verification/receipts/20260831-202915Z-ff8c939-predeploy--health.public.md
@@ -1,0 +1,37 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260831-202915Z-ff8c939-predeploy
+feature_id: health.public
+profile: changed
+surface: api
+sha: ff8c93903c163621491e344ea3ad210a4dad4e13
+code_digest: 27b3a2e476cfb871912da84ef6f196cc247079298562fca086e431085f410c65
+dirty: true
+untracked: 0
+status: blocked
+reason: "GitHub source and health revision are in this PR but not on live Railway yet; cannot bind a deploy commitHash to this tree."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260831-202915Z-ff8c939-predeploy
+created_at: 2026-08-31T20:29:15.385Z
+---
+
+# Receipt: health.public — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260831-202915Z-ff8c939-predeploy/env.txt | env | aux | 7cdd5219ce360b854a0a04d67cfdb6e95e569b7fff98fa4e96ed41aff61beba6 |

--- a/verification/receipts/20260831-203707Z-ca3db4c-predeploy2--health.public.md
+++ b/verification/receipts/20260831-203707Z-ca3db4c-predeploy2--health.public.md
@@ -1,0 +1,37 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260831-203707Z-ca3db4c-predeploy2
+feature_id: health.public
+profile: changed
+surface: api
+sha: ca3db4c65dc16628a1e207d9318de3b419ffe636
+code_digest: 6ad4793136bc1060f2b4df0a6c9390a2b9eb85a20edadc19d427a06811434162
+dirty: true
+untracked: 0
+status: blocked
+reason: "GitHub source and health revision not live yet; drive requires revision == HEAD."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260831-203707Z-ca3db4c-predeploy2
+created_at: 2026-08-31T20:37:07.823Z
+---
+
+# Receipt: health.public — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260831-203707Z-ca3db4c-predeploy2/env.txt | env | aux | 8d048569fa592189a29132ef65dc047b358bd26fa7c6ef7c81ae58021ae3b003 |


### PR DESCRIPTION
## Why
Live health 200 could not certify a git tree: Railway web/collector were source-less redeploys with no commitHash.

## What
- Public health JSON may include `revision` from `GIT_SHA` or `RAILWAY_GIT_COMMIT_SHA`
- `.railway/railway.ts` sets GitHub source `computindev/dns-ops` branch `master` for web and collector
- `health.public` proof/harness require revision match when `GIT_SHA` is set

## Not in this PR
- No `railway config apply` until this lands on master
- No product behavior beyond health JSON

## How to review
1. Health tests: collector `index.test.ts` liveness + web `health.ready.test.ts`
2. IaC plan is 0 add / 2 change / 0 destroy (GitHub source only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `revision` field to web and collector health endpoints so a live health 200 can certify a specific git tree. Binds Railway web and collector to the GitHub source so deploys carry `RAILWAY_GIT_COMMIT_SHA`.

- Health responses include `revision` when `GIT_SHA` or `RAILWAY_GIT_COMMIT_SHA` is set, and omit it otherwise.
- The verification harness requires the live revision to match the expected SHA and blocks `health.public` until the GitHub-sourced deploy is live.
- `.railway/railway.ts` sets the GitHub source to `computindev/dns-ops` branch `master` for both services.
- No `railway config apply` is run until this PR is merged to master.

<sup>Written for commit 5af0349048bdf02a96e15fa1e6eafcaef76945d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

