### PR TITLE
chore(live): pin asorin Cloudflare token fingerprint

### DIFF
--- a/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
+++ b/docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json
@@ -4,7 +4,7 @@
   "zone": "asorin.ai",
   "zoneId": "7391960081e72b26c9c5066133013ab2",
   "provider": "cloudflare",
-  "providerCredentialFingerprint": "sha256:17fe70271d1013db5ef7fffa31f6ea68e98a2a0040300a3acb3ee96e4b9bfd8f",
+  "providerCredentialFingerprint": "sha256:1006bbfa4775b56061786d3e953418aee06a142336f3f51408ce45d5663df019",
   "testAssets": {
     "webHost": "asorin.ai",
     "wwwHost": "www.asorin.ai",


### PR DESCRIPTION
## Why
The controlled-live harness refuses a token whose SHA-256 does not match the committed manifest. The live operator token fingerprint changed.

## What
One-line update of `providerCredentialFingerprint` in the asorin controlled-live manifest.

## Not in this PR
- No DNS mutation
- No token material
- No Railway apply

## How to review
Confirm only the fingerprint string changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pinned Cloudflare token fingerprint for the asorin controlled-live harness so it matches the operator token currently in use. The harness was rejecting the old fingerprint, blocking live DNS operations. Only the fingerprint string changed in the manifest; no DNS mutations, token material, or infrastructure apply is included.

<sup>Written for commit e2aec0c3c4964337da9c2df7ef65de1456a2ea1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

