### PR TITLE
chore(verify): pass health.public on SHA-bound Railway deploys

### DIFF
--- a/verification/receipts/20260831-204338Z-3b01ab1-live-sha--health.public.md
+++ b/verification/receipts/20260831-204338Z-3b01ab1-live-sha--health.public.md
@@ -1,0 +1,47 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260831-204338Z-3b01ab1-live-sha
+feature_id: health.public
+profile: changed
+surface: api
+sha: 3b01ab1e2336d3decfeac22a6d7fdf2e6db2abc7
+code_digest: 6ad4793136bc1060f2b4df0a6c9390a2b9eb85a20edadc19d427a06811434162
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260831-204338Z-3b01ab1-live-sha
+created_at: 2026-08-31T20:43:56.365Z
+---
+
+# Receipt: health.public — passed
+
+## Observations (expected → seen)
+- Live project `dns-ops`, environment `production`
+- Web deploy `c30e1eb7` commitHash `3b01ab1e2336d3decfeac22a6d7fdf2e6db2abc7` DOCKERFILE SUCCESS
+- Collector deploy `efd24559` same commitHash DOCKERFILE SUCCESS
+- GET web `/api/health` 200 healthy revision=3b01ab1e2336d3decfeac22a6d7fdf2e6db2abc7
+- GET collector `/healthz` 200 ok same revision
+- GET collector `/readyz` 200 ready same revision
+
+## Forbidden (must not happen → confirmed absent)
+- No 502 without service
+- No secrets in public bodies
+- Did not treat /healthz as /readyz
+
+## Read-back
+- Second web `/api/health` still 200 healthy with the same revision
+- revision matches git HEAD and Railway commitHash on both services
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260831-204338Z-3b01ab1-live-sha/env.txt | env | aux | 451223466333ce8034825ca407edb232ddef6d74dc717c59c5d9158eb1eee3ff |
+| verification/runs/20260831-204338Z-3b01ab1-live-sha/http/01-web-health.json | http | evidence | 4b02062bef20b4badb2f5bb513669b11eda8dc05e946226633baf5b87ad967a5 |
+| verification/runs/20260831-204338Z-3b01ab1-live-sha/http/02-readback-web-health.json | http | evidence | 9e5be9e8d111c544d78be3cad4a826758d0be69fbca584cf27ee28d07ce9a619 |
+| verification/runs/20260831-204338Z-3b01ab1-live-sha/http/03-collector-healthz.json | http | evidence | 638549d9bdc2a0fe046a2e95220aea69b5c094cffe22ddc8048fb9a1b859f49b |
+| verification/runs/20260831-204338Z-3b01ab1-live-sha/http/04-collector-readyz.json | http | evidence | 67405aee6ae5e07450fa1028c17cf4448e65944fe2d17c78e80e4b0621454333 |
+| verification/runs/20260831-204338Z-3b01ab1-live-sha/readback/web-health.json | readback | evidence | 27e7d6dfa1e4f9f458b594aad12d59edb394b30f83a04f74cf741fb08314ad24 |


### PR DESCRIPTION
## Why
Live web and collector now deploy from GitHub master with commitHash `3b01ab1`. Health JSON `revision` matches.

## What
One `passed` `health.public` receipt bound to that tree. Notes record project `dns-ops` / `production` and deploy ids `c30e1eb7` / `efd24559`.

## Not in this PR
- No further Railway apply
- No product code

## How to review
Receipt Observations name the commitHash and revision. Evidence dumps stay gitignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SHA-bound `health.public` verification receipt showing the live Railway deploys of commit `3b01ab1` pass health checks.

- Records observations for web deploy `c30e1eb7` and collector deploy `efd24559`, both at commitHash `3b01ab1` in project `dns-ops` / `production`.
- Confirms `/api/health`, `/healthz`, and `/readyz` return 200 with revision matching git HEAD and the Railway commitHash, including a read-back check.
- Verifies no 502 without service, no secrets in public bodies, and no `/healthz` treated as `/readyz`.
- Includes no Railway apply or product code; evidence dumps stay gitignored.

<sup>Written for commit 5341d49a798e54988fd3e06b3fa76def3020a240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

