### PR TITLE
fix(collector): trust only persisted evidence for active probes

### DIFF
--- a/apps/collector/src/dns/collector.authoritative.test.ts
+++ b/apps/collector/src/dns/collector.authoritative.test.ts
@@ -113,7 +113,12 @@ vi.mock('../middleware/error-tracking.js', () => ({
 }));
 
 vi.mock('@dns-ops/parsing', () => ({
+  MAX_DNS_CNAME_HOPS: 5,
   observationsToRecordSets: vi.fn().mockReturnValue([]),
+  tryNormalizeDNSOwner: (name: string) => ({
+    original: name,
+    normalized: name.toLowerCase().replace(/\.$/, ''),
+  }),
 }));
 
 describe('PR-07.6: Authoritative Collection', () => {

--- a/apps/collector/src/dns/collector.ruleset-version.test.ts
+++ b/apps/collector/src/dns/collector.ruleset-version.test.ts
@@ -141,7 +141,12 @@ vi.mock('../middleware/error-tracking.js', () => ({
 }));
 
 vi.mock('@dns-ops/parsing', () => ({
+  MAX_DNS_CNAME_HOPS: 5,
   observationsToRecordSets: vi.fn().mockReturnValue([]),
+  tryNormalizeDNSOwner: (name: string) => ({
+    original: name,
+    normalized: name.toLowerCase().replace(/\.$/, ''),
+  }),
 }));
 
 describe('TB-3 step 0: collector persists rulesetVersionId on findings', () => {

--- a/apps/collector/src/dns/collector.ts
+++ b/apps/collector/src/dns/collector.ts
@@ -25,7 +25,7 @@ import {
   SnapshotRepository,
   SuggestionRepository,
 } from '@dns-ops/db';
-import { observationsToRecordSets } from '@dns-ops/parsing';
+import { observationsToRecordSets, tryNormalizeDomain } from '@dns-ops/parsing';
 import {
   authoritativeFailureRule,
   authoritativeMismatchRule,
@@ -61,6 +61,11 @@ import type {
 // Current ruleset version - keep in sync with web app findings.ts
 const CURRENT_RULESET_VERSION = '1.2.0';
 const CURRENT_RULESET_NAME = 'DNS and Mail Rules';
+const MAX_MTA_STS_CNAME_HOPS = 5;
+
+function normalizeDnsOwnerName(name: string): string {
+  return name.trim().replace(/\.+$/, '').toLowerCase();
+}
 
 const logger = getCollectorLogger();
 
@@ -205,8 +210,16 @@ export class DNSCollector {
       }
     }
 
+    // Collect bounded MTA-STS CNAME hops and terminal TXT evidence from the
+    // recursive vantage. External canonical owners are not served by the
+    // managed zone's authoritative nameservers, so follow-up queries remain
+    // recursive while the initial alias is still collected at every enabled
+    // vantage above.
+    const initialResults = [...recursiveResults, ...authoritativeResults];
+    const cnameResults = await this.collectMtaStsCnameChain(initialResults, errors);
+
     // Combine all results
-    const allResults = [...recursiveResults, ...authoritativeResults];
+    const allResults = [...initialResults, ...cnameResults];
 
     // Collect delegation data if enabled (Bead 12)
     let delegationData = null;
@@ -331,6 +344,64 @@ export class DNSCollector {
     });
 
     return mailResult.queries;
+  }
+
+  /**
+   * Follow persisted MTA-STS CNAME evidence far enough to collect each hop
+   * and the terminal TXT owner. The bound keeps a malicious or malformed DNS
+   * chain from expanding the collection indefinitely.
+   */
+  private async collectMtaStsCnameChain(
+    initialResults: DNSQueryResult[],
+    errors: CollectionError[]
+  ): Promise<DNSQueryResult[]> {
+    if (this.config.includeMailRecords === false) return [];
+
+    const initialOwner = normalizeDnsOwnerName(`_mta-sts.${this.config.domain}`);
+    const queriedNames = new Set([initialOwner]);
+    let pending = new Set(this.extractMtaStsCnameTargets(initialResults, new Set([initialOwner])));
+    const collected: DNSQueryResult[] = [];
+    const recursiveVantage: VantageInfo = {
+      type: 'public-recursive',
+      identifier: '8.8.8.8',
+      region: 'us-central',
+    };
+
+    for (let hop = 1; hop <= MAX_MTA_STS_CNAME_HOPS && pending.size > 0; hop++) {
+      const owners = [...pending].filter((owner) => !queriedNames.has(owner));
+      if (owners.length === 0) break;
+      for (const owner of owners) queriedNames.add(owner);
+
+      const queries = owners.flatMap((name) => [
+        { name, type: 'CNAME' },
+        { name, type: 'TXT' },
+      ]);
+      const results = await this.collectFromVantage(queries, recursiveVantage, errors);
+      collected.push(...results);
+      pending = new Set(this.extractMtaStsCnameTargets(results, new Set(owners)));
+    }
+
+    return collected;
+  }
+
+  private extractMtaStsCnameTargets(
+    results: DNSQueryResult[],
+    ownerNames: ReadonlySet<string>
+  ): string[] {
+    const targets: string[] = [];
+    for (const result of results) {
+      if (result.query.type !== 'CNAME' || !result.success) continue;
+      const queryName = normalizeDnsOwnerName(result.query.name);
+      if (!queryName || !ownerNames.has(queryName)) continue;
+      for (const answer of result.answers) {
+        if (answer.type !== 'CNAME' || normalizeDnsOwnerName(answer.name) !== queryName) {
+          continue;
+        }
+        const target = tryNormalizeDomain(answer.data)?.normalized;
+        if (target) targets.push(target);
+      }
+    }
+    return [...new Set(targets)];
   }
 
   /**

--- a/apps/collector/src/dns/collector.ts
+++ b/apps/collector/src/dns/collector.ts
@@ -354,16 +354,16 @@ export class DNSCollector {
    * chain from expanding the collection indefinitely.
    */
   private async collectMtaStsCnameChain(
-    initialResults: DNSQueryResult[],
+    initialResults: TimedDNSQueryResult[],
     errors: CollectionError[]
-  ): Promise<DNSQueryResult[]> {
+  ): Promise<TimedDNSQueryResult[]> {
     if (this.config.includeMailRecords === false) return [];
 
     const initialOwner = tryNormalizeDNSOwner(`_mta-sts.${this.config.domain}`)?.normalized;
     if (!initialOwner) return [];
     const queriedNames = new Set([initialOwner]);
     let pending = new Set(this.extractMtaStsCnameTargets(initialResults, new Set([initialOwner])));
-    const collected: DNSQueryResult[] = [];
+    const collected: TimedDNSQueryResult[] = [];
     const recursiveVantage: VantageInfo = {
       type: 'public-recursive',
       identifier: '8.8.8.8',

--- a/apps/collector/src/dns/collector.ts
+++ b/apps/collector/src/dns/collector.ts
@@ -25,7 +25,11 @@ import {
   SnapshotRepository,
   SuggestionRepository,
 } from '@dns-ops/db';
-import { observationsToRecordSets, tryNormalizeDomain } from '@dns-ops/parsing';
+import {
+  MAX_DNS_CNAME_HOPS,
+  observationsToRecordSets,
+  tryNormalizeDNSOwner,
+} from '@dns-ops/parsing';
 import {
   authoritativeFailureRule,
   authoritativeMismatchRule,
@@ -61,11 +65,6 @@ import type {
 // Current ruleset version - keep in sync with web app findings.ts
 const CURRENT_RULESET_VERSION = '1.2.0';
 const CURRENT_RULESET_NAME = 'DNS and Mail Rules';
-const MAX_MTA_STS_CNAME_HOPS = 5;
-
-function normalizeDnsOwnerName(name: string): string {
-  return name.trim().replace(/\.+$/, '').toLowerCase();
-}
 
 const logger = getCollectorLogger();
 
@@ -159,7 +158,8 @@ export class DNSCollector {
     db: IDatabaseAdapter,
     options?: { resolver?: ResolverLike; queryConcurrency?: number }
   ) {
-    this.config = config;
+    const normalizedDomain = tryNormalizeDNSOwner(config.domain)?.normalized;
+    this.config = normalizedDomain ? { ...config, domain: normalizedDomain } : config;
     this.resolver = options?.resolver ?? new DNSResolver();
     this.semaphore = new Semaphore(options?.queryConcurrency ?? getDnsQueryConcurrency());
     this.domainRepo = new DomainRepository(db);
@@ -259,7 +259,6 @@ export class DNSCollector {
   private async generateQueries(): Promise<DNSQuery[]> {
     const queries: DNSQuery[] = [];
     const {
-      domain,
       zoneManagement,
       recordTypes,
       queryNames,
@@ -267,12 +266,15 @@ export class DNSCollector {
       dkimSelectors,
       managedDkimSelectors,
     } = this.config;
+    const domain = tryNormalizeDNSOwner(this.config.domain)?.normalized ?? this.config.domain;
 
     if (queryNames) {
       // Use explicit query names (targeted inspection)
       for (const name of queryNames) {
+        const normalizedName = tryNormalizeDNSOwner(name)?.normalized;
+        if (!normalizedName) continue;
         for (const type of recordTypes) {
-          queries.push({ name, type });
+          queries.push({ name: normalizedName, type });
         }
       }
     } else if (zoneManagement === 'unmanaged') {
@@ -357,7 +359,8 @@ export class DNSCollector {
   ): Promise<DNSQueryResult[]> {
     if (this.config.includeMailRecords === false) return [];
 
-    const initialOwner = normalizeDnsOwnerName(`_mta-sts.${this.config.domain}`);
+    const initialOwner = tryNormalizeDNSOwner(`_mta-sts.${this.config.domain}`)?.normalized;
+    if (!initialOwner) return [];
     const queriedNames = new Set([initialOwner]);
     let pending = new Set(this.extractMtaStsCnameTargets(initialResults, new Set([initialOwner])));
     const collected: DNSQueryResult[] = [];
@@ -367,7 +370,7 @@ export class DNSCollector {
       region: 'us-central',
     };
 
-    for (let hop = 1; hop <= MAX_MTA_STS_CNAME_HOPS && pending.size > 0; hop++) {
+    for (let hop = 1; hop <= MAX_DNS_CNAME_HOPS && pending.size > 0; hop++) {
       const owners = [...pending].filter((owner) => !queriedNames.has(owner));
       if (owners.length === 0) break;
       for (const owner of owners) queriedNames.add(owner);
@@ -391,13 +394,12 @@ export class DNSCollector {
     const targets: string[] = [];
     for (const result of results) {
       if (result.query.type !== 'CNAME' || !result.success) continue;
-      const queryName = normalizeDnsOwnerName(result.query.name);
+      const queryName = tryNormalizeDNSOwner(result.query.name)?.normalized;
       if (!queryName || !ownerNames.has(queryName)) continue;
       for (const answer of result.answers) {
-        if (answer.type !== 'CNAME' || normalizeDnsOwnerName(answer.name) !== queryName) {
-          continue;
-        }
-        const target = tryNormalizeDomain(answer.data)?.normalized;
+        const answerName = tryNormalizeDNSOwner(answer.name)?.normalized;
+        if (answer.type !== 'CNAME' || answerName !== queryName) continue;
+        const target = tryNormalizeDNSOwner(answer.data)?.normalized;
         if (target) targets.push(target);
       }
     }
@@ -535,7 +537,8 @@ export class DNSCollector {
     snapshotId: string;
     resultState: 'complete' | 'partial' | 'failed';
   }> {
-    const { tenantId, domain, zoneManagement, triggeredBy } = this.config;
+    const { tenantId, zoneManagement, triggeredBy } = this.config;
+    const domain = tryNormalizeDNSOwner(this.config.domain)?.normalized ?? this.config.domain;
     // Find or create domain within the current tenant scope.
     // The same normalized domain may legitimately exist in multiple tenant portfolios.
     let domainRecord = await this.domainRepo.findByNameForTenant(domain, tenantId);

--- a/apps/collector/src/dns/integration.test.ts
+++ b/apps/collector/src/dns/integration.test.ts
@@ -671,22 +671,23 @@ describe('DNS Collector Integration', () => {
     }
   });
 
-  it('should persist collected CNAME hops and authorize the terminal MTA-STS TXT', async () => {
+  it('should canonicalize mixed-case underscore CNAME hops and authorize terminal TXT', async () => {
     const { db, rows } = createInMemoryDb();
     const initialOwner = '_mta-sts.example.com';
-    const terminalOwner = 'mta-sts-policy.example.net';
+    const observedTarget = '_Policy._MTA-STS.Example.NET.';
+    const terminalOwner = '_policy._mta-sts.example.net';
     const txtRecord = 'v=STSv1; id=20260901';
     const queryResults = new Map<string, DNSQueryResult>([
       [
         `${initialOwner}:CNAME`,
         buildSuccessResult(initialOwner, 'CNAME', [
-          makeAnswer(initialOwner, 'CNAME', terminalOwner, 120),
+          makeAnswer('_MTA-STS.Example.COM.', 'CNAME', observedTarget, 120),
         ]),
       ],
       [
         `${terminalOwner}:TXT`,
         buildSuccessResult(terminalOwner, 'TXT', [
-          makeAnswer(terminalOwner, 'TXT', txtRecord, 300),
+          makeAnswer('_POLICY._MTA-STS.EXAMPLE.NET.', 'TXT', txtRecord, 300),
         ]),
       ],
     ]);
@@ -694,7 +695,7 @@ describe('DNS Collector Integration', () => {
     const collector = createCollectorWithMockedResolver(
       {
         tenantId: 'tenant-cname',
-        domain: 'example.com',
+        domain: 'Example.COM.',
         zoneManagement: 'unknown',
         recordTypes: ['TXT'],
         triggeredBy: 'test',
@@ -706,6 +707,13 @@ describe('DNS Collector Integration', () => {
     const collection = await collector.collect();
 
     expect(collection.resultState).toBe('complete');
+    const observations = rows('observations');
+    expect(observations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ queryName: initialOwner, queryType: 'CNAME' }),
+        expect.objectContaining({ queryName: terminalOwner, queryType: 'TXT' }),
+      ])
+    );
     const recordSets = rows('record_sets');
     expect(recordSets).toEqual(
       expect.arrayContaining([
@@ -728,7 +736,7 @@ describe('DNS Collector Integration', () => {
     );
 
     const evidence = await loadPersistedMtaStsEvidence(db, {
-      domain: 'example.com',
+      domain: 'EXAMPLE.COM.',
       tenantId: 'tenant-cname',
     });
     expect(evidence).toMatchObject({ ok: true, txtRecord, txtRecordId: '20260901' });

--- a/apps/collector/src/dns/integration.test.ts
+++ b/apps/collector/src/dns/integration.test.ts
@@ -13,6 +13,7 @@
 
 import type { IDatabaseAdapter } from '@dns-ops/db';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { loadPersistedMtaStsEvidence } from '../probes/persisted-dns-authorization.js';
 import { DNSCollector, type ResolverLike } from './collector.js';
 import { DNSResolver } from './resolver.js';
 import type { CollectionConfig, DNSQueryResult, VantageInfo } from './types.js';
@@ -226,11 +227,44 @@ function createInMemoryDb() {
     return tables.get(name) ?? [];
   }
 
-  function getConditionParam(condition: unknown): unknown {
-    const sql = condition as {
-      queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+  function getConditionPairs(condition: unknown): Array<[string, unknown]> {
+    const pairs: Array<[string, unknown]> = [];
+    const visit = (value: unknown): void => {
+      if (!value || typeof value !== 'object') return;
+      const record = value as {
+        queryChunks?: unknown[];
+        constructor?: { name?: string };
+        name?: string;
+        value?: unknown;
+      };
+      const chunks = record.queryChunks ?? [];
+      const column = chunks.find((chunk): chunk is { name: string } =>
+        Boolean(
+          chunk &&
+            typeof chunk === 'object' &&
+            typeof (chunk as { name?: unknown }).name === 'string' &&
+            (chunk as { constructor?: { name?: string } }).constructor?.name !== 'Param'
+        )
+      );
+      const param = chunks.find((chunk): chunk is { value: unknown } =>
+        Boolean(
+          chunk &&
+            typeof chunk === 'object' &&
+            (chunk as { constructor?: { name?: string } }).constructor?.name === 'Param'
+        )
+      );
+      if (column && param) pairs.push([column.name, param.value]);
+      for (const chunk of chunks) visit(chunk);
     };
-    return sql.queryChunks?.find((c) => c?.constructor?.name === 'Param')?.value;
+    visit(condition);
+    return pairs;
+  }
+
+  function matches(row: Row, condition: unknown): boolean {
+    return getConditionPairs(condition).every(([column, value]) => {
+      const key = column.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+      return row[key] === value;
+    });
   }
 
   const db: IDatabaseAdapter = {
@@ -238,13 +272,11 @@ function createInMemoryDb() {
     select: vi.fn(async (table: unknown) => [...rows(getTable(table))]),
     selectWhere: vi.fn(async (table: unknown, condition: unknown) => {
       const name = getTable(table);
-      const param = getConditionParam(condition);
-      return rows(name).filter((r) => Object.values(r).some((v) => v === param));
+      return rows(name).filter((row) => matches(row, condition));
     }),
     selectOne: vi.fn(async (table: unknown, condition: unknown) => {
       const name = getTable(table);
-      const param = getConditionParam(condition);
-      return rows(name).find((r) => Object.values(r).some((v) => v === param));
+      return rows(name).find((row) => matches(row, condition));
     }),
     insert: vi.fn(async (table: unknown, values: Record<string, unknown>) => {
       const name = getTable(table);
@@ -272,8 +304,7 @@ function createInMemoryDb() {
     }),
     update: vi.fn(async (table: unknown, values: Record<string, unknown>, condition: unknown) => {
       const name = getTable(table);
-      const param = getConditionParam(condition);
-      const target = rows(name).find((r) => Object.values(r).some((v) => v === param));
+      const target = rows(name).find((row) => matches(row, condition));
       if (target) Object.assign(target, values);
       return target ? [target] : [];
     }),
@@ -637,6 +668,77 @@ describe('DNS Collector Integration', () => {
       const values = aRecordSet.values as string[];
       expect(values).toBeDefined();
       expect(values.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('should persist collected CNAME hops and authorize the terminal MTA-STS TXT', async () => {
+    const { db, rows } = createInMemoryDb();
+    const initialOwner = '_mta-sts.example.com';
+    const terminalOwner = 'mta-sts-policy.example.net';
+    const txtRecord = 'v=STSv1; id=20260901';
+    const queryResults = new Map<string, DNSQueryResult>([
+      [
+        `${initialOwner}:CNAME`,
+        buildSuccessResult(initialOwner, 'CNAME', [
+          makeAnswer(initialOwner, 'CNAME', terminalOwner, 120),
+        ]),
+      ],
+      [
+        `${terminalOwner}:TXT`,
+        buildSuccessResult(terminalOwner, 'TXT', [
+          makeAnswer(terminalOwner, 'TXT', txtRecord, 300),
+        ]),
+      ],
+    ]);
+
+    const collector = createCollectorWithMockedResolver(
+      {
+        tenantId: 'tenant-cname',
+        domain: 'example.com',
+        zoneManagement: 'unknown',
+        recordTypes: ['TXT'],
+        triggeredBy: 'test',
+        includeMailRecords: true,
+      },
+      db,
+      queryResults
+    );
+    const collection = await collector.collect();
+
+    expect(collection.resultState).toBe('complete');
+    const recordSets = rows('record_sets');
+    expect(recordSets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: initialOwner,
+          type: 'CNAME',
+          values: [terminalOwner],
+        }),
+        expect.objectContaining({
+          name: terminalOwner,
+          type: 'CNAME',
+          values: [],
+        }),
+        expect.objectContaining({
+          name: terminalOwner,
+          type: 'TXT',
+          values: [txtRecord],
+        }),
+      ])
+    );
+
+    const evidence = await loadPersistedMtaStsEvidence(db, {
+      domain: 'example.com',
+      tenantId: 'tenant-cname',
+    });
+    expect(evidence).toMatchObject({ ok: true, txtRecord, txtRecordId: '20260901' });
+    if (evidence.ok) {
+      expect(evidence.dnsResults).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ query: { name: initialOwner, type: 'CNAME' } }),
+          expect.objectContaining({ query: { name: terminalOwner, type: 'TXT' } }),
+        ])
+      );
     }
   });
 

--- a/apps/collector/src/e2e/probe-security.e2e.test.ts
+++ b/apps/collector/src/e2e/probe-security.e2e.test.ts
@@ -6,8 +6,8 @@
  *
  * These tests are designed to catch the class of issues found during the
  * PR-06 security review:
- *   1. IPv4-mapped IPv6 bypass (::ffff:127.0.0.1)
- *   2. Redirect-to-private bypass (fetch following 3xx to private IP)
+ *   1. IPv6 policy bypass (including mapped and site-local forms)
+ *   2. Redirect-to-private bypass (following 3xx to private IP)
  *   3. Concurrency/timeout not wired from env config
  *   4. Global semaphore not enforced across concurrent requests
  *
@@ -21,66 +21,41 @@ import { resetProbeSemaphore, Semaphore } from '../probes/semaphore.js';
 import { checkSSRF, validateUrl } from '../probes/ssrf-guard.js';
 
 // ---------------------------------------------------------------------------
-// PR-06.1 — SSRF Guard: IPv4-mapped IPv6 bypass
+// PR-06.1 — SSRF Guard: IPv6 targets fail closed
 // ---------------------------------------------------------------------------
 
-describe('PR-06.1 E2E: IPv4-mapped IPv6 SSRF bypass prevention', () => {
-  // Gap: the original checkIPv6 used prefix matching and caught ::ffff:* as
-  // "::/128 (unspecified)" with the wrong category. Public IPv4-mapped IPs
-  // were also incorrectly blocked. The fix extracts the embedded IPv4 and
-  // routes it through checkIPv4 for correct classification.
+describe('PR-06.1 E2E: IPv6 SSRF targets fail closed', () => {
+  // IPv6 policy is intentionally fail closed until a complete, maintained
+  // public-address policy exists. Mapped forms cannot bypass that boundary.
 
-  const PRIVATE_MAPPED = [
-    { addr: '::ffff:127.0.0.1', category: 'loopback', desc: 'loopback via mapped' },
-    { addr: '::ffff:10.0.0.1', category: 'private', desc: '10.x via mapped' },
-    { addr: '::ffff:192.168.1.1', category: 'private', desc: '192.168.x via mapped' },
-    { addr: '::ffff:172.16.0.1', category: 'private', desc: '172.16.x via mapped' },
-    { addr: '::ffff:172.31.255.255', category: 'private', desc: '172.31.x via mapped' },
-    { addr: '::ffff:169.254.169.254', category: 'link-local', desc: 'AWS metadata via mapped' },
-    { addr: '::ffff:0.0.0.0', category: 'reserved', desc: '0.0.0.0 via mapped' },
+  const IPV6_TARGETS = [
+    '::ffff:127.0.0.1',
+    '::ffff:10.0.0.1',
+    '::ffff:8.8.8.8',
+    '::ffff:7f00:0001',
+    'fec0::1',
+    '2001:db8::1',
   ] as const;
 
-  for (const { addr, category, desc } of PRIVATE_MAPPED) {
-    it(`blocks ${desc} (${addr})`, () => {
+  for (const addr of IPV6_TARGETS) {
+    it(`blocks IPv6 target ${addr}`, () => {
       const r = checkSSRF(addr);
       expect(r.allowed, `${addr} should be blocked`).toBe(false);
-      expect(r.blockedCategory, `${addr} wrong category`).toBe(category);
+      expect(r.blockedCategory, `${addr} wrong category`).toBe('reserved');
     });
   }
-
-  it('blocks ::ffff:7f00:0001 (hex form of 127.0.0.1) as loopback', () => {
-    const r = checkSSRF('::ffff:7f00:0001');
-    expect(r.allowed).toBe(false);
-    expect(r.blockedCategory).toBe('loopback');
-  });
-
-  it('blocks ::ffff:c0a8:0101 (hex form of 192.168.1.1) as private', () => {
-    const r = checkSSRF('::ffff:c0a8:0101');
-    expect(r.allowed).toBe(false);
-    expect(r.blockedCategory).toBe('private');
-  });
-
-  it('ALLOWS ::ffff:8.8.8.8 (Google DNS, public IPv4 in mapped form)', () => {
-    const r = checkSSRF('::ffff:8.8.8.8');
-    expect(r.allowed).toBe(true);
-  });
-
-  it('ALLOWS ::ffff:1.1.1.1 (Cloudflare DNS, public IPv4 in mapped form)', () => {
-    const r = checkSSRF('::ffff:1.1.1.1');
-    expect(r.allowed).toBe(true);
-  });
 
   it('validateUrl blocks https://[::ffff:127.0.0.1] (IPv6 URL syntax)', () => {
     // Browsers and curl accept bracketed IPv6 in URLs
     const r = validateUrl('https://[::ffff:127.0.0.1]/path');
     expect(r.allowed).toBe(false);
-    expect(r.blockedCategory).toBe('loopback');
+    expect(r.blockedCategory).toBe('reserved');
   });
 
   it('validateUrl blocks https://[::ffff:10.0.0.1]', () => {
     const r = validateUrl('https://[::ffff:10.0.0.1]');
     expect(r.allowed).toBe(false);
-    expect(r.blockedCategory).toBe('private');
+    expect(r.blockedCategory).toBe('reserved');
   });
 });
 
@@ -89,9 +64,8 @@ describe('PR-06.1 E2E: IPv4-mapped IPv6 SSRF bypass prevention', () => {
 // ---------------------------------------------------------------------------
 
 describe('PR-06.1 E2E: DNS rebinding risk documentation', () => {
-  // The SSRF guard checks the URL hostname at call time but cannot prevent a
-  // DNS server from returning different IPs on the second resolution (rebind).
-  // We document the residual risk and verify the mitigating checks work.
+  // The SSRF guard checks the URL hostname and each resolved address. Active
+  // transports pin the checked address before making a connection.
 
   it('blocks a private IP that a rebound hostname could resolve to (127.0.0.1)', () => {
     // After rebinding, the guard MUST block the resolved IP
@@ -111,10 +85,7 @@ describe('PR-06.1 E2E: DNS rebinding risk documentation', () => {
     expect(r.blockedCategory).toBe('link-local');
   });
 
-  // Note: Full DNS rebinding prevention requires a custom `lookup` callback
-  // in net.connect / tls.connect that resolves the hostname and passes the
-  // result through checkSSRF before connecting. That is a future hardening
-  // item documented in the security review (docs/security/probe-sandbox-review.md).
+  // SMTP, MTA-STS, and webhook transports use checked-address pinning.
 });
 
 // ---------------------------------------------------------------------------
@@ -122,11 +93,8 @@ describe('PR-06.1 E2E: DNS rebinding risk documentation', () => {
 // ---------------------------------------------------------------------------
 
 describe('PR-06.1 E2E: Redirect-to-private prevention in MTA-STS fetch', () => {
-  // Gap: fetch() follows redirects by default. Without redirect:'error', a
-  // server at mta-sts.attacker.com returning 301→http://127.0.0.1/exfil
-  // would be followed without SSRF checking the redirect target.
-  //
-  // Fix: mta-sts.ts now passes redirect:'error' to fetch().
+  // Native HTTPS transports do not follow redirects; MTA-STS and webhook
+  // delivery reject every 3xx response.
 
   it('validateUrl blocks redirect target http://127.0.0.1/exfil', () => {
     const r = validateUrl('http://127.0.0.1/exfil');
@@ -149,7 +117,7 @@ describe('PR-06.1 E2E: Redirect-to-private prevention in MTA-STS fetch', () => {
   it('validateUrl blocks redirect target http://[::ffff:127.0.0.1]/', () => {
     const r = validateUrl('http://[::ffff:127.0.0.1]/');
     expect(r.allowed).toBe(false);
-    expect(r.blockedCategory).toBe('loopback');
+    expect(r.blockedCategory).toBe('reserved');
   });
 
   it('validateUrl allows redirect to legitimate public URL', () => {
@@ -159,12 +127,11 @@ describe('PR-06.1 E2E: Redirect-to-private prevention in MTA-STS fetch', () => {
 });
 
 // ---------------------------------------------------------------------------
-// PR-06.1 E2E — fc00::/7 unique local full range (pre-existing prefix bug)
+// PR-06.1 E2E — unique local IPv6 targets fail closed
 // ---------------------------------------------------------------------------
 
-describe('PR-06.1 E2E: fc00::/7 unique local IPv6 full range', () => {
-  // Bug in pre-PR-06 code: prefix 'fc00:' only matched fc00::/12, not full /7.
-  // fc00::/7 = fc00:: through fdff::. Requires 'fc' and 'fd' prefixes.
+describe('PR-06.1 E2E: unique local IPv6 targets fail closed', () => {
+  // Every IPv6 target is rejected until a complete, maintained policy exists.
 
   const UNIQUE_LOCAL = [
     { addr: 'fc00::1', desc: 'fc00:: start' },
@@ -177,10 +144,10 @@ describe('PR-06.1 E2E: fc00::/7 unique local IPv6 full range', () => {
   ];
 
   for (const { addr, desc } of UNIQUE_LOCAL) {
-    it(`blocks ${desc} (${addr}) as private`, () => {
+    it(`blocks ${desc} (${addr}) as reserved`, () => {
       const r = checkSSRF(addr);
       expect(r.allowed, `${addr} should be blocked`).toBe(false);
-      expect(r.blockedCategory, `${addr} wrong category`).toBe('private');
+      expect(r.blockedCategory, `${addr} wrong category`).toBe('reserved');
     });
   }
 });
@@ -559,7 +526,7 @@ describe('PR-06 E2E: Defense-in-depth — both SSRF guard and allowlist enforced
 
     const r = simulateProbeRequest('::ffff:192.168.1.1', TENANT, 25);
     expect(r.blocked).toBe(true);
-    expect(r.reason).toContain('ssrf:private');
+    expect(r.reason).toContain('ssrf:reserved');
   });
 
   it('public hostname not in allowlist: blocked at allowlist layer', () => {

--- a/apps/collector/src/jobs/fleet-report.test.ts
+++ b/apps/collector/src/jobs/fleet-report.test.ts
@@ -93,6 +93,38 @@ describe('Fleet Report Routes', () => {
       expect(json.error).toContain('too large');
     });
 
+    it.each([
+      null,
+      42,
+      [],
+      {},
+      { domain: null },
+      { domain: 42 },
+      { domain: 'not a domain' },
+    ])('should return 400 for malformed inventory member %j', async (member) => {
+      const res = await app.request('/api/fleet-report/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inventory: [member] }),
+      });
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain('Invalid inventory entry');
+    });
+
+    it('should accept valid domain objects in inventory', async () => {
+      const res = await app.request('/api/fleet-report/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inventory: [{ domain: 'example.com' }] }),
+      });
+
+      expect([200, 500]).toContain(res.status);
+      const json = await res.json();
+      if (json.error) expect(json.error).not.toContain('Invalid inventory entry');
+    });
+
     it('should process valid inventory (DB context available)', async () => {
       // This test verifies that the DB context is properly available
       // The route successfully uses c.get('db') without crashing
@@ -391,29 +423,34 @@ describe('Fleet Report truth model (issue #65)', () => {
       : '';
   }
 
-  function getConditionParam(condition: unknown): unknown {
+  function getConditionParams(condition: unknown): unknown[] {
+    if (!condition || typeof condition !== 'object') return [];
     const sql = condition as {
       queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
     };
-    return sql.queryChunks?.find((c) => c?.constructor?.name === 'Param')?.value;
+    return (sql.queryChunks ?? []).flatMap((chunk) =>
+      chunk?.constructor?.name === 'Param' ? [chunk.value] : getConditionParams(chunk)
+    );
   }
 
   function createMockDb(data: MockData) {
     return {
       selectWhere: async (table: unknown, condition: unknown) => {
         const tableName = getTableName(table);
-        const param = getConditionParam(condition);
+        const params = getConditionParams(condition);
         if (tableName === 'domains') {
-          return data.domains.filter((d) => d.normalizedName === param || d.tenantId === param);
+          return data.domains.filter(
+            (d) => params.includes(d.normalizedName) && params.includes(d.tenantId)
+          );
         }
         if (tableName === 'snapshots') {
-          return data.snapshots.filter((s) => s.domainId === param);
+          return data.snapshots.filter((s) => params.includes(s.domainId));
         }
         if (tableName === 'findings') {
-          return data.findings.filter((f) => f.snapshotId === param);
+          return data.findings.filter((f) => params.includes(f.snapshotId));
         }
         if (tableName === 'observations') {
-          return data.observations.filter((o) => o.snapshotId === param);
+          return data.observations.filter((o) => params.includes(o.snapshotId));
         }
         return [];
       },

--- a/apps/collector/src/jobs/fleet-report.ts
+++ b/apps/collector/src/jobs/fleet-report.ts
@@ -42,7 +42,7 @@ fleetReportRoutes.post('/run', async (c) => {
     inventory = [],
     checks = ['spf', 'dmarc', 'mx', 'infrastructure'],
     format = 'detailed',
-  } = body;
+  } = body && typeof body === 'object' && !Array.isArray(body) ? body : {};
 
   if (!Array.isArray(inventory) || inventory.length === 0) {
     return c.json(
@@ -65,6 +65,17 @@ fleetReportRoutes.post('/run', async (c) => {
     );
   }
 
+  const inventoryDomains = inventory.map(inventoryItemDomain);
+  const invalidIndex = inventoryDomains.indexOf(undefined);
+  if (invalidIndex !== -1) {
+    return c.json(
+      {
+        error: `Invalid inventory entry at index ${invalidIndex}: expected a domain string or an object with a valid domain string`,
+      },
+      400
+    );
+  }
+
   // Tenant-scoped domain lookups
   const tenantId = c.get('tenantId');
   if (!tenantId) {
@@ -81,9 +92,7 @@ fleetReportRoutes.post('/run', async (c) => {
     const results: FleetReportResult[] = [];
     const errors: Array<{ domain: string; error: string }> = [];
 
-    for (const item of inventory) {
-      const domainName = typeof item === 'string' ? item : item.domain;
-
+    for (const domainName of inventoryDomains as string[]) {
       try {
         // Find domain scoped to tenant
         const domain = await domainRepo.findByNameForTenant(domainName, tenantId);
@@ -291,6 +300,18 @@ fleetReportRoutes.get('/templates', (c) => {
 // =============================================================================
 // Helper Types & Functions
 // =============================================================================
+
+function inventoryItemDomain(item: unknown): string | undefined {
+  const domain =
+    typeof item === 'string'
+      ? item
+      : item && typeof item === 'object' && !Array.isArray(item)
+        ? (item as { domain?: unknown }).domain
+        : undefined;
+
+  if (typeof domain !== 'string' || !isValidDomain(domain)) return undefined;
+  return domain.trim();
+}
 
 interface FleetReportResult {
   domain: string;

--- a/apps/collector/src/jobs/monitoring.test.ts
+++ b/apps/collector/src/jobs/monitoring.test.ts
@@ -8,12 +8,15 @@
 
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installWebhookTransportMock } from '../notifications/webhook.test-support.js';
 import type { Env } from '../types.js';
 import { monitoringRoutes } from './monitoring.js';
 
-// Mock fetch for webhook tests
+const mockHttpsRequest = vi.hoisted(() => vi.fn());
+vi.mock('node:https', () => ({ request: mockHttpsRequest }));
+
+// Request-plan spy for the native HTTPS webhook fixture.
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
 
 // Mock DNS so resolveAndCheck() doesn't hit the network and hang
 vi.mock('node:dns', () => ({
@@ -31,6 +34,9 @@ const NORMALIZED_TENANT_ID = '197364d6-0eda-54c5-bcda-3702507a5221';
 const originalEnv = process.env;
 beforeEach(() => {
   process.env = { ...originalEnv, INTERNAL_SECRET: 'test-internal-secret' };
+  mockFetch.mockReset();
+  mockHttpsRequest.mockReset();
+  installWebhookTransportMock(mockHttpsRequest, mockFetch);
 });
 afterEach(() => {
   process.env = originalEnv;

--- a/apps/collector/src/jobs/probe-routes.authorization.test.ts
+++ b/apps/collector/src/jobs/probe-routes.authorization.test.ts
@@ -20,6 +20,7 @@ import {
   probeMXHosts,
   probeSMTPStarttls,
 } from '../probes/index.js';
+import { getProbeSemaphore, resetProbeSemaphore } from '../probes/semaphore.js';
 import type { Env } from '../types.js';
 import { probeRoutes } from './probe-routes.js';
 
@@ -57,11 +58,29 @@ function getTableName(table: unknown): string {
   return '';
 }
 
-function getConditionParam(condition: unknown): unknown {
-  const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+function getConditionParams(condition: unknown): unknown[] {
+  const values: unknown[] = [];
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== 'object') return;
+    const record = value as {
+      constructor?: { name?: string };
+      queryChunks?: unknown[];
+      value?: unknown;
+    };
+    if (record.constructor?.name === 'Param') {
+      values.push(record.value);
+      return;
+    }
+    for (const chunk of record.queryChunks ?? []) visit(chunk);
   };
-  return sql.queryChunks?.find((c) => c?.constructor?.name === 'Param')?.value;
+  visit(condition);
+  return values;
+}
+
+function matches(row: Row, condition: unknown): boolean {
+  return getConditionParams(condition).every((value) =>
+    Object.values(row).some((field) => field === value)
+  );
 }
 
 function createMockDb(state: Record<string, Row[]>): IDatabaseAdapter {
@@ -70,14 +89,10 @@ function createMockDb(state: Record<string, Row[]>): IDatabaseAdapter {
     type: 'postgres',
     getDrizzle: () => undefined,
     select: async (table: unknown) => [...rows(getTableName(table))],
-    selectWhere: async (table: unknown, condition: unknown) => {
-      const param = getConditionParam(condition);
-      return rows(getTableName(table)).filter((r) => Object.values(r).some((v) => v === param));
-    },
-    selectOne: async (table: unknown, condition: unknown) => {
-      const param = getConditionParam(condition);
-      return rows(getTableName(table)).find((r) => Object.values(r).some((v) => v === param));
-    },
+    selectWhere: async (table: unknown, condition: unknown) =>
+      rows(getTableName(table)).filter((row) => matches(row, condition)),
+    selectOne: async (table: unknown, condition: unknown) =>
+      rows(getTableName(table)).find((row) => matches(row, condition)),
     insert: async () => ({}),
     insertMany: async () => [],
     update: async () => [],
@@ -260,6 +275,7 @@ const mockedProbeSMTPStarttls = vi.mocked(probeSMTPStarttls);
 const mockedProbeMXHosts = vi.mocked(probeMXHosts);
 
 beforeEach(() => {
+  resetProbeSemaphore(5);
   vi.clearAllMocks();
   process.env.ENABLE_ACTIVE_PROBES = 'true';
   probeAllowlistManager.clearAll();
@@ -288,6 +304,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
+  resetProbeSemaphore(5);
   probeAllowlistManager.clearAll();
 });
 
@@ -572,6 +590,72 @@ describe('Issue #67: probe authorization requires persisted DNS evidence', () =>
   });
 
   describe('stale evidence fails closed', () => {
+    it('does not fetch MTA-STS after semaphore wait crosses evidence expiry', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-09-01T00:00:00.000Z'));
+      resetProbeSemaphore(1);
+
+      let release!: () => void;
+      const holder = getProbeSemaphore().run(
+        () =>
+          new Promise<void>((resolve) => {
+            release = resolve;
+          })
+      );
+      const request = post(
+        createMockApp(evidenceState({ txtTtl: 0.1, queriedOffsetMs: 0 })),
+        '/mta-sts',
+        { domain: 'example.com' }
+      );
+
+      for (let i = 0; i < 200 && getProbeSemaphore().queued === 0; i++) {
+        await Promise.resolve();
+      }
+      expect(getProbeSemaphore().queued).toBe(1);
+
+      vi.advanceTimersByTime(101);
+      release();
+      await holder;
+      const response = await request;
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({ reason: 'stale-evidence' });
+      expect(mockedFetchMTASTSPolicy).not.toHaveBeenCalled();
+    });
+
+    it('does not start an SMTP probe after semaphore wait crosses evidence expiry', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-09-01T00:00:00.000Z'));
+      resetProbeSemaphore(1);
+
+      let release!: () => void;
+      const holder = getProbeSemaphore().run(
+        () =>
+          new Promise<void>((resolve) => {
+            release = resolve;
+          })
+      );
+      const request = post(
+        createMockApp(evidenceState({ mxTtl: 0.1, queriedOffsetMs: 0 })),
+        '/smtp-starttls',
+        { domain: 'example.com', hostname: 'mail.example.com' }
+      );
+
+      for (let i = 0; i < 200 && getProbeSemaphore().queued === 0; i++) {
+        await Promise.resolve();
+      }
+      expect(getProbeSemaphore().queued).toBe(1);
+
+      vi.advanceTimersByTime(101);
+      release();
+      await holder;
+      const response = await request;
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({ reason: 'stale-evidence' });
+      expect(mockedProbeSMTPStarttls).not.toHaveBeenCalled();
+    });
+
     it('rejects evidence older than the five-minute ceiling', async () => {
       const app = createMockApp(evidenceState({ queriedOffsetMs: 400_000 }));
       const res = await post(app, '/smtp-starttls', { domain: 'example.com' });

--- a/apps/collector/src/jobs/probe-routes.authorization.test.ts
+++ b/apps/collector/src/jobs/probe-routes.authorization.test.ts
@@ -353,6 +353,33 @@ describe('Issue #67: probe authorization requires persisted DNS evidence', () =>
       expect(json.reason).toBe('caller-supplied-dns-evidence');
       expect(tenantAllowlistCount()).toBe(0);
     });
+
+    it.each([
+      ['/mta-sts', { domain: 'example.com', mxRecords: ['10 mail.example.com.'] }],
+      ['/mta-sts', { domain: 'example.com', dnsResults: [] }],
+      [
+        '/smtp-starttls',
+        {
+          domain: 'example.com',
+          hostname: 'mail.example.com',
+          txtRecords: ['v=STSv1; id=20260831'],
+        },
+      ],
+      ['/smtp-starttls', { domain: 'example.com', dnsResults: [] }],
+      ['/allowlist/generate', { domain: 'example.com', txtRecords: ['v=STSv1; id=20260831'] }],
+      ['/allowlist/generate', { domain: 'example.com', mxRecords: ['10 mail.example.com.'] }],
+    ])('rejects DNS-shaped fields irrelevant to the route %s (cross-field rejection)', async (path, body) => {
+      const app = createApp(createMockDb(evidenceState()));
+      const res = await post(app, path, body);
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('caller-supplied-dns-evidence');
+      expect(mockedFetchMTASTSPolicy).not.toHaveBeenCalled();
+      expect(mockedProbeSMTPStarttls).not.toHaveBeenCalled();
+      expect(mockedProbeMXHosts).not.toHaveBeenCalled();
+      expect(tenantAllowlistCount()).toBe(0);
+    });
   });
 
   describe('fresh persisted evidence authorizes (no network)', () => {
@@ -407,6 +434,28 @@ describe('Issue #67: probe authorization requires persisted DNS evidence', () =>
       );
       const json = await res.json();
       expect(json.summary.total).toBe(1);
+    });
+
+    it('/smtp-starttls allowlists mixed-case persisted MX data canonically', async () => {
+      const state = evidenceState({
+        mxAnswerSection: [
+          { name: 'example.com', type: 'MX', ttl: 3600, data: '10 MAIL.EXAMPLE.COM.' },
+        ],
+      });
+      const app = createMockApp(state);
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(200);
+      expect(mockedProbeMXHosts).toHaveBeenCalledWith(
+        [{ hostname: 'mail.example.com', priority: 10 }],
+        TENANT_A,
+        expect.anything()
+      );
+      // The allowlist entry derived from the raw mixed-case answer must
+      // match the normalized probe target.
+      expect(
+        probeAllowlistManager.getTenantAllowlist(TENANT_A).isAllowed('mail.example.com', 25)
+      ).toBe(true);
     });
 
     it('/allowlist/generate derives entries from persisted evidence only', async () => {

--- a/apps/collector/src/jobs/probe-routes.authorization.test.ts
+++ b/apps/collector/src/jobs/probe-routes.authorization.test.ts
@@ -1,0 +1,661 @@
+/**
+ * Probe Route Authorization Tests - Issue #67
+ *
+ * Proves that probe authorization requires fresh, persisted, tenant-owned DNS
+ * evidence from the collector's domain → snapshot → record-set →
+ * source-observation chain. Caller-supplied DNS arrays (txtRecords, mxRecords,
+ * dnsResults), mock/probe vantage provenance, stale TTLs, and cross-tenant
+ * access must all fail closed without invoking probe functions.
+ *
+ * The existing probe functions are mocked at the module boundary so no socket,
+ * fetch, or DNS call ever occurs.
+ */
+
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import { Hono } from 'hono';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchMTASTSPolicy,
+  probeAllowlistManager,
+  probeMXHosts,
+  probeSMTPStarttls,
+} from '../probes/index.js';
+import type { Env } from '../types.js';
+import { probeRoutes } from './probe-routes.js';
+
+vi.mock('../probes/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../probes/index.js')>();
+  return {
+    ...actual,
+    fetchMTASTSPolicy: vi.fn(),
+    probeMXHosts: vi.fn(),
+    probeSMTPStarttls: vi.fn(),
+  };
+});
+
+const TENANT_A = 'tenant-a';
+const TENANT_B = 'tenant-b';
+const ORIGINAL_ENABLE_ACTIVE_PROBES = process.env.ENABLE_ACTIVE_PROBES;
+
+// =============================================================================
+// Mock DB (in-memory, Drizzle table-name aware) — same approach as
+// monitoring.test.ts / packages/testkit mock-db, kept local to avoid a new dep.
+// =============================================================================
+
+type Row = Record<string, unknown>;
+
+function getTableName(table: unknown): string {
+  if (!table || typeof table !== 'object') return '';
+  const record = table as Record<symbol | string, unknown>;
+  const symbolName = Symbol.for('drizzle:Name');
+  if (typeof record[symbolName] === 'string') return record[symbolName] as string;
+  const symbols = Object.getOwnPropertySymbols(record);
+  const drizzleName = symbols.find((s) => String(s) === 'Symbol(drizzle:Name)');
+  if (drizzleName && typeof record[drizzleName] === 'string') {
+    return record[drizzleName] as string;
+  }
+  return '';
+}
+
+function getConditionParam(condition: unknown): unknown {
+  const sql = condition as {
+    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+  };
+  return sql.queryChunks?.find((c) => c?.constructor?.name === 'Param')?.value;
+}
+
+function createMockDb(state: Record<string, Row[]>): IDatabaseAdapter {
+  const rows = (name: string): Row[] => state[name] ?? [];
+  return {
+    type: 'postgres',
+    getDrizzle: () => undefined,
+    select: async (table: unknown) => [...rows(getTableName(table))],
+    selectWhere: async (table: unknown, condition: unknown) => {
+      const param = getConditionParam(condition);
+      return rows(getTableName(table)).filter((r) => Object.values(r).some((v) => v === param));
+    },
+    selectOne: async (table: unknown, condition: unknown) => {
+      const param = getConditionParam(condition);
+      return rows(getTableName(table)).find((r) => Object.values(r).some((v) => v === param));
+    },
+    insert: async () => ({}),
+    insertMany: async () => [],
+    update: async () => [],
+    updateOne: async () => undefined,
+    delete: async () => 0,
+    transaction: async () => undefined,
+  } as unknown as IDatabaseAdapter;
+}
+
+// =============================================================================
+// Persisted evidence fixture: valid fresh collector chain for example.com
+// =============================================================================
+
+interface EvidenceOptions {
+  tenantId?: string;
+  snapshotState?: string;
+  includeMx?: boolean;
+  includeMtaSts?: boolean;
+  mxConsistent?: boolean;
+  txtConsistent?: boolean;
+  mxSourceIds?: string[];
+  txtSourceIds?: string[];
+  mxTtl?: number;
+  txtTtl?: number;
+  queriedOffsetMs?: number;
+  futureDated?: boolean;
+  mxVantageIdentifier?: string | null;
+  mxVantageType?: string;
+  mxStatus?: string;
+  mxResponseCode?: number;
+  mxFlags?: Record<string, boolean> | null;
+  mxAnswerSection?: Row[];
+}
+
+function evidenceState(overrides: EvidenceOptions = {}): Record<string, Row[]> {
+  const now = Date.now();
+  const o: Required<Omit<EvidenceOptions, 'mxAnswerSection'>> &
+    Pick<EvidenceOptions, 'mxAnswerSection'> = {
+    tenantId: TENANT_A,
+    snapshotState: 'complete',
+    includeMx: true,
+    includeMtaSts: true,
+    mxConsistent: true,
+    txtConsistent: true,
+    mxSourceIds: ['obs-mx'],
+    txtSourceIds: ['obs-txt'],
+    mxTtl: 3600,
+    txtTtl: 3600,
+    queriedOffsetMs: 60_000,
+    futureDated: false,
+    mxVantageIdentifier: '1.1.1.1',
+    mxVantageType: 'public-recursive',
+    mxStatus: 'success',
+    mxResponseCode: 0,
+    mxFlags: null,
+    ...overrides,
+  };
+  const queriedAt = o.futureDated ? new Date(now + 60_000) : new Date(now - o.queriedOffsetMs);
+
+  const recordSets: Row[] = [];
+  const observations: Row[] = [];
+
+  if (o.includeMx) {
+    recordSets.push({
+      id: 'rs-mx',
+      snapshotId: 'snap-1',
+      name: 'example.com',
+      type: 'MX',
+      ttl: o.mxTtl,
+      values: ['10 mail.example.com.'],
+      sourceObservationIds: o.mxSourceIds,
+      sourceVantages: ['1.1.1.1'],
+      isConsistent: o.mxConsistent,
+      createdAt: queriedAt,
+    });
+    observations.push({
+      id: 'obs-mx',
+      snapshotId: 'snap-1',
+      queryName: 'example.com',
+      queryType: 'MX',
+      vantageType: o.mxVantageType,
+      vantageIdentifier: o.mxVantageIdentifier,
+      status: o.mxStatus,
+      queriedAt,
+      responseTimeMs: 20,
+      responseCode: o.mxResponseCode,
+      flags: o.mxFlags,
+      answerSection:
+        o.mxAnswerSection === undefined
+          ? [{ name: 'example.com', type: 'MX', ttl: o.mxTtl, data: '10 mail.example.com.' }]
+          : o.mxAnswerSection,
+    });
+  }
+
+  if (o.includeMtaSts) {
+    recordSets.push({
+      id: 'rs-txt',
+      snapshotId: 'snap-1',
+      name: '_mta-sts.example.com',
+      type: 'TXT',
+      ttl: o.txtTtl,
+      values: ['v=STSv1; id=20260831'],
+      sourceObservationIds: o.txtSourceIds,
+      sourceVantages: ['1.1.1.1'],
+      isConsistent: o.txtConsistent,
+      createdAt: queriedAt,
+    });
+    observations.push({
+      id: 'obs-txt',
+      snapshotId: 'snap-1',
+      queryName: '_mta-sts.example.com',
+      queryType: 'TXT',
+      vantageType: 'public-recursive',
+      vantageIdentifier: '1.1.1.1',
+      status: 'success',
+      queriedAt,
+      responseTimeMs: 20,
+      responseCode: 0,
+      flags: null,
+      answerSection: [
+        { name: '_mta-sts.example.com', type: 'TXT', ttl: o.txtTtl, data: 'v=STSv1; id=20260831' },
+      ],
+    });
+  }
+
+  return {
+    domains: [
+      {
+        id: 'dom-1',
+        name: 'example.com',
+        normalizedName: 'example.com',
+        tenantId: o.tenantId,
+        createdAt: new Date(now - 86_400_000),
+        updatedAt: new Date(now - 86_400_000),
+      },
+    ],
+    snapshots: [
+      {
+        id: 'snap-1',
+        domainId: 'dom-1',
+        resultState: o.snapshotState,
+        createdAt: new Date(now - 120_000),
+        observationCount: observations.length,
+      },
+    ],
+    record_sets: recordSets,
+    observations,
+  };
+}
+
+// =============================================================================
+// App/request helpers
+// =============================================================================
+
+function createApp(db: IDatabaseAdapter | undefined, tenantId: string = TENANT_A): Hono<Env> {
+  const app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    if (db) c.set('db', db);
+    c.set('tenantId', tenantId);
+    await next();
+  });
+  app.route('/api/probe', probeRoutes);
+  return app;
+}
+
+function post(app: Hono<Env>, path: string, body: unknown): Promise<Response> {
+  return app.request(`/api/probe${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function tenantAllowlistCount(): number {
+  return probeAllowlistManager.getTenantAllowlist(TENANT_A).getAllEntries().length;
+}
+
+const mockedFetchMTASTSPolicy = vi.mocked(fetchMTASTSPolicy);
+const mockedProbeSMTPStarttls = vi.mocked(probeSMTPStarttls);
+const mockedProbeMXHosts = vi.mocked(probeMXHosts);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.ENABLE_ACTIVE_PROBES = 'true';
+  probeAllowlistManager.clearAll();
+  mockedFetchMTASTSPolicy.mockResolvedValue({
+    success: true,
+    domain: 'example.com',
+    policyUrl: 'https://mta-sts.example.com/.well-known/mta-sts.txt',
+    responseTimeMs: 1,
+  });
+  mockedProbeSMTPStarttls.mockResolvedValue({
+    success: true,
+    hostname: 'mail.example.com',
+    port: 25,
+    supportsStarttls: true,
+    responseTimeMs: 1,
+  });
+  mockedProbeMXHosts.mockResolvedValue([
+    {
+      success: true,
+      hostname: 'mail.example.com',
+      port: 25,
+      supportsStarttls: true,
+      responseTimeMs: 1,
+    },
+  ]);
+});
+
+afterEach(() => {
+  probeAllowlistManager.clearAll();
+});
+
+afterAll(() => {
+  if (ORIGINAL_ENABLE_ACTIVE_PROBES === undefined) {
+    delete process.env.ENABLE_ACTIVE_PROBES;
+  } else {
+    process.env.ENABLE_ACTIVE_PROBES = ORIGINAL_ENABLE_ACTIVE_PROBES;
+  }
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Issue #67: probe authorization requires persisted DNS evidence', () => {
+  describe('caller-supplied DNS evidence never authorizes', () => {
+    it('rejects txtRecords on /mta-sts even when valid persisted evidence exists', async () => {
+      const app = createApp(createMockDb(evidenceState()));
+      const res = await post(app, '/mta-sts', {
+        domain: 'example.com',
+        txtRecords: ['v=STSv1; id=20260831'],
+      });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('caller-supplied-dns-evidence');
+      expect(mockedFetchMTASTSPolicy).not.toHaveBeenCalled();
+      expect(tenantAllowlistCount()).toBe(0);
+    });
+
+    it('rejects mxRecords on /smtp-starttls and does not probe', async () => {
+      const app = createApp(createMockDb(evidenceState()));
+      const res = await post(app, '/smtp-starttls', {
+        hostname: 'mail.example.com',
+        mxRecords: ['10 mail.example.com.'],
+      });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('caller-supplied-dns-evidence');
+      expect(mockedProbeSMTPStarttls).not.toHaveBeenCalled();
+      expect(mockedProbeMXHosts).not.toHaveBeenCalled();
+      expect(tenantAllowlistCount()).toBe(0);
+    });
+
+    it('rejects dnsResults on /allowlist/generate and leaves the allowlist empty', async () => {
+      const app = createApp(createMockDb(evidenceState()));
+      const res = await post(app, '/allowlist/generate', {
+        domain: 'example.com',
+        dnsResults: [
+          {
+            query: { name: 'example.com', type: 'MX' },
+            vantage: { type: 'public-recursive', identifier: 'mock' },
+            success: true,
+            answers: [{ name: 'example.com', type: 'MX', ttl: 300, data: '10 evil.example.com.' }],
+          },
+        ],
+      });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('caller-supplied-dns-evidence');
+      expect(tenantAllowlistCount()).toBe(0);
+    });
+  });
+
+  describe('fresh persisted evidence authorizes (no network)', () => {
+    it('/mta-sts probes the persisted policy host with allowlist checks enabled', async () => {
+      const app = createApp(createMockDb(evidenceState()));
+      const res = await post(app, '/mta-sts', { domain: 'example.com' });
+
+      expect(res.status).toBe(200);
+      expect(mockedFetchMTASTSPolicy).toHaveBeenCalledTimes(1);
+      expect(mockedFetchMTASTSPolicy).toHaveBeenCalledWith(
+        'example.com',
+        TENANT_A,
+        expect.objectContaining({ checkAllowlist: true })
+      );
+      const json = await res.json();
+      expect(json.domain).toBe('example.com');
+      expect(json.txtRecordId).toBe('20260831');
+      expect(
+        probeAllowlistManager.getTenantAllowlist(TENANT_A).isAllowed('mta-sts.example.com', 443)
+      ).toBe(true);
+    });
+
+    it('/smtp-starttls probes a persisted MX target on port 25', async () => {
+      const app = createApp(createMockDb(evidenceState()));
+      const res = await post(app, '/smtp-starttls', {
+        domain: 'example.com',
+        hostname: 'MAIL.EXAMPLE.COM.',
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockedProbeSMTPStarttls).toHaveBeenCalledTimes(1);
+      expect(mockedProbeSMTPStarttls).toHaveBeenCalledWith(
+        'mail.example.com',
+        TENANT_A,
+        expect.objectContaining({ port: 25, checkAllowlist: true })
+      );
+      expect(
+        probeAllowlistManager.getTenantAllowlist(TENANT_A).isAllowed('mail.example.com', 25)
+      ).toBe(true);
+    });
+
+    it('/smtp-starttls batch probes exactly the persisted MX hosts', async () => {
+      const app = createApp(createMockDb(evidenceState()));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(200);
+      expect(mockedProbeMXHosts).toHaveBeenCalledTimes(1);
+      expect(mockedProbeMXHosts).toHaveBeenCalledWith(
+        [{ hostname: 'mail.example.com', priority: 10 }],
+        TENANT_A,
+        expect.objectContaining({ timeoutMs: expect.any(Number) })
+      );
+      const json = await res.json();
+      expect(json.summary.total).toBe(1);
+    });
+
+    it('/allowlist/generate derives entries from persisted evidence only', async () => {
+      const app = createApp(createMockDb(evidenceState()));
+      const res = await post(app, '/allowlist/generate', { domain: 'example.com' });
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.entriesAdded).toBe(json.entries.length);
+      expect(json.entriesAdded).toBeGreaterThanOrEqual(2);
+      expect(
+        probeAllowlistManager.getTenantAllowlist(TENANT_A).isAllowed('mail.example.com', 25)
+      ).toBe(true);
+      expect(
+        probeAllowlistManager.getTenantAllowlist(TENANT_A).isAllowed('mta-sts.example.com', 443)
+      ).toBe(true);
+    });
+  });
+
+  describe('unattached observations do not authorize', () => {
+    it('rejects a record set with no source observation links', async () => {
+      const state = evidenceState({ mxSourceIds: [], txtSourceIds: [] });
+      const app = createApp(createMockDb(state));
+      const res = await post(app, '/mta-sts', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('missing-source-observations');
+      expect(mockedFetchMTASTSPolicy).not.toHaveBeenCalled();
+      expect(tenantAllowlistCount()).toBe(0);
+    });
+
+    it('rejects a source observation id that cannot be resolved', async () => {
+      const state = evidenceState({ txtSourceIds: ['obs-ghost'] });
+      const app = createMockApp(state);
+      const res = await post(app, '/mta-sts', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('missing-source-observation');
+      expect(mockedFetchMTASTSPolicy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tenant ownership', () => {
+    it('rejects a domain owned by another tenant', async () => {
+      const app = createApp(createMockDb(evidenceState({ tenantId: TENANT_B })), TENANT_A);
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('unknown-domain');
+      expect(mockedProbeMXHosts).not.toHaveBeenCalled();
+      expect(tenantAllowlistCount()).toBe(0);
+    });
+  });
+
+  describe('missing evidence fails closed', () => {
+    it('rejects an unregistered domain', async () => {
+      const app = createApp(createMockDb({}));
+      const res = await post(app, '/mta-sts', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('unknown-domain');
+      expect(mockedFetchMTASTSPolicy).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-complete snapshot', async () => {
+      const app = createMockApp(evidenceState({ snapshotState: 'partial' }));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('incomplete-snapshot');
+      expect(mockedProbeMXHosts).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing MX record set', async () => {
+      const app = createMockApp(evidenceState({ includeMx: false }));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('missing-record-set');
+      expect(mockedProbeMXHosts).not.toHaveBeenCalled();
+    });
+
+    it('rejects a successful observation with no answers', async () => {
+      const app = createMockApp(evidenceState({ mxAnswerSection: [] }));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('missing-answer');
+      expect(mockedProbeMXHosts).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing domain parameter', async () => {
+      const app = createMockApp(evidenceState());
+      const res = await post(app, '/mta-sts', {});
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an invalid domain value', async () => {
+      const app = createMockApp(evidenceState());
+      const res = await post(app, '/mta-sts', { domain: 'not a domain' });
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.reason).toBe('invalid-domain');
+    });
+  });
+
+  describe('stale evidence fails closed', () => {
+    it('rejects evidence older than the five-minute ceiling', async () => {
+      const app = createMockApp(evidenceState({ queriedOffsetMs: 400_000 }));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('stale-evidence');
+      expect(mockedProbeMXHosts).not.toHaveBeenCalled();
+      expect(tenantAllowlistCount()).toBe(0);
+    });
+
+    it('rejects zero-TTL answers', async () => {
+      const app = createMockApp(evidenceState({ mxTtl: 0 }));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('stale-evidence');
+    });
+
+    it('rejects future-dated observations', async () => {
+      const app = createMockApp(evidenceState({ futureDated: true }));
+      const res = await post(app, '/mta-sts', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('stale-evidence');
+      expect(mockedFetchMTASTSPolicy).not.toHaveBeenCalled();
+    });
+
+    it('treats the exact expiry boundary as stale', async () => {
+      const app = createMockApp(evidenceState({ queriedOffsetMs: 300_000 }));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('stale-evidence');
+    });
+
+    it('honors a shorter answer TTL below the ceiling', async () => {
+      const fresh = createMockApp(evidenceState({ mxTtl: 60, queriedOffsetMs: 10_000 }));
+      const resFresh = await post(fresh, '/smtp-starttls', { domain: 'example.com' });
+      expect(resFresh.status).toBe(200);
+
+      const expired = createMockApp(evidenceState({ mxTtl: 60, queriedOffsetMs: 61_000 }));
+      const resExpired = await post(expired, '/smtp-starttls', { domain: 'example.com' });
+      expect(resExpired.status).toBe(403);
+      const json = await resExpired.json();
+      expect(json.reason).toBe('stale-evidence');
+    });
+  });
+
+  describe('untrusted provenance fails closed', () => {
+    it.each([
+      ['mock vantage identifier', { mxVantageIdentifier: 'mock' }],
+      ['missing vantage identifier', { mxVantageIdentifier: null }],
+      ['probe vantage type', { mxVantageType: 'probe' }],
+      ['failed observation status', { mxStatus: 'error' }],
+      ['non-NOERROR response code', { mxResponseCode: 2 }],
+      ['inconsistent record set', { mxConsistent: false }],
+    ])('rejects %s', async (_label, overrides) => {
+      const app = createMockApp(evidenceState(overrides));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      expect(mockedProbeMXHosts).not.toHaveBeenCalled();
+      expect(mockedProbeSMTPStarttls).not.toHaveBeenCalled();
+      expect(tenantAllowlistCount()).toBe(0);
+    });
+
+    it('rejects authoritative vantage data without the AA flag', async () => {
+      const app = createMockApp(evidenceState({ mxVantageType: 'authoritative', mxFlags: null }));
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('authoritative-answer-flag-missing');
+    });
+
+    it('accepts authoritative vantage data carrying the AA flag', async () => {
+      const app = createMockApp(
+        evidenceState({ mxVantageType: 'authoritative', mxFlags: { authoritative: true } })
+      );
+      const res = await post(app, '/smtp-starttls', { domain: 'example.com' });
+
+      expect(res.status).toBe(200);
+      expect(mockedProbeMXHosts).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('targets cannot be overridden by the caller', () => {
+    it('rejects a hostname that is not a persisted MX target', async () => {
+      const app = createMockApp(evidenceState());
+      const res = await post(app, '/smtp-starttls', {
+        domain: 'example.com',
+        hostname: 'evil.example.com',
+      });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('hostname-not-in-evidence');
+      expect(mockedProbeSMTPStarttls).not.toHaveBeenCalled();
+      expect(tenantAllowlistCount()).toBe(0);
+    });
+
+    it('rejects ports other than 25', async () => {
+      const app = createMockApp(evidenceState());
+      const res = await post(app, '/smtp-starttls', {
+        domain: 'example.com',
+        hostname: 'mail.example.com',
+        port: 587,
+      });
+
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.reason).toBe('port-not-permitted');
+      expect(mockedProbeSMTPStarttls).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('missing database fails closed', () => {
+    it('returns 503 when no database is bound to the request context', async () => {
+      const app = createApp(undefined);
+      const res = await post(app, '/mta-sts', { domain: 'example.com' });
+
+      expect(res.status).toBe(503);
+      const json = await res.json();
+      expect(json.reason).toBe('database-unavailable');
+      expect(mockedFetchMTASTSPolicy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+function createMockApp(state: Record<string, Row[]>, tenantId: string = TENANT_A): Hono<Env> {
+  return createApp(createMockDb(state), tenantId);
+}

--- a/apps/collector/src/jobs/probe-routes.ts
+++ b/apps/collector/src/jobs/probe-routes.ts
@@ -33,7 +33,7 @@
 import { normalizeDNSDomain } from '@dns-ops/parsing';
 import { Hono } from 'hono';
 import { getEnvConfig } from '../config/env.js';
-import type { AllowlistEntry } from '../probes/allowlist.js';
+import { type AllowlistEntry, isExpiryFresh } from '../probes/allowlist.js';
 import {
   fetchMTASTSPolicy,
   probeAllowlistManager,
@@ -169,16 +169,23 @@ probeRoutes.post('/mta-sts', async (c) => {
   // Allowlist entries are derived only from the persisted evidence.
   probeAllowlistManager
     .getTenantAllowlist(tenantId)
-    .generateFromDnsResults(evidence.domain, evidence.dnsResults);
+    .generateFromDnsResults(evidence.domain, evidence.dnsResults, evidence.expiresAt);
 
-  // Fetch policy — run under global semaphore to enforce PROBE_CONCURRENCY
+  // Fetch policy — run under global semaphore to enforce PROBE_CONCURRENCY.
+  // The evidence may expire while waiting for a permit, so the check must
+  // happen inside the semaphore callback immediately before the fetch starts.
   const config = getEnvConfig();
-  const result = await getProbeSemaphore().run(() =>
-    fetchMTASTSPolicy(evidence.domain, tenantId, {
+  const result = await getProbeSemaphore().run(async () => {
+    if (!isExpiryFresh(evidence.expiresAt)) return null;
+    return fetchMTASTSPolicy(evidence.domain, tenantId, {
       timeoutMs: config.probes.timeoutMs,
       checkAllowlist: true,
-    })
-  );
+      expiresAt: evidence.expiresAt,
+    });
+  });
+  if (!result) {
+    return c.json({ error: 'Persisted DNS evidence is stale', reason: 'stale-evidence' }, 403);
+  }
 
   return c.json({
     ...result,
@@ -257,28 +264,41 @@ probeRoutes.post('/smtp-starttls', async (c) => {
     // only once the request is fully authorized.
     probeAllowlistManager
       .getTenantAllowlist(tenantId)
-      .generateFromDnsResults(evidence.domain, evidence.dnsResults);
+      .generateFromDnsResults(evidence.domain, evidence.dnsResults, evidence.expiresAt);
 
-    // Run under global semaphore to enforce PROBE_CONCURRENCY
-    const result = await getProbeSemaphore().run(() =>
-      probeSMTPStarttls(target.hostname, tenantId, {
+    // Run under global semaphore to enforce PROBE_CONCURRENCY. Recheck after
+    // semaphore acquisition so delayed work cannot start with stale evidence.
+    const result = await getProbeSemaphore().run(async () => {
+      if (!isExpiryFresh(evidence.expiresAt)) return null;
+      return probeSMTPStarttls(target.hostname, tenantId, {
         port: 25,
         timeoutMs: config.probes.timeoutMs,
         checkAllowlist: true,
-      })
-    );
+        expiresAt: evidence.expiresAt,
+      });
+    });
+    if (!result) {
+      return c.json({ error: 'Persisted DNS evidence is stale', reason: 'stale-evidence' }, 403);
+    }
 
     return c.json(result);
   }
 
-  // Batch probe of every persisted MX target
+  // Batch probe of every persisted MX target. Check immediately before
+  // handing the targets to the probe runner; it also rechecks per host so
+  // later batches cannot start after the shared evidence expiry.
   probeAllowlistManager
     .getTenantAllowlist(tenantId)
-    .generateFromDnsResults(evidence.domain, evidence.dnsResults);
+    .generateFromDnsResults(evidence.domain, evidence.dnsResults, evidence.expiresAt);
+
+  if (!isExpiryFresh(evidence.expiresAt)) {
+    return c.json({ error: 'Persisted DNS evidence is stale', reason: 'stale-evidence' }, 403);
+  }
 
   const results = await probeMXHosts(evidence.hosts, tenantId, {
     timeoutMs: config.probes.timeoutMs,
     concurrency: config.probes.concurrency,
+    expiresAt: evidence.expiresAt,
   });
 
   return c.json({
@@ -328,10 +348,12 @@ probeRoutes.post('/allowlist/generate', async (c) => {
   const allowlist = probeAllowlistManager.getTenantAllowlist(tenantId);
   const entries: AllowlistEntry[] = [];
   if (mx.ok) {
-    entries.push(...allowlist.generateFromDnsResults(mx.domain, mx.dnsResults));
+    entries.push(...allowlist.generateFromDnsResults(mx.domain, mx.dnsResults, mx.expiresAt));
   }
   if (mtaSts.ok) {
-    entries.push(...allowlist.generateFromDnsResults(mtaSts.domain, mtaSts.dnsResults));
+    entries.push(
+      ...allowlist.generateFromDnsResults(mtaSts.domain, mtaSts.dnsResults, mtaSts.expiresAt)
+    );
   }
 
   return c.json({

--- a/apps/collector/src/jobs/probe-routes.ts
+++ b/apps/collector/src/jobs/probe-routes.ts
@@ -138,13 +138,15 @@ function hasCallerSuppliedDnsEvidence(body: {
  */
 probeRoutes.post('/mta-sts', async (c) => {
   const body = await c.req.json().catch(() => ({}));
-  const { domain, txtRecords } = body;
+  const { domain } = body;
   const tenantId = c.get('tenantId');
 
   if (!domain || typeof domain !== 'string') {
     return c.json({ error: 'Domain is required', reason: 'missing-domain' }, 400);
   }
-  if (hasCallerSuppliedDnsEvidence({ txtRecords })) {
+  // The whole body is checked: any DNS-shaped field is rejected, not only
+  // the one this route consumes.
+  if (hasCallerSuppliedDnsEvidence(body)) {
     return c.json(
       {
         error: 'Caller-supplied DNS records are not accepted',
@@ -197,10 +199,12 @@ probeRoutes.post('/mta-sts', async (c) => {
  */
 probeRoutes.post('/smtp-starttls', async (c) => {
   const body = await c.req.json().catch(() => ({}));
-  const { domain, hostname, port, mxRecords } = body;
+  const { domain, hostname, port } = body;
   const tenantId = c.get('tenantId');
 
-  if (hasCallerSuppliedDnsEvidence({ mxRecords })) {
+  // The whole body is checked: any DNS-shaped field is rejected, not only
+  // the one this route consumes.
+  if (hasCallerSuppliedDnsEvidence(body)) {
     return c.json(
       {
         error: 'Caller-supplied DNS records are not accepted',
@@ -293,13 +297,15 @@ probeRoutes.post('/smtp-starttls', async (c) => {
  */
 probeRoutes.post('/allowlist/generate', async (c) => {
   const body = await c.req.json().catch(() => ({}));
-  const { domain, dnsResults } = body;
+  const { domain } = body;
   const tenantId = c.get('tenantId');
 
   if (!domain || typeof domain !== 'string') {
     return c.json({ error: 'Domain is required', reason: 'missing-domain' }, 400);
   }
-  if (hasCallerSuppliedDnsEvidence({ dnsResults })) {
+  // The whole body is checked: any DNS-shaped field is rejected, not only
+  // the one this route consumes.
+  if (hasCallerSuppliedDnsEvidence(body)) {
     return c.json(
       {
         error: 'Caller-supplied DNS records are not accepted',

--- a/apps/collector/src/jobs/probe-routes.ts
+++ b/apps/collector/src/jobs/probe-routes.ts
@@ -1,8 +1,15 @@
 /**
- * Probe Routes - Bead 10
+ * Probe Routes - Bead 10 / Issue #67
  *
  * API endpoints for triggering non-DNS probes.
  * All probes require allowlist validation and SSRF protection.
+ *
+ * Authorization (Issue #67): every route derives probe targets exclusively
+ * from fresh persisted DNS evidence — the tenant-owned domain → latest
+ * complete snapshot → consistent record set → source observation chain —
+ * and revalidates that evidence on every request. Caller-supplied DNS
+ * arrays (txtRecords / mxRecords / dnsResults) are rejected, never mixed
+ * with trusted evidence.
  *
  * ## Usage Model (dns-ops-1j4.13.5)
  *
@@ -23,17 +30,21 @@
  * - Consider a separate "advanced diagnostics" permission
  */
 
+import { normalizeDNSDomain } from '@dns-ops/parsing';
 import { Hono } from 'hono';
 import { getEnvConfig } from '../config/env.js';
-import type { DNSQueryResult } from '../dns/types.js';
 import type { AllowlistEntry } from '../probes/allowlist.js';
 import {
   fetchMTASTSPolicy,
   probeAllowlistManager,
   probeMXHosts,
   probeSMTPStarttls,
-  validateMTASTSTxtRecord,
 } from '../probes/index.js';
+import {
+  type EvidenceFailure,
+  loadPersistedMtaStsEvidence,
+  loadPersistedMxEvidence,
+} from '../probes/persisted-dns-authorization.js';
 import { getProbeSemaphore, initProbeSemaphore } from '../probes/semaphore.js';
 import type { SMTPProbeResult } from '../probes/smtp-starttls.js';
 import type { Env } from '../types.js';
@@ -85,41 +96,83 @@ probeRoutes.use('/smtp-starttls', async (c, next) => {
   return next();
 });
 
+/** Fail closed when the request context has no database adapter bound. */
+function requireDb(c: { get: (key: 'db') => Env['Variables']['db'] }) {
+  const db = c.get('db');
+  if (!db) {
+    return {
+      response: {
+        status: 503 as const,
+        body: {
+          error: 'Database unavailable',
+          reason: 'database-unavailable',
+        },
+      },
+      db: undefined,
+    };
+  }
+  return { response: undefined, db };
+}
+
+function failureResponse(failure: EvidenceFailure) {
+  return { error: failure.error, reason: failure.reason };
+}
+
+/**
+ * Caller-supplied DNS-shaped arrays are rejected outright (Issue #67):
+ * they are not proven registered-domain evidence.
+ */
+function hasCallerSuppliedDnsEvidence(body: {
+  txtRecords?: unknown;
+  mxRecords?: unknown;
+  dnsResults?: unknown;
+}): boolean {
+  return (
+    body.txtRecords !== undefined || body.mxRecords !== undefined || body.dnsResults !== undefined
+  );
+}
+
 /**
  * POST /api/probe/mta-sts
- * Fetch MTA-STS policy for a domain
+ * Fetch MTA-STS policy for a domain (persisted evidence only)
  */
 probeRoutes.post('/mta-sts', async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const { domain, txtRecords } = body;
   const tenantId = c.get('tenantId');
 
-  if (!domain) {
-    return c.json({ error: 'Domain is required' }, 400);
+  if (!domain || typeof domain !== 'string') {
+    return c.json({ error: 'Domain is required', reason: 'missing-domain' }, 400);
   }
-
-  // Validate MTA-STS TXT record first
-  const txtValidation = await validateMTASTSTxtRecord(domain, txtRecords || []);
-
-  if (!txtValidation.valid) {
+  if (hasCallerSuppliedDnsEvidence({ txtRecords })) {
     return c.json(
       {
-        error: 'MTA-STS TXT record validation failed',
-        details: txtValidation.error,
+        error: 'Caller-supplied DNS records are not accepted',
+        reason: 'caller-supplied-dns-evidence',
       },
-      400
+      403
     );
   }
 
-  // Add to tenant-scoped allowlist (MTA-STS endpoint is derived from DNS)
+  const { response, db } = requireDb(c);
+  if (response) return c.json(response.body, response.status);
+
+  // Revalidate persisted evidence on every request, even if an in-memory
+  // allowlist entry already exists.
+  const evidence = await loadPersistedMtaStsEvidence(db, { domain, tenantId });
+  if (!evidence.ok) {
+    return c.json(failureResponse(evidence), evidence.status);
+  }
+
+  // Allowlist entries are derived only from the persisted evidence.
   probeAllowlistManager
     .getTenantAllowlist(tenantId)
-    .addCustomEntry(`mta-sts.${domain}`, 443, 'probe-api', `MTA-STS policy fetch for ${domain}`);
+    .generateFromDnsResults(evidence.domain, evidence.dnsResults);
 
   // Fetch policy — run under global semaphore to enforce PROBE_CONCURRENCY
   const config = getEnvConfig();
   const result = await getProbeSemaphore().run(() =>
-    fetchMTASTSPolicy(domain, tenantId, {
+    fetchMTASTSPolicy(evidence.domain, tenantId, {
       timeoutMs: config.probes.timeoutMs,
       checkAllowlist: true,
     })
@@ -127,51 +180,86 @@ probeRoutes.post('/mta-sts', async (c) => {
 
   return c.json({
     ...result,
-    domain,
-    txtRecordId: txtValidation.id,
+    domain: evidence.domain,
+    txtRecordId: evidence.txtRecordId,
   });
 });
 
 /**
  * POST /api/probe/smtp-starttls
- * Probe SMTP server for STARTTLS support
+ * Probe SMTP server for STARTTLS support (persisted MX evidence only)
+ *
+ * Body: { domain, hostname?, port? }
+ * - `domain` must be a tenant-owned registered domain with fresh persisted MX evidence.
+ * - Optional `hostname` must exactly match a persisted MX target (normalized).
+ * - Only port 25 is permitted.
+ * - Without `hostname`, every persisted MX target is probed.
  */
 probeRoutes.post('/smtp-starttls', async (c) => {
   const body = await c.req.json().catch(() => ({}));
-  const { hostname, port, mxRecords } = body;
+  const { domain, hostname, port, mxRecords } = body;
   const tenantId = c.get('tenantId');
 
-  // Option 1: Single host probe
-  if (hostname) {
-    // Add to tenant-scoped allowlist if MX records provided
-    if (mxRecords && Array.isArray(mxRecords)) {
-      const mockResults: DNSQueryResult[] = [
+  if (hasCallerSuppliedDnsEvidence({ mxRecords })) {
+    return c.json(
+      {
+        error: 'Caller-supplied DNS records are not accepted',
+        reason: 'caller-supplied-dns-evidence',
+      },
+      403
+    );
+  }
+  if (!domain || typeof domain !== 'string') {
+    return c.json({ error: 'Domain is required', reason: 'missing-domain' }, 400);
+  }
+  if (port !== undefined && port !== 25) {
+    return c.json(
+      { error: 'Only port 25 is permitted for SMTP probes', reason: 'port-not-permitted' },
+      403
+    );
+  }
+
+  const { response, db } = requireDb(c);
+  if (response) return c.json(response.body, response.status);
+
+  // Revalidate persisted evidence on every request, even if an in-memory
+  // allowlist entry already exists.
+  const evidence = await loadPersistedMxEvidence(db, { domain, tenantId });
+  if (!evidence.ok) {
+    return c.json(failureResponse(evidence), evidence.status);
+  }
+
+  const config = getEnvConfig();
+
+  // Single-host probe: the requested hostname must exactly match a
+  // persisted (normalized) MX target.
+  if (hostname !== undefined) {
+    if (typeof hostname !== 'string') {
+      return c.json({ error: 'Hostname is required', reason: 'missing-hostname' }, 400);
+    }
+    const normalized = normalizeDNSDomain(hostname);
+    const target = evidence.hosts.find((h) => h.hostname === normalized);
+    if (!target) {
+      return c.json(
         {
-          query: { name: hostname, type: 'MX' },
-          vantage: { type: 'public-recursive', identifier: 'mock' },
-          success: true,
-          answers: mxRecords.map((mx: string) => ({
-            name: hostname,
-            type: 'MX',
-            ttl: 300,
-            data: mx,
-          })),
-          authority: [],
-          additional: [],
-          responseTime: 0,
+          error: 'Hostname does not match persisted MX evidence',
+          reason: 'hostname-not-in-evidence',
         },
-      ];
-      probeAllowlistManager
-        .getTenantAllowlist(tenantId)
-        .generateFromDnsResults(hostname, mockResults);
+        403
+      );
     }
 
+    // Allowlist entries are derived only from the persisted evidence, and
+    // only once the request is fully authorized.
+    probeAllowlistManager
+      .getTenantAllowlist(tenantId)
+      .generateFromDnsResults(evidence.domain, evidence.dnsResults);
+
     // Run under global semaphore to enforce PROBE_CONCURRENCY
-    const smtpConfig = getEnvConfig();
     const result = await getProbeSemaphore().run(() =>
-      probeSMTPStarttls(hostname, tenantId, {
-        port: port || 25,
-        timeoutMs: smtpConfig.probes.timeoutMs,
+      probeSMTPStarttls(target.hostname, tenantId, {
+        port: 25,
+        timeoutMs: config.probes.timeoutMs,
         checkAllowlist: true,
       })
     );
@@ -179,82 +267,66 @@ probeRoutes.post('/smtp-starttls', async (c) => {
     return c.json(result);
   }
 
-  // Option 2: Batch probe from MX records
-  if (mxRecords && Array.isArray(mxRecords) && mxRecords.length > 0) {
-    // Parse MX records and add to tenant-scoped allowlist
-    const hosts = mxRecords.map((record: string) => {
-      const parts = record.trim().split(/\s+/);
-      return {
-        hostname: parts.length > 1 ? parts[1].replace(/\.$/, '') : record,
-        priority: parts.length > 0 ? parseInt(parts[0], 10) : 0,
-      };
-    });
+  // Batch probe of every persisted MX target
+  probeAllowlistManager
+    .getTenantAllowlist(tenantId)
+    .generateFromDnsResults(evidence.domain, evidence.dnsResults);
 
-    // Generate tenant-scoped allowlist
-    const mockResults: DNSQueryResult[] = [
-      {
-        query: { name: 'probe', type: 'MX' },
-        vantage: { type: 'public-recursive', identifier: 'mock' },
-        success: true,
-        answers: hosts.map((h) => ({
-          name: 'probe',
-          type: 'MX',
-          ttl: 300,
-          data: `${h.priority} ${h.hostname}.`,
-        })),
-        authority: [],
-        additional: [],
-        responseTime: 0,
-      },
-    ];
-    probeAllowlistManager.getTenantAllowlist(tenantId).generateFromDnsResults('probe', mockResults);
+  const results = await probeMXHosts(evidence.hosts, tenantId, {
+    timeoutMs: config.probes.timeoutMs,
+    concurrency: config.probes.concurrency,
+  });
 
-    // Use configured timeout and concurrency (not hardcoded values)
-    const batchConfig = getEnvConfig();
-    const results = await probeMXHosts(hosts, tenantId, {
-      timeoutMs: batchConfig.probes.timeoutMs,
-      concurrency: batchConfig.probes.concurrency,
-    });
-
-    return c.json({
-      hosts: results,
-      summary: {
-        total: results.length,
-        successful: results.filter((r: SMTPProbeResult) => r.success).length,
-        supportsStarttls: results.filter((r: SMTPProbeResult) => r.supportsStarttls).length,
-      },
-    });
-  }
-
-  return c.json(
-    {
-      error: 'Either hostname or mxRecords is required',
+  return c.json({
+    hosts: results,
+    summary: {
+      total: results.length,
+      successful: results.filter((r: SMTPProbeResult) => r.success).length,
+      supportsStarttls: results.filter((r: SMTPProbeResult) => r.supportsStarttls).length,
     },
-    400
-  );
+  });
 });
 
 /**
  * POST /api/probe/allowlist/generate
- * Generate tenant-scoped allowlist from DNS results
+ * Generate tenant-scoped allowlist entries from persisted DNS evidence only
  */
 probeRoutes.post('/allowlist/generate', async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const { domain, dnsResults } = body;
   const tenantId = c.get('tenantId');
 
-  if (!domain || !dnsResults || !Array.isArray(dnsResults)) {
+  if (!domain || typeof domain !== 'string') {
+    return c.json({ error: 'Domain is required', reason: 'missing-domain' }, 400);
+  }
+  if (hasCallerSuppliedDnsEvidence({ dnsResults })) {
     return c.json(
       {
-        error: 'Domain and dnsResults (array) are required',
+        error: 'Caller-supplied DNS records are not accepted',
+        reason: 'caller-supplied-dns-evidence',
       },
-      400
+      403
     );
   }
 
-  const entries = probeAllowlistManager
-    .getTenantAllowlist(tenantId)
-    .generateFromDnsResults(domain, dnsResults);
+  const { response, db } = requireDb(c);
+  if (response) return c.json(response.body, response.status);
+
+  const mx = await loadPersistedMxEvidence(db, { domain, tenantId });
+  const mtaSts = await loadPersistedMtaStsEvidence(db, { domain, tenantId });
+  if (!mx.ok && !mtaSts.ok) {
+    const failure = (mx.ok ? mtaSts : mx) as EvidenceFailure;
+    return c.json(failureResponse(failure), failure.status);
+  }
+
+  const allowlist = probeAllowlistManager.getTenantAllowlist(tenantId);
+  const entries: AllowlistEntry[] = [];
+  if (mx.ok) {
+    entries.push(...allowlist.generateFromDnsResults(mx.domain, mx.dnsResults));
+  }
+  if (mtaSts.ok) {
+    entries.push(...allowlist.generateFromDnsResults(mtaSts.domain, mtaSts.dnsResults));
+  }
 
   return c.json({
     domain,

--- a/apps/collector/src/mail/collector.ts
+++ b/apps/collector/src/mail/collector.ts
@@ -69,6 +69,7 @@ export async function generateMailQueries(
     { name: domain, type: 'MX' },
     { name: domain, type: 'TXT' }, // For SPF
     { name: `_dmarc.${domain}`, type: 'TXT' },
+    { name: `_mta-sts.${domain}`, type: 'CNAME' },
     { name: `_mta-sts.${domain}`, type: 'TXT' },
     { name: `_smtp._tls.${domain}`, type: 'TXT' },
   ];

--- a/apps/collector/src/notifications/integration.test.ts
+++ b/apps/collector/src/notifications/integration.test.ts
@@ -2,25 +2,37 @@
  * Notification Integration Tests - PR-08.3
  *
  * Tests webhook notification integration with alert creation:
- * - Webhook URL configured → fetch fires with correct payload
+ * - Webhook URL configured → native HTTPS request fires with correct payload
  * - No webhook URL → no attempt
  * - Suppressed alert → no notification
  * - Private IP webhook → SSRF guard rejects
  * - Webhook timeout → error logged, no crash
  */
 
+import { promises as dnsPromises } from 'node:dns';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildWebhookPayload, isPrivateUrl, sendAlertWebhook } from './webhook.js';
+import { installWebhookTransportMock } from './webhook.test-support.js';
 
+vi.mock('node:dns', () => ({
+  promises: { lookup: vi.fn() },
+}));
+
+const mockLookup = dnsPromises.lookup as ReturnType<typeof vi.fn>;
+const mockHttpsRequest = vi.hoisted(() => vi.fn());
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+vi.mock('node:https', () => ({ request: mockHttpsRequest }));
 
 describe('PR-08.3: Notification Integration Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetch.mockReset();
+    mockLookup.mockReset().mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    mockHttpsRequest.mockReset();
+    installWebhookTransportMock(mockHttpsRequest, mockFetch);
   });
 
-  describe('Webhook URL configured → fetch fires with correct payload', () => {
+  describe('Webhook URL configured → native HTTPS request fires with correct payload', () => {
     it('sends webhook with correct payload structure', async () => {
       mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
 

--- a/apps/collector/src/notifications/routes.test.ts
+++ b/apps/collector/src/notifications/routes.test.ts
@@ -2,13 +2,21 @@
  * Notification Routes Tests - PR-08.1
  */
 
+import { promises as dnsPromises } from 'node:dns';
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../types.js';
 import { notificationRoutes } from './routes.js';
+import { installWebhookTransportMock } from './webhook.test-support.js';
 
+vi.mock('node:dns', () => ({
+  promises: { lookup: vi.fn() },
+}));
+
+const mockLookup = dnsPromises.lookup as ReturnType<typeof vi.fn>;
+const mockHttpsRequest = vi.hoisted(() => vi.fn());
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+vi.mock('node:https', () => ({ request: mockHttpsRequest }));
 
 describe('Notification Routes', () => {
   let app: Hono<Env>;
@@ -17,6 +25,10 @@ describe('Notification Routes', () => {
     app = new Hono<Env>();
     app.route('/api/notify', notificationRoutes);
     vi.clearAllMocks();
+    mockFetch.mockReset();
+    mockLookup.mockReset().mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    mockHttpsRequest.mockReset();
+    installWebhookTransportMock(mockHttpsRequest, mockFetch);
   });
 
   describe('POST /api/notify/webhook', () => {

--- a/apps/collector/src/notifications/webhook.e2e.test.ts
+++ b/apps/collector/src/notifications/webhook.e2e.test.ts
@@ -7,19 +7,31 @@
  * - Alert status transitions (pending → sent)
  */
 
+import { promises as dnsPromises } from 'node:dns';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildWebhookPayload, isPrivateUrl, sendAlertWebhook } from './webhook.js';
+import { installWebhookTransportMock } from './webhook.test-support.js';
+
+vi.mock('node:dns', () => ({
+  promises: { lookup: vi.fn() },
+}));
 
 // =============================================================================
-// Mock fetch for E2E tests
+// Mock native HTTPS for E2E tests
 // =============================================================================
 
+const mockLookup = dnsPromises.lookup as ReturnType<typeof vi.fn>;
+const mockHttpsRequest = vi.hoisted(() => vi.fn());
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+vi.mock('node:https', () => ({ request: mockHttpsRequest }));
 
 describe('Phase 2: Webhook Notification E2E Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetch.mockReset();
+    mockLookup.mockReset().mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    mockHttpsRequest.mockReset();
+    installWebhookTransportMock(mockHttpsRequest, mockFetch);
   });
 
   // =============================================================================
@@ -51,7 +63,7 @@ describe('Phase 2: Webhook Notification E2E Tests', () => {
       expect(result.statusCode).toBe(200);
       expect(result.resolvedHostname).toBe('webhook.service.com');
 
-      // Verify fetch was called with correct parameters
+      // Verify the native HTTPS request through the fixture's request-plan spy
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
         'https://webhook.service.com/alerts',
@@ -383,6 +395,10 @@ describe('Phase 2: Webhook Notification E2E Tests', () => {
 describe('Webhook Integration Patterns', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetch.mockReset();
+    mockLookup.mockReset().mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    mockHttpsRequest.mockReset();
+    installWebhookTransportMock(mockHttpsRequest, mockFetch);
   });
 
   it('demonstrates successful webhook delivery pattern', async () => {

--- a/apps/collector/src/notifications/webhook.test-support.ts
+++ b/apps/collector/src/notifications/webhook.test-support.ts
@@ -1,0 +1,161 @@
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import type { vi } from 'vitest';
+
+export interface WebhookResponsePlan {
+  statusCode?: number;
+  headers?: Record<string, string>;
+  body?: string;
+  stall?: boolean;
+  error?: unknown;
+}
+
+export interface WebhookRequestView {
+  options: Record<string, unknown>;
+  body?: string;
+  destroyed: boolean;
+  ended: boolean;
+  timeoutCallback?: () => void;
+}
+
+export interface WebhookResponseView {
+  statusCode: number;
+  headers: Record<string, string>;
+  destroyed: boolean;
+}
+
+export interface WebhookTransportState {
+  plan: WebhookResponsePlan;
+  requests: WebhookRequestView[];
+  responses: WebhookResponseView[];
+  fetchMock?: ReturnType<typeof vi.fn>;
+}
+
+const fetchStates = new WeakMap<object, WebhookTransportState>();
+const patchedFetchMocks = new WeakSet<object>();
+
+/** Install a deterministic native-HTTPS fixture for webhook tests. */
+export function installWebhookTransportMock(
+  requestMock: ReturnType<typeof vi.fn>,
+  fetchMock?: ReturnType<typeof vi.fn>
+): WebhookTransportState {
+  const state: WebhookTransportState = {
+    plan: { statusCode: 200 },
+    requests: [],
+    responses: [],
+    fetchMock,
+  };
+
+  if (fetchMock) {
+    fetchStates.set(fetchMock, state);
+    if (!patchedFetchMocks.has(fetchMock)) {
+      const originalResolvedValueOnce = fetchMock.mockResolvedValueOnce.bind(fetchMock);
+      const originalRejectedValueOnce = fetchMock.mockRejectedValueOnce.bind(fetchMock);
+      fetchMock.mockResolvedValueOnce = ((value: unknown) => {
+        const current = fetchStates.get(fetchMock);
+        const response = value as { status?: number } | null | undefined;
+        if (current) current.plan = { statusCode: response?.status ?? 200 };
+        return originalResolvedValueOnce(value);
+      }) as typeof fetchMock.mockResolvedValueOnce;
+      fetchMock.mockRejectedValueOnce = ((error: unknown) => {
+        const current = fetchStates.get(fetchMock);
+        if (current) {
+          current.plan = { error };
+        }
+        return originalRejectedValueOnce(error);
+      }) as typeof fetchMock.mockRejectedValueOnce;
+      patchedFetchMocks.add(fetchMock);
+    }
+  }
+
+  class FixtureResponse extends EventEmitter {
+    readonly statusCode: number;
+    readonly statusMessage: string;
+    readonly headers: Record<string, string>;
+    destroyed = false;
+
+    constructor(plan: WebhookResponsePlan) {
+      super();
+      this.statusCode = plan.statusCode ?? 200;
+      this.statusMessage = this.statusCode >= 200 && this.statusCode < 300 ? 'OK' : 'Error';
+      this.headers = plan.headers ?? {};
+      state.responses.push(this);
+    }
+
+    destroy(): this {
+      this.destroyed = true;
+      return this;
+    }
+  }
+
+  class FixtureRequest extends EventEmitter {
+    readonly options: Record<string, unknown>;
+    destroyed = false;
+    ended = false;
+    body?: string;
+    timeoutCallback: (() => void) | undefined;
+
+    constructor(options: Record<string, unknown>, callback: (response: IncomingMessage) => void) {
+      super();
+      this.options = options;
+      state.requests.push(this);
+      this.once('fixture-end', (body: string) => {
+        const plan = state.plan;
+        this.body = body;
+        if (state.fetchMock) {
+          const headers = this.options.headers as Record<string, string> | undefined;
+          const hostHeader = headers?.Host ?? headers?.host;
+          const host = hostHeader ?? String(this.options.hostname);
+          const path = String(this.options.path ?? '/');
+          const fetchSpy = state.fetchMock as unknown as (
+            url: string,
+            init: { method: unknown; headers?: Record<string, string>; body: string }
+          ) => unknown;
+          void Promise.resolve(
+            fetchSpy(`https://${host}${path}`, {
+              method: this.options.method,
+              headers,
+              body,
+            })
+          ).catch(() => undefined);
+        }
+        if (plan.error) {
+          this.emit('error', plan.error);
+          return;
+        }
+        if (plan.stall) return;
+
+        const response = new FixtureResponse(plan);
+        callback(response as unknown as IncomingMessage);
+        queueMicrotask(() => {
+          if (plan.body) response.emit('data', Buffer.from(plan.body));
+          response.emit('end');
+          response.emit('close');
+        });
+      });
+    }
+
+    setTimeout(_timeoutMs: number, callback: () => void): this {
+      this.timeoutCallback = callback;
+      return this;
+    }
+
+    end(body?: string): this {
+      this.ended = true;
+      this.emit('fixture-end', body ?? '');
+      return this;
+    }
+
+    destroy(): this {
+      this.destroyed = true;
+      return this;
+    }
+  }
+
+  requestMock.mockImplementation(
+    (options: Record<string, unknown>, callback: (response: IncomingMessage) => void) =>
+      new FixtureRequest(options, callback)
+  );
+
+  return state;
+}

--- a/apps/collector/src/notifications/webhook.test.ts
+++ b/apps/collector/src/notifications/webhook.test.ts
@@ -1,70 +1,173 @@
-/**
- * Webhook Notification Tests - PR-08.1
- */
+/** Webhook delivery tests for the pinned native HTTPS transport. */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as dnsPromises } from 'node:dns';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildWebhookPayload, isPrivateUrl, sendAlertWebhook } from './webhook.js';
+import { installWebhookTransportMock, type WebhookTransportState } from './webhook.test-support.js';
 
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+const mockLookup = dnsPromises.lookup as ReturnType<typeof vi.fn>;
+const mockHttpsRequest = vi.hoisted(() => vi.fn());
+vi.mock('node:dns', () => ({
+  promises: { lookup: vi.fn() },
+}));
+vi.mock('node:https', () => ({ request: mockHttpsRequest }));
 
-describe('Webhook SSRF Protection', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+const payload = {
+  alertId: 'alert-123',
+  title: 'Test',
+  description: 'desc',
+  severity: 'high' as const,
+  domain: 'example.com',
+  tenantId: 'tenant-1',
+  timestamp: new Date().toISOString(),
+  domain360Link: 'https://app.example.com/domain/example.com',
+};
 
-  it('blocks RFC 1918 private IPs', () => {
+let transport: WebhookTransportState;
+
+beforeEach(() => {
+  mockLookup.mockReset().mockResolvedValue({ address: '93.184.216.34', family: 4 });
+  mockHttpsRequest.mockReset();
+  transport = installWebhookTransportMock(mockHttpsRequest);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('Webhook URL validation', () => {
+  it('blocks private and localhost URLs', () => {
     expect(isPrivateUrl('http://10.0.0.1:8080')).toBe(true);
-    expect(isPrivateUrl('http://172.16.0.1:8080')).toBe(true);
-    expect(isPrivateUrl('http://192.168.0.1:8080')).toBe(true);
-  });
-
-  it('blocks localhost', () => {
     expect(isPrivateUrl('http://localhost:8080')).toBe(true);
     expect(isPrivateUrl('http://127.0.0.1:8080')).toBe(true);
   });
 
-  it('allows public URLs', () => {
+  it('allows a syntactically public HTTPS URL before DNS resolution', () => {
     expect(isPrivateUrl('https://webhook.example.com/alerts')).toBe(false);
   });
 });
 
-describe('Webhook Delivery', () => {
-  const payload = {
-    alertId: 'alert-123',
-    title: 'Test',
-    description: 'desc',
-    severity: 'high' as const,
-    domain: 'example.com',
-    tenantId: 'tenant-1',
-    timestamp: new Date().toISOString(),
-    domain360Link: 'https://app.example.com/domain/example.com',
-  };
+describe('Pinned webhook delivery', () => {
+  it('pins the checked public IPv4 while preserving method, body, headers, Host, SNI, and TLS validation', async () => {
+    const result = await sendAlertWebhook('https://webhook.example.com:8443/alerts?x=1', payload);
 
-  it('sends webhook successfully', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
-    const result = await sendAlertWebhook('https://webhook.example.com', payload);
-    expect(result.success).toBe(true);
+    expect(result).toMatchObject({
+      success: true,
+      statusCode: 200,
+      resolvedHostname: 'webhook.example.com',
+    });
+    expect(mockLookup).toHaveBeenCalledWith('webhook.example.com', { family: 4 });
+
+    const request = transport.requests[0];
+    expect(request?.options).toMatchObject({
+      protocol: 'https:',
+      hostname: '93.184.216.34',
+      port: 8443,
+      path: '/alerts?x=1',
+      method: 'POST',
+      agent: false,
+      servername: 'webhook.example.com',
+      rejectUnauthorized: true,
+      headers: {
+        Host: 'webhook.example.com:8443',
+        'Content-Type': 'application/json',
+        'User-Agent': 'dns-ops-collector/1.0 webhook-notifier',
+      },
+    });
+    expect(JSON.parse(request?.body ?? '')).toEqual(payload);
+
+    const lookup = request?.options.lookup as
+      | ((
+          hostname: string,
+          options: { family?: number },
+          callback: (...args: unknown[]) => void
+        ) => void)
+      | undefined;
+    const callback = vi.fn();
+    lookup?.('93.184.216.34', {}, callback);
+    expect(callback).toHaveBeenCalledWith(null, '93.184.216.34', 4);
   });
 
-  it('blocks SSRF attempts', async () => {
-    const result = await sendAlertWebhook('http://10.0.0.1/webhook', payload);
+  it('fails closed on DNS errors without opening an HTTPS request', async () => {
+    mockLookup.mockRejectedValueOnce(Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' }));
+
+    const result = await sendAlertWebhook('https://missing.example.com/alerts', payload);
+
     expect(result.success).toBe(false);
-    expect(result.error).toBe('SSRF_BLOCKED');
+    expect(result.error).toContain('ENOTFOUND');
+    expect(transport.requests).toHaveLength(0);
   });
 
-  it('handles errors gracefully', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('NETWORK_ERROR'));
-    const result = await sendAlertWebhook('https://webhook.example.com', payload);
+  it.each([
+    '127.0.0.1',
+    'fec0::1',
+    '2606:4700:4700::1111',
+    '::ffff:93.184.216.34',
+  ])('fails closed when DNS returns non-public or IPv6 address %s', async (address) => {
+    mockLookup.mockResolvedValueOnce({ address, family: address.includes(':') ? 6 : 4 });
+
+    const result = await sendAlertWebhook('https://webhook.example.com/alerts', payload);
+
     expect(result.success).toBe(false);
+    expect(result.error).toContain(address);
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  it('rejects redirects without following Location', async () => {
+    transport.plan = { statusCode: 301, headers: { location: 'http://127.0.0.1/' } };
+
+    const result = await sendAlertWebhook('https://webhook.example.com/alerts', payload);
+
+    expect(result).toMatchObject({ success: false, error: 'HTTP redirect 301 is not allowed' });
+    expect(transport.requests).toHaveLength(1);
+    expect(transport.responses[0]?.destroyed).toBe(true);
+  });
+
+  it('bounds declared and streamed response bodies', async () => {
+    transport.plan = { statusCode: 200, headers: { 'content-length': '65537' } };
+    const declared = await sendAlertWebhook('https://webhook.example.com/alerts', payload);
+    expect(declared.success).toBe(false);
+    expect(declared.error).toContain('Content-Length');
+
+    transport.plan = { statusCode: 200, body: 'x'.repeat(65537) };
+    const streamed = await sendAlertWebhook('https://webhook.example.com/alerts', payload);
+    expect(streamed.success).toBe(false);
+    expect(streamed.error).toContain('body exceeds');
+  });
+
+  it('enforces one cumulative timeout across DNS, connection, and body consumption', async () => {
+    vi.useFakeTimers();
+    transport.plan = { stall: true };
+    const promise = sendAlertWebhook('https://slow.example.com/alerts', payload);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(promise).resolves.toMatchObject({ success: false, error: 'TIMEOUT' });
+    expect(transport.requests[0]?.destroyed).toBe(true);
+  });
+
+  it('requires HTTPS for outbound webhook delivery', async () => {
+    const result = await sendAlertWebhook('http://webhook.example.com/alerts', payload);
+
+    expect(result).toMatchObject({ success: false, error: 'HTTPS_REQUIRED' });
+    expect(transport.requests).toHaveLength(0);
   });
 });
 
 describe('buildWebhookPayload', () => {
-  it('builds correct structure', () => {
-    const alert = { id: 'a1', title: 'Test', severity: 'high', domain: 'ex.com', tenantId: 't1' };
-    const payload = buildWebhookPayload(alert, 'https://app.example.com');
-    expect(payload.alertId).toBe('a1');
-    expect(payload.domain360Link).toContain('/domain/');
+  it('builds the expected payload and default link', () => {
+    const built = buildWebhookPayload({
+      id: 'a1',
+      title: 'Test',
+      severity: 'high',
+      domain: 'ex.com',
+      tenantId: 't1',
+    });
+
+    expect(built).toMatchObject({
+      alertId: 'a1',
+      description: '',
+      domain360Link: 'https://app.dns-ops.example.com/domain/ex.com',
+    });
   });
 });

--- a/apps/collector/src/notifications/webhook.ts
+++ b/apps/collector/src/notifications/webhook.ts
@@ -8,6 +8,9 @@
  * consistent protection against private/internal target blocking.
  */
 
+import type { IncomingMessage } from 'node:http';
+import * as https from 'node:https';
+import * as tls from 'node:tls';
 import { resolveAndCheck, validateUrl } from '../probes/ssrf-guard.js';
 
 export interface WebhookPayload {
@@ -42,25 +45,182 @@ export function isPrivateUrl(url: string): boolean {
   return !result.allowed;
 }
 
+const WEBHOOK_TIMEOUT_MS = 5_000;
+const MAX_WEBHOOK_RESPONSE_BYTES = 64 * 1024;
+
+class WebhookTimeoutError extends Error {
+  constructor() {
+    super('Webhook delivery deadline exceeded');
+    this.name = 'WebhookTimeoutError';
+  }
+}
+
+interface WebhookResponse {
+  statusCode: number;
+}
+
+function remainingMs(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
+}
+
+function declaredResponseSize(headers: IncomingMessage['headers']): number | null {
+  const value = headers['content-length'];
+  if (value === undefined) return null;
+  const text = Array.isArray(value) ? value.join(',') : value;
+  if (!/^\d+$/.test(text)) throw new Error('Webhook response has an invalid Content-Length');
+  const length = Number(text);
+  if (!Number.isSafeInteger(length)) throw new Error('Webhook response Content-Length is invalid');
+  return length;
+}
+
+/** Send one pinned HTTPS request without redirect following. */
+function requestPinnedWebhook(
+  url: URL,
+  resolvedIp: string,
+  body: string,
+  signal: AbortSignal,
+  deadline: number
+): Promise<WebhookResponse> {
+  if (signal.aborted) return Promise.reject(new WebhookTimeoutError());
+
+  return new Promise((resolve, reject) => {
+    let request: ReturnType<typeof https.request> | undefined;
+    let response: IncomingMessage | undefined;
+    let settled = false;
+    let bodyComplete = false;
+    let bodyBytes = 0;
+
+    const cleanupResponse = () => {
+      response?.off('data', onData);
+      response?.off('end', onEnd);
+      response?.off('error', onResponseError);
+      response?.off('aborted', onResponseAborted);
+      response?.off('close', onResponseClose);
+    };
+    const cleanup = () => {
+      cleanupResponse();
+      request?.off('error', onRequestError);
+      request?.off('timeout', onRequestTimeout);
+      signal.removeEventListener('abort', onAbort);
+    };
+    const destroy = () => {
+      request?.destroy();
+      response?.destroy();
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      destroy();
+      reject(error);
+    };
+    const finish = () => {
+      if (settled || !response) return;
+      settled = true;
+      bodyComplete = true;
+      cleanup();
+      resolve({ statusCode: response.statusCode ?? 0 });
+    };
+    const onAbort = () => fail(new WebhookTimeoutError());
+    const onRequestError = (error: Error) => fail(error);
+    const onRequestTimeout = () => fail(new WebhookTimeoutError());
+    const onResponseError = (error: Error) => fail(error);
+    const onResponseAborted = () => fail(new Error('Webhook response was aborted'));
+    const onResponseClose = () => {
+      if (!bodyComplete) fail(new Error('Webhook response closed before body completion'));
+    };
+    const onData = (chunk: Buffer | string) => {
+      bodyBytes += Buffer.isBuffer(chunk) ? chunk.byteLength : Buffer.byteLength(chunk);
+      if (bodyBytes > MAX_WEBHOOK_RESPONSE_BYTES) {
+        fail(new Error('Webhook response body exceeds 65536 bytes'));
+      }
+    };
+    const onEnd = () => {
+      bodyComplete = true;
+      finish();
+    };
+
+    try {
+      signal.addEventListener('abort', onAbort, { once: true });
+      request = https.request(
+        {
+          protocol: 'https:',
+          hostname: resolvedIp,
+          port: url.port ? Number(url.port) : 443,
+          path: `${url.pathname}${url.search}`,
+          method: 'POST',
+          agent: false,
+          servername: url.hostname,
+          rejectUnauthorized: true,
+          checkServerIdentity: (_hostname, certificate) =>
+            tls.checkServerIdentity(url.hostname, certificate),
+          headers: {
+            Host: url.host,
+            'Content-Type': 'application/json',
+            'User-Agent': 'dns-ops-collector/1.0 webhook-notifier',
+          },
+          // The address was checked before this request; never resolve the
+          // original hostname again and reopen the DNS rebinding window.
+          lookup: (_hostname, _options, callback) => callback(null, resolvedIp, 4),
+        },
+        (incoming) => {
+          response = incoming;
+          if (settled) {
+            incoming.destroy();
+            return;
+          }
+
+          const statusCode = incoming.statusCode ?? 0;
+          if (statusCode >= 300 && statusCode < 400) {
+            fail(new Error(`HTTP redirect ${statusCode} is not allowed`));
+            return;
+          }
+
+          try {
+            const length = declaredResponseSize(incoming.headers);
+            if (length !== null && length > MAX_WEBHOOK_RESPONSE_BYTES) {
+              fail(new Error('Webhook response Content-Length exceeds 65536 bytes'));
+              return;
+            }
+          } catch (error) {
+            fail(error);
+            return;
+          }
+
+          incoming.on('data', onData);
+          incoming.on('end', onEnd);
+          incoming.on('error', onResponseError);
+          incoming.on('aborted', onResponseAborted);
+          incoming.on('close', onResponseClose);
+        }
+      );
+      request.on('error', onRequestError);
+      request.setTimeout(remainingMs(deadline), onRequestTimeout);
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      request.end(body);
+    } catch (error) {
+      fail(error);
+    }
+  });
+}
+
 /**
- * Send an alert webhook notification
+ * Send an alert webhook notification.
  *
- * Best-effort delivery - errors are logged but don't throw.
- * All URLs are validated against the shared SSRF guard.
- *
- * @param webhookUrl - The URL to POST the notification to
- * @param payload - The webhook payload
- * @param signal - Optional AbortSignal for cancellation
- * @returns WebhookResult with success status
+ * Best-effort delivery - errors are logged but don't throw. Hostname DNS is
+ * resolved once to a checked public IPv4 and the native HTTPS request is
+ * pinned to that address while retaining the original Host/SNI identity.
  */
 export async function sendAlertWebhook(
   webhookUrl: string,
   payload: WebhookPayload,
   signal?: AbortSignal
 ): Promise<WebhookResult> {
-  // SSRF guard — step 1: reject obviously bad URLs (IP literals, localhost, bad protocol)
   const ssrfCheck = validateUrl(webhookUrl);
-  if (!ssrfCheck.allowed) {
+  if (!ssrfCheck.allowed || !ssrfCheck.url) {
     return {
       success: false,
       error: 'SSRF_BLOCKED',
@@ -68,69 +228,60 @@ export async function sendAlertWebhook(
     };
   }
 
-  // SSRF guard — step 2: resolve hostname and check the resolved IP
-  // Closes DNS rebinding TOCTOU gap (see docs/security/probe-sandbox-review.md)
-  const hostname = ssrfCheck.url?.hostname;
-  if (hostname) {
-    const dnsCheck = await resolveAndCheck(hostname);
+  const url = ssrfCheck.url;
+  const hostname = url.hostname;
+  if (url.protocol !== 'https:') {
+    return { success: false, error: 'HTTPS_REQUIRED', resolvedHostname: hostname };
+  }
+
+  const controller = new AbortController();
+  const deadline = Date.now() + WEBHOOK_TIMEOUT_MS;
+  const timeoutId = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+  const onExternalAbort = () => controller.abort();
+  signal?.addEventListener('abort', onExternalAbort, { once: true });
+
+  try {
+    if (signal?.aborted) controller.abort();
+    const dnsCheck = await resolveAndCheck(hostname, controller.signal);
     if (!dnsCheck.allowed) {
       return {
         success: false,
-        error: 'SSRF_DNS_REBINDING_BLOCKED',
+        error: controller.signal.aborted ? 'TIMEOUT' : (dnsCheck.reason ?? 'DNS resolution failed'),
         resolvedHostname: hostname,
       };
     }
-  }
 
-  // 5 second timeout
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 5000);
+    const response = await requestPinnedWebhook(
+      url,
+      dnsCheck.ip,
+      JSON.stringify(payload),
+      controller.signal,
+      deadline
+    );
 
-  const fetchSignal = signal ?? controller.signal;
-
-  try {
-    const response = await fetch(webhookUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': 'dns-ops-collector/1.0 webhook-notifier',
-      },
-      body: JSON.stringify(payload),
-      signal: fetchSignal,
-    });
-
-    clearTimeout(timeout);
-
-    if (response.ok) {
-      return {
-        success: true,
-        statusCode: response.status,
-        resolvedHostname: ssrfCheck.url?.hostname,
-      };
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      return { success: true, statusCode: response.statusCode, resolvedHostname: hostname };
     }
 
     return {
       success: false,
-      statusCode: response.status,
-      error: `HTTP ${response.status}`,
-      resolvedHostname: ssrfCheck.url?.hostname,
+      statusCode: response.statusCode,
+      error: `HTTP ${response.statusCode}`,
+      resolvedHostname: hostname,
     };
   } catch (error) {
-    clearTimeout(timeout);
-
-    if (error instanceof Error && error.name === 'AbortError') {
-      return {
-        success: false,
-        error: 'TIMEOUT',
-        resolvedHostname: ssrfCheck.url?.hostname,
-      };
-    }
-
+    const isTimeout =
+      controller.signal.aborted ||
+      error instanceof WebhookTimeoutError ||
+      (error instanceof Error && error.name === 'AbortError');
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'UNKNOWN_ERROR',
-      resolvedHostname: ssrfCheck.url?.hostname,
+      error: isTimeout ? 'TIMEOUT' : error instanceof Error ? error.message : 'UNKNOWN_ERROR',
+      resolvedHostname: hostname,
     };
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener('abort', onExternalAbort);
   }
 }
 

--- a/apps/collector/src/probes/allowlist-tenant.test.ts
+++ b/apps/collector/src/probes/allowlist-tenant.test.ts
@@ -157,4 +157,43 @@ describe('Tenant-Scoped Allowlist - AUTH-003', () => {
       expect(entries[0].type).toBe('mx');
     });
   });
+
+  describe('hostname canonicalization (Issue #67 review)', () => {
+    it('canonicalizes mixed-case MX answers so lowercase probes are allowed', () => {
+      const allowlist = createTenantAllowlist('tenant-mixed-case');
+
+      const entries = allowlist.generateFromDnsResults('example.com', [
+        {
+          success: true,
+          query: { name: 'example.com', type: 'MX' as const },
+          answers: [
+            {
+              name: 'example.com',
+              type: 'MX' as const,
+              ttl: 300,
+              data: '10 MAIL.EXAMPLE.COM.',
+            },
+          ],
+        },
+      ]);
+
+      // Entry is stored canonical, matching the lowercase hosts the
+      // persisted-evidence loader produces.
+      expect(entries[0].hostname).toBe('mail.example.com');
+
+      // Lookups are canonicalized too: raw-case and canonical queries both hit.
+      expect(allowlist.isAllowed('mail.example.com', 25)).toBe(true);
+      expect(allowlist.isAllowed('MAIL.EXAMPLE.COM', 25)).toBe(true);
+      expect(allowlist.getEntry('Mail.Example.Com', 25)).toBeDefined();
+    });
+
+    it('canonicalizes custom entries', () => {
+      const allowlist = createTenantAllowlist('tenant-custom-case');
+
+      allowlist.addCustomEntry('RELAY.Example.ORG.', 25, 'ops', 'break-glass');
+
+      expect(allowlist.isAllowed('relay.example.org', 25)).toBe(true);
+      expect(allowlist.isAllowed('RELAY.EXAMPLE.ORG', 25)).toBe(true);
+    });
+  });
 });

--- a/apps/collector/src/probes/allowlist.test.ts
+++ b/apps/collector/src/probes/allowlist.test.ts
@@ -246,6 +246,47 @@ describe('Allowlist Entry Generation - Bead 13.4', () => {
     expect(entries).toHaveLength(0);
   });
 
+  it('should preserve a persisted evidence expiry on generated entries', () => {
+    const persistedExpiry = new Date('2024-01-01T00:00:42Z');
+    const dnsResults: DNSQueryResult[] = [
+      {
+        query: { name: 'example.com', type: 'MX' },
+        vantage: { type: 'public-recursive', identifier: 'google' },
+        success: true,
+        answers: [{ name: 'example.com', type: 'MX', ttl: 300, data: '10 mail.example.com.' }],
+        authority: [],
+        additional: [],
+        responseTime: 50,
+      },
+    ];
+
+    const entries = allowlist.generateFromDnsResults('example.com', dnsResults, persistedExpiry);
+
+    expect(entries[0]?.expiresAt.getTime()).toBe(persistedExpiry.getTime());
+    expect(allowlist.getEntry('mail.example.com', 25)?.expiresAt.getTime()).toBe(
+      persistedExpiry.getTime()
+    );
+  });
+
+  it('should treat the persisted expiry boundary as expired', () => {
+    const persistedExpiry = new Date('2024-01-01T00:00:00Z');
+    const dnsResults: DNSQueryResult[] = [
+      {
+        query: { name: 'example.com', type: 'MX' },
+        vantage: { type: 'public-recursive', identifier: 'google' },
+        success: true,
+        answers: [{ name: 'example.com', type: 'MX', ttl: 300, data: '10 mail.example.com.' }],
+        authority: [],
+        additional: [],
+        responseTime: 50,
+      },
+    ];
+
+    allowlist.generateFromDnsResults('example.com', dnsResults, persistedExpiry);
+
+    expect(allowlist.isAllowed('mail.example.com', 25)).toBe(false);
+  });
+
   it('should track derivation info for audit', () => {
     const dnsResults: DNSQueryResult[] = [
       {
@@ -380,6 +421,33 @@ describe('Legacy ProbeAllowlist Canonicalization - Issue #67 review', () => {
 
     expect(allowlist.isAllowed('relay.example.org', 25)).toBe(true);
     expect(allowlist.isAllowed('RELAY.EXAMPLE.ORG', 25)).toBe(true);
+  });
+
+  it('should derive MTA-STS allowlist entries from a canonical TXT owner', () => {
+    const dnsResults: DNSQueryResult[] = [
+      {
+        query: { name: 'policy.provider.example', type: 'TXT' },
+        vantage: { type: 'public-recursive', identifier: 'google' },
+        success: true,
+        answers: [
+          {
+            name: 'policy.provider.example',
+            type: 'TXT',
+            ttl: 300,
+            data: 'v=STSv1; id=20240101',
+          },
+        ],
+        authority: [],
+        additional: [],
+        responseTime: 30,
+      },
+    ];
+
+    const entries = allowlist.generateFromDnsResults('example.com', dnsResults);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.hostname).toBe('mta-sts.example.com');
+    expect(allowlist.isAllowed('mta-sts.example.com', 443)).toBe(true);
   });
 
   it('should canonicalize MTA-STS entries from mixed-case domains', () => {

--- a/apps/collector/src/probes/allowlist.test.ts
+++ b/apps/collector/src/probes/allowlist.test.ts
@@ -333,6 +333,81 @@ describe('Allowlist Lookup - Bead 13.4', () => {
 });
 
 // =============================================================================
+// Legacy ProbeAllowlist Hostname Canonicalization (Issue #67 review)
+// =============================================================================
+
+describe('Legacy ProbeAllowlist Canonicalization - Issue #67 review', () => {
+  let allowlist: ProbeAllowlist;
+
+  beforeEach(() => {
+    allowlist = new ProbeAllowlist(60000);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    allowlist.clear();
+  });
+
+  it('should canonicalize mixed-case trailing-dot MX answers so lowercase probes are allowed', () => {
+    const dnsResults: DNSQueryResult[] = [
+      {
+        query: { name: 'example.com', type: 'MX' },
+        vantage: { type: 'public-recursive', identifier: 'google' },
+        success: true,
+        answers: [{ name: 'example.com', type: 'MX', ttl: 300, data: '10 MAIL.EXAMPLE.COM.' }],
+        authority: [],
+        additional: [],
+        responseTime: 50,
+      },
+    ];
+
+    const entries = allowlist.generateFromDnsResults('example.com', dnsResults);
+
+    // Entry is stored canonical, matching the lowercase hosts the
+    // persisted-evidence loader produces.
+    expect(entries[0].hostname).toBe('mail.example.com');
+
+    // Lookups are canonicalized too: raw-case and trailing-dot queries both hit.
+    expect(allowlist.isAllowed('mail.example.com', 25)).toBe(true);
+    expect(allowlist.isAllowed('MAIL.EXAMPLE.COM.', 25)).toBe(true);
+    expect(allowlist.getEntry('Mail.Example.Com', 25)).toBeDefined();
+  });
+
+  it('should canonicalize custom entries', () => {
+    allowlist.addCustomEntry('RELAY.Example.ORG.', 25, 'ops', 'break-glass');
+
+    expect(allowlist.isAllowed('relay.example.org', 25)).toBe(true);
+    expect(allowlist.isAllowed('RELAY.EXAMPLE.ORG', 25)).toBe(true);
+  });
+
+  it('should canonicalize MTA-STS entries from mixed-case domains', () => {
+    const dnsResults: DNSQueryResult[] = [
+      {
+        query: { name: '_mta-sts.Example.COM', type: 'TXT' },
+        vantage: { type: 'public-recursive', identifier: 'google' },
+        success: true,
+        answers: [
+          { name: '_mta-sts.Example.COM', type: 'TXT', ttl: 300, data: 'v=STSv1; id=20240101' },
+        ],
+        authority: [],
+        additional: [],
+        responseTime: 30,
+      },
+    ];
+
+    const entries = allowlist.generateFromDnsResults('Example.COM', dnsResults);
+
+    expect(entries[0].type).toBe('mta-sts');
+    expect(entries[0].hostname).toBe('mta-sts.example.com');
+
+    expect(allowlist.isAllowed('mta-sts.example.com', 443)).toBe(true);
+    expect(allowlist.isAllowed('MTA-STS.Example.COM', 443)).toBe(true);
+  });
+});
+
+// =============================================================================
 // Custom Entry Tests
 // =============================================================================
 

--- a/apps/collector/src/probes/allowlist.ts
+++ b/apps/collector/src/probes/allowlist.ts
@@ -26,9 +26,14 @@ export interface AllowlistEntry {
 
 export interface TenantScopedAllowlist {
   /**
-   * Generate allowlist entries from DNS query results for this tenant
+   * Generate allowlist entries from DNS query results for this tenant.
+   * Persisted evidence can supply its already-computed expiry.
    */
-  generateFromDnsResults(domain: string, dnsResults: DNSQueryResult[]): AllowlistEntry[];
+  generateFromDnsResults(
+    domain: string,
+    dnsResults: DNSQueryResult[],
+    expiresAt?: Date
+  ): AllowlistEntry[];
 
   /**
    * Add a custom allowlist entry for this tenant
@@ -72,6 +77,13 @@ function canonicalHostname(hostname: string): string {
   return hostname.trim().toLowerCase().replace(/\.$/, '');
 }
 
+/** An omitted expiry keeps the legacy allowlist API's TTL behavior. */
+export function isExpiryFresh(expiresAt?: Date): boolean {
+  if (expiresAt === undefined) return true;
+  const timestamp = expiresAt instanceof Date ? expiresAt.getTime() : Number.NaN;
+  return Number.isFinite(timestamp) && timestamp > Date.now();
+}
+
 /**
  * Create a tenant-scoped allowlist instance
  */
@@ -84,19 +96,24 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
   }
 
   function cleanup(): void {
-    const now = new Date();
     for (const [k, entry] of entries) {
-      if (entry.expiresAt < now) {
+      if (!isExpiryFresh(entry.expiresAt)) {
         entries.delete(k);
       }
     }
   }
 
   return {
-    generateFromDnsResults(domain: string, dnsResults: DNSQueryResult[]): AllowlistEntry[] {
+    generateFromDnsResults(
+      domain: string,
+      dnsResults: DNSQueryResult[],
+      persistedExpiresAt?: Date
+    ): AllowlistEntry[] {
       const resultEntries: AllowlistEntry[] = [];
       const now = new Date();
-      const expiresAt = new Date(now.getTime() + defaultTtlMs);
+      const entryExpiresAt = persistedExpiresAt
+        ? new Date(persistedExpiresAt.getTime())
+        : new Date(now.getTime() + defaultTtlMs);
 
       for (const dnsResult of dnsResults) {
         if (!dnsResult.success) continue;
@@ -118,7 +135,7 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
                   queryName: dnsResult.query.name,
                   answerData: answer.data,
                 },
-                expiresAt,
+                expiresAt: new Date(entryExpiresAt.getTime()),
               };
               resultEntries.push(entry);
               entries.set(key(entry), entry);
@@ -127,7 +144,13 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
         }
 
         // Extract MTA-STS policy host
-        if (dnsResult.query.type === 'TXT' && dnsResult.query.name.includes('_mta-sts')) {
+        if (
+          dnsResult.query.type === 'TXT' &&
+          (dnsResult.query.name.toLowerCase().includes('_mta-sts') ||
+            dnsResult.answers.some((answer) =>
+              answer.data.trim().toLowerCase().startsWith('v=stsv1')
+            ))
+        ) {
           const entry: AllowlistEntry = {
             tenantId,
             type: 'mta-sts',
@@ -139,7 +162,7 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
               queryName: dnsResult.query.name,
               answerData: dnsResult.answers.map((a: { data: string }) => a.data).join(', '),
             },
-            expiresAt,
+            expiresAt: new Date(entryExpiresAt.getTime()),
           };
           resultEntries.push(entry);
           entries.set(key(entry), entry);
@@ -280,10 +303,16 @@ export class ProbeAllowlist {
     this.defaultTtlMs = defaultTtlMs;
   }
 
-  generateFromDnsResults(domain: string, dnsResults: DNSQueryResult[]): AllowlistEntry[] {
+  generateFromDnsResults(
+    domain: string,
+    dnsResults: DNSQueryResult[],
+    persistedExpiresAt?: Date
+  ): AllowlistEntry[] {
     const entries: AllowlistEntry[] = [];
     const now = new Date();
-    const expiresAt = new Date(now.getTime() + this.defaultTtlMs);
+    const entryExpiresAt = persistedExpiresAt
+      ? new Date(persistedExpiresAt.getTime())
+      : new Date(now.getTime() + this.defaultTtlMs);
 
     for (const result of dnsResults) {
       if (!result.success) continue;
@@ -304,7 +333,7 @@ export class ProbeAllowlist {
                 queryName: result.query.name,
                 answerData: answer.data,
               },
-              expiresAt,
+              expiresAt: new Date(entryExpiresAt.getTime()),
             };
             entries.push(entry);
             this.entries.set(this.key(entry), entry);
@@ -312,7 +341,11 @@ export class ProbeAllowlist {
         }
       }
 
-      if (result.query.type === 'TXT' && result.query.name.includes('_mta-sts')) {
+      if (
+        result.query.type === 'TXT' &&
+        (result.query.name.toLowerCase().includes('_mta-sts') ||
+          result.answers.some((answer) => answer.data.trim().toLowerCase().startsWith('v=stsv1')))
+      ) {
         const entry: AllowlistEntry = {
           tenantId: 'default',
           type: 'mta-sts',
@@ -324,7 +357,7 @@ export class ProbeAllowlist {
             queryName: result.query.name,
             answerData: result.answers.map((a: { data: string }) => a.data).join(', '),
           },
-          expiresAt,
+          expiresAt: new Date(entryExpiresAt.getTime()),
         };
         entries.push(entry);
         this.entries.set(this.key(entry), entry);
@@ -395,9 +428,8 @@ export class ProbeAllowlist {
   }
 
   private cleanup(): void {
-    const now = new Date();
     for (const [key, entry] of this.entries) {
-      if (entry.expiresAt < now) {
+      if (!isExpiryFresh(entry.expiresAt)) {
         this.entries.delete(key);
       }
     }

--- a/apps/collector/src/probes/allowlist.ts
+++ b/apps/collector/src/probes/allowlist.ts
@@ -62,6 +62,17 @@ export interface TenantScopedAllowlist {
 }
 
 /**
+ * Canonical hostname form for allowlist keying: DNS names are
+ * case-insensitive (RFC 1035 §2.3.3) and may carry a trailing root dot.
+ * Persisted MX targets arrive normalized lowercase, while raw MX answer
+ * data may be mixed-case — both entries and lookups are canonicalized so
+ * mixed-case answers authorize normalized probe targets.
+ */
+function canonicalHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/\.$/, '');
+}
+
+/**
  * Create a tenant-scoped allowlist instance
  */
 export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
@@ -95,7 +106,7 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
           for (const answer of dnsResult.answers) {
             const parts = answer.data.trim().split(/\s+/);
             if (parts.length >= 2) {
-              const hostname = parts[1].replace(/\.$/, '');
+              const hostname = canonicalHostname(parts[1]);
               const entry: AllowlistEntry = {
                 tenantId,
                 type: 'mx',
@@ -120,7 +131,7 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
           const entry: AllowlistEntry = {
             tenantId,
             type: 'mta-sts',
-            hostname: `mta-sts.${domain}`,
+            hostname: canonicalHostname(`mta-sts.${domain}`),
             port: 443,
             derivedFrom: {
               domain,
@@ -150,7 +161,7 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
       const entry: AllowlistEntry = {
         tenantId,
         type: 'custom',
-        hostname,
+        hostname: canonicalHostname(hostname),
         port,
         derivedFrom: {
           domain: 'custom',
@@ -168,13 +179,14 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
     isAllowed(hostname: string, port?: number): boolean {
       cleanup();
 
-      const entryKey = port ? `${hostname}:${port}` : hostname;
+      const host = canonicalHostname(hostname);
+      const entryKey = port ? `${host}:${port}` : host;
       if (entries.has(entryKey)) {
         return true;
       }
 
       for (const entry of entries.values()) {
-        if (entry.hostname === hostname) {
+        if (entry.hostname === host) {
           if (port === undefined || entry.port === undefined || entry.port === port) {
             return true;
           }
@@ -187,7 +199,8 @@ export function createTenantAllowlist(tenantId: string): TenantScopedAllowlist {
     getEntry(hostname: string, port?: number): AllowlistEntry | undefined {
       cleanup();
 
-      const entryKey = port ? `${hostname}:${port}` : hostname;
+      const host = canonicalHostname(hostname);
+      const entryKey = port ? `${host}:${port}` : host;
       return entries.get(entryKey);
     },
 
@@ -279,7 +292,7 @@ export class ProbeAllowlist {
         for (const answer of result.answers) {
           const parts = answer.data.trim().split(/\s+/);
           if (parts.length >= 2) {
-            const hostname = parts[1].replace(/\.$/, '');
+            const hostname = canonicalHostname(parts[1]);
             const entry: AllowlistEntry = {
               tenantId: 'default', // Legacy entries are tenant-scoped
               type: 'mx',
@@ -303,7 +316,7 @@ export class ProbeAllowlist {
         const entry: AllowlistEntry = {
           tenantId: 'default',
           type: 'mta-sts',
-          hostname: `mta-sts.${domain}`,
+          hostname: canonicalHostname(`mta-sts.${domain}`),
           port: 443,
           derivedFrom: {
             domain,
@@ -333,7 +346,7 @@ export class ProbeAllowlist {
     const entry: AllowlistEntry = {
       tenantId: 'default',
       type: 'custom',
-      hostname,
+      hostname: canonicalHostname(hostname),
       port,
       derivedFrom: {
         domain: 'custom',
@@ -351,13 +364,14 @@ export class ProbeAllowlist {
   isAllowed(hostname: string, port?: number): boolean {
     this.cleanup();
 
-    const key = port ? `${hostname}:${port}` : hostname;
+    const host = canonicalHostname(hostname);
+    const key = port ? `${host}:${port}` : host;
     if (this.entries.has(key)) {
       return true;
     }
 
     for (const entry of this.entries.values()) {
-      if (entry.hostname === hostname) {
+      if (entry.hostname === host) {
         if (port === undefined || entry.port === undefined || entry.port === port) {
           return true;
         }
@@ -370,7 +384,8 @@ export class ProbeAllowlist {
   getEntry(hostname: string, port?: number): AllowlistEntry | undefined {
     this.cleanup();
 
-    const key = port ? `${hostname}:${port}` : hostname;
+    const host = canonicalHostname(hostname);
+    const key = port ? `${host}:${port}` : host;
     return this.entries.get(key);
   }
 

--- a/apps/collector/src/probes/mta-sts.test.ts
+++ b/apps/collector/src/probes/mta-sts.test.ts
@@ -1,0 +1,321 @@
+/** Deterministic MTA-STS pinned HTTPS probe tests. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchMTASTSPolicy } from './mta-sts.js';
+import { getProbeSemaphore, resetProbeSemaphore } from './semaphore.js';
+
+const POLICY = 'version: STSv1\nmode: enforce\nmax_age: 300\nmx: *.example.com\n';
+
+type ResponsePlan =
+  | 'success'
+  | 'redirect'
+  | 'declared-too-large'
+  | 'stream-too-large'
+  | 'stall-dns'
+  | 'stall-before-response'
+  | 'stall-body';
+
+interface RequestView {
+  options: Record<string, unknown>;
+  destroyed: boolean;
+  ended: boolean;
+  timeoutCallback?: () => void;
+}
+
+interface ResponseView {
+  destroyed: boolean;
+}
+
+const fixtureState = vi.hoisted(() => ({
+  lookup: vi.fn(),
+  requests: [] as RequestView[],
+  responses: [] as ResponseView[],
+  plan: 'success' as ResponsePlan,
+  plans: [] as ResponsePlan[],
+}));
+
+vi.mock('node:dns', () => ({
+  promises: {
+    lookup: fixtureState.lookup,
+  },
+}));
+
+vi.mock('node:https', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:https')>();
+  const { EventEmitter } = await import('node:events');
+
+  class FixtureResponse extends EventEmitter {
+    readonly statusCode: number;
+    readonly statusMessage: string;
+    readonly headers: Record<string, string>;
+    destroyed = false;
+
+    constructor(statusCode: number, headers: Record<string, string> = {}) {
+      super();
+      this.statusCode = statusCode;
+      this.statusMessage = statusCode === 200 ? 'OK' : 'Moved Permanently';
+      this.headers = headers;
+      fixtureState.responses.push(this);
+    }
+
+    destroy(): this {
+      this.destroyed = true;
+      return this;
+    }
+  }
+
+  class FixtureRequest extends EventEmitter {
+    readonly options: Record<string, unknown>;
+    readonly callback: (response: FixtureResponse) => void;
+    readonly plan: ResponsePlan;
+    destroyed = false;
+    ended = false;
+    timeoutCallback: (() => void) | undefined;
+
+    constructor(options: Record<string, unknown>, callback: (response: FixtureResponse) => void) {
+      super();
+      this.options = options;
+      this.callback = callback;
+      this.plan = fixtureState.plans[fixtureState.requests.length] ?? fixtureState.plan;
+      fixtureState.requests.push(this);
+    }
+
+    setTimeout(_timeoutMs: number, callback: () => void): this {
+      this.timeoutCallback = callback;
+      return this;
+    }
+
+    end(): this {
+      this.ended = true;
+      queueMicrotask(() => {
+        const plan = this.plan;
+        if (plan === 'stall-before-response') return;
+        if (plan === 'redirect') {
+          this.callback(new FixtureResponse(301, { location: 'http://127.0.0.1/' }));
+          return;
+        }
+        if (plan === 'declared-too-large') {
+          this.callback(new FixtureResponse(200, { 'content-length': '65537' }));
+          return;
+        }
+        if (plan === 'stream-too-large') {
+          const response = new FixtureResponse(200);
+          this.callback(response);
+          queueMicrotask(() => {
+            response.emit('data', Buffer.alloc(65536));
+            response.emit('data', Buffer.from('x'));
+          });
+          return;
+        }
+        const response = new FixtureResponse(200, { 'content-length': String(POLICY.length) });
+        this.callback(response);
+        queueMicrotask(() => {
+          response.emit('data', Buffer.from(POLICY.slice(0, 12)));
+          if (plan === 'stall-body') return;
+          response.emit('data', Buffer.from(POLICY.slice(12)));
+          response.emit('end');
+          response.emit('close');
+        });
+      });
+      return this;
+    }
+
+    destroy(): this {
+      this.destroyed = true;
+      return this;
+    }
+  }
+
+  const request = vi.fn(
+    (options: Record<string, unknown>, callback: (response: FixtureResponse) => void) =>
+      new FixtureRequest(options, callback)
+  );
+  return { ...actual, request };
+});
+
+beforeEach(() => {
+  fixtureState.lookup.mockReset().mockImplementation(() => {
+    if (fixtureState.plan === 'stall-dns') return new Promise(() => undefined);
+    return Promise.resolve([{ address: '93.184.216.34', family: 4 }]);
+  });
+  fixtureState.requests.length = 0;
+  fixtureState.responses.length = 0;
+  fixtureState.plan = 'success';
+  fixtureState.plans.length = 0;
+  resetProbeSemaphore(5);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetProbeSemaphore(5);
+});
+
+describe('fetchMTASTSPolicy pinned HTTPS transport', () => {
+  it('pins the checked address while preserving Host, SNI, and certificate validation', async () => {
+    const result = await fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result).toMatchObject({ success: true, rawPolicy: POLICY });
+    expect(fixtureState.lookup).toHaveBeenCalledWith('mta-sts.example.com', { all: true });
+
+    const request = fixtureState.requests[0];
+    expect(request?.options).toMatchObject({
+      hostname: 'mta-sts.example.com',
+      path: '/.well-known/mta-sts.txt',
+      agent: false,
+      servername: 'mta-sts.example.com',
+      rejectUnauthorized: true,
+      headers: {
+        Host: 'mta-sts.example.com',
+        'User-Agent': 'DNS-Ops-Probe/1.0',
+      },
+    });
+
+    const lookup = request?.options.lookup as
+      | ((
+          hostname: string,
+          options: { all?: boolean },
+          callback: (...args: unknown[]) => void
+        ) => void)
+      | undefined;
+    expect(lookup).toBeDefined();
+    const callback = vi.fn();
+    lookup?.('mta-sts.example.com', {}, callback);
+    expect(callback).toHaveBeenCalledWith(null, '93.184.216.34', 4);
+  });
+
+  it('rejects every unsafe address returned by DNS', async () => {
+    fixtureState.lookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '127.0.0.1', family: 4 },
+    ]);
+
+    const result = await fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('127.0.0.1');
+    expect(fixtureState.requests).toHaveLength(0);
+  });
+
+  it.each([
+    ['100.64.0.0', '100.64.0.0/10'],
+    ['100.127.255.255', '100.64.0.0/10'],
+    ['198.18.0.0', '198.18.0.0/15'],
+    ['198.19.255.255', '198.18.0.0/15'],
+  ])('rejects an IANA special-purpose resolved address at the %s boundary (%s)', async (address) => {
+    fixtureState.lookup.mockResolvedValue([{ address, family: 4 }]);
+
+    const result = await fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect(result.error).toContain(`resolved to ${address}`);
+    expect(fixtureState.requests).toHaveLength(0);
+  });
+
+  it('fails closed on DNS errors and empty/non-IP results', async () => {
+    fixtureState.lookup.mockRejectedValueOnce(new Error('ENOTFOUND'));
+    const failed = await fetchMTASTSPolicy('missing.example', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+    expect(failed.success).toBe(false);
+    expect(failed.error).toContain('ENOTFOUND');
+
+    fixtureState.lookup.mockResolvedValueOnce([]);
+    const empty = await fetchMTASTSPolicy('empty.example', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+    expect(empty.success).toBe(false);
+    expect(empty.error).toContain('no addresses');
+  });
+
+  it('rejects redirects without following the Location target', async () => {
+    fixtureState.plan = 'redirect';
+    const result = await fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('redirect');
+    expect(fixtureState.requests[0]?.destroyed).toBe(true);
+    expect(fixtureState.requests).toHaveLength(1);
+  });
+
+  it('enforces declared and streamed 64 KiB body limits', async () => {
+    fixtureState.plan = 'declared-too-large';
+    const declared = await fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+    expect(declared.success).toBe(false);
+    expect(declared.error).toContain('Content-Length');
+    expect(fixtureState.responses[0]?.destroyed).toBe(true);
+
+    fixtureState.plan = 'stream-too-large';
+    const streamed = await fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+    expect(streamed.success).toBe(false);
+    expect(streamed.error).toContain('body exceeds');
+    expect(fixtureState.requests[1]?.destroyed).toBe(true);
+  });
+});
+
+describe('fetchMTASTSPolicy cumulative deadline', () => {
+  it.each([
+    ['DNS', 'stall-dns'],
+    ['connect/header', 'stall-before-response'],
+    ['body', 'stall-body'],
+  ] as const)('times out a stalled %s phase', async (_phase, plan) => {
+    vi.useFakeTimers();
+    fixtureState.plan = plan;
+    const promise = fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(25);
+    const result = await promise;
+    expect(result).toMatchObject({ success: false, error: 'Timeout after 25ms' });
+    if (fixtureState.requests[0]) expect(fixtureState.requests[0].destroyed).toBe(true);
+    if (fixtureState.responses[0]) expect(fixtureState.responses[0].destroyed).toBe(true);
+  });
+
+  it('releases a semaphore permit after a stalled body', async () => {
+    vi.useFakeTimers();
+    resetProbeSemaphore(1);
+    fixtureState.plan = 'success';
+    fixtureState.plans.push('stall-body', 'success');
+    const first = getProbeSemaphore().run(() =>
+      fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+        checkAllowlist: false,
+        timeoutMs: 25,
+      })
+    );
+    const second = getProbeSemaphore().run(() =>
+      fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+        checkAllowlist: false,
+        timeoutMs: 25,
+      })
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    const firstResult = await first;
+    expect(firstResult.success).toBe(false);
+    await vi.runAllTicks();
+    await vi.advanceTimersByTimeAsync(1);
+    const secondResult = await second;
+    expect(secondResult.success).toBe(true);
+    expect(fixtureState.requests).toHaveLength(2);
+  });
+});

--- a/apps/collector/src/probes/mta-sts.test.ts
+++ b/apps/collector/src/probes/mta-sts.test.ts
@@ -203,6 +203,24 @@ describe('fetchMTASTSPolicy pinned HTTPS transport', () => {
   });
 
   it.each([
+    ['fc00::1', 6],
+    ['fec0::1', 6],
+    ['2606:4700:4700::1111', 6],
+    ['::ffff:93.184.216.34', 6],
+  ] as const)('rejects IPv6 answer %s before opening HTTPS', async (address, family) => {
+    fixtureState.lookup.mockResolvedValue([{ address, family }]);
+
+    const result = await fetchMTASTSPolicy('example.com', 'tenant-fixture', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(address);
+    expect(fixtureState.requests).toHaveLength(0);
+  });
+
+  it.each([
     ['100.64.0.0', '100.64.0.0/10'],
     ['100.127.255.255', '100.64.0.0/10'],
     ['198.18.0.0', '198.18.0.0/15'],

--- a/apps/collector/src/probes/mta-sts.ts
+++ b/apps/collector/src/probes/mta-sts.ts
@@ -5,8 +5,12 @@
  * Validates policy format and extracts mode/max_age/mx directives.
  */
 
+import * as dns from 'node:dns';
+import type { IncomingHttpHeaders, IncomingMessage } from 'node:http';
+import * as https from 'node:https';
+import { isIP } from 'node:net';
 import { isExpiryFresh, probeAllowlistManager } from './allowlist.js';
-import { resolveAndCheck, validateUrl } from './ssrf-guard.js';
+import { checkSSRF, validateUrl } from './ssrf-guard.js';
 
 export interface MTASTSProbeResult {
   success: boolean;
@@ -26,6 +30,238 @@ export interface MTASTSPolicy {
   maxAge: number;
   mx: string[];
   raw: string;
+}
+
+const MAX_POLICY_BYTES = 64 * 1024;
+
+class MTASTSProbeTimeoutError extends Error {
+  constructor() {
+    super('MTA-STS probe deadline exceeded');
+    this.name = 'MTASTSProbeTimeoutError';
+  }
+}
+
+interface PinnedAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+interface PolicyResponse {
+  statusCode: number;
+  statusMessage?: string;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+function remainingMs(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
+}
+
+/** Race a DNS operation against the probe's cumulative deadline. */
+function withAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new MTASTSProbeTimeoutError());
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      reject(new MTASTSProbeTimeoutError());
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+async function resolvePinnedAddress(hostname: string, signal: AbortSignal): Promise<PinnedAddress> {
+  const records = await withAbort(dns.promises.lookup(hostname, { all: true }), signal);
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error(`DNS resolution returned no addresses for ${hostname}`);
+  }
+
+  const addresses: PinnedAddress[] = [];
+  for (const record of records) {
+    if (!record || typeof record.address !== 'string') {
+      throw new Error(`DNS resolution returned a non-IP address for ${hostname}`);
+    }
+    const family = isIP(record.address);
+    if (family !== 4 && family !== 6) {
+      throw new Error(`DNS resolution returned a non-IP address for ${hostname}`);
+    }
+    if (record.family !== 4 && record.family !== 6) {
+      throw new Error(`DNS resolution returned an invalid address family for ${hostname}`);
+    }
+    if (record.family !== family) {
+      throw new Error(`DNS resolution returned a mismatched address family for ${hostname}`);
+    }
+
+    const check = checkSSRF(record.address);
+    if (!check.allowed) {
+      throw new Error(
+        `SSRF DNS rebinding blocked: ${hostname} resolved to ${record.address} (${check.reason})`
+      );
+    }
+    addresses.push({ address: record.address, family });
+  }
+
+  return addresses[0];
+}
+
+function declaredBodySize(headers: IncomingHttpHeaders): number | null {
+  const value = headers['content-length'];
+  if (value === undefined) return null;
+  const text = Array.isArray(value) ? value.join(',') : value;
+  if (!/^\d+$/.test(text)) throw new Error('MTA-STS response has an invalid Content-Length');
+  const length = Number(text);
+  if (!Number.isSafeInteger(length)) throw new Error('MTA-STS response Content-Length is invalid');
+  return length;
+}
+
+/**
+ * Issue one pinned HTTPS request and consume its body under the same signal.
+ * Native https does not follow redirects, so every 3xx is rejected here.
+ */
+function requestPolicy(
+  options: https.RequestOptions,
+  signal: AbortSignal,
+  deadline: number
+): Promise<PolicyResponse> {
+  return new Promise((resolve, reject) => {
+    let request: ReturnType<typeof https.request> | undefined;
+    let response: IncomingMessage | undefined;
+    let settled = false;
+    let bodyComplete = false;
+    let chunks: Buffer[] = [];
+    let bodyBytes = 0;
+
+    const cleanupResponse = () => {
+      if (!response) return;
+      response.off('data', onData);
+      response.off('end', onEnd);
+      response.off('error', onResponseError);
+      response.off('aborted', onAborted);
+      response.off('close', onResponseClose);
+    };
+    const cleanup = () => {
+      cleanupResponse();
+      request?.off('error', onRequestError);
+      request?.off('timeout', onRequestTimeout);
+      signal.removeEventListener('abort', onAbort);
+    };
+    const destroy = () => {
+      // Destroy without an error after cleanup so Node cannot emit an
+      // unhandled error event for a listener we just removed.
+      request?.destroy();
+      response?.destroy();
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      destroy();
+      reject(error);
+    };
+    const finish = () => {
+      if (settled || !response) return;
+      settled = true;
+      bodyComplete = true;
+      const body = Buffer.concat(chunks).toString('utf8');
+      chunks = [];
+      cleanup();
+      resolve({
+        statusCode: response.statusCode ?? 0,
+        statusMessage: response.statusMessage,
+        headers: response.headers,
+        body,
+      });
+    };
+    const onAbort = () => fail(new MTASTSProbeTimeoutError());
+    const onRequestError = (error: Error) => fail(error);
+    const onRequestTimeout = () => fail(new MTASTSProbeTimeoutError());
+    const onResponseError = (error: Error) => fail(error);
+    const onAborted = () => fail(new Error('MTA-STS response was aborted'));
+    const onResponseClose = () => {
+      if (!bodyComplete) fail(new Error('MTA-STS response closed before body completion'));
+    };
+    const onData = (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      bodyBytes += buffer.byteLength;
+      if (bodyBytes > MAX_POLICY_BYTES) {
+        fail(new Error('MTA-STS response body exceeds 65536 bytes'));
+        return;
+      }
+      chunks.push(buffer);
+    };
+    const onEnd = () => {
+      bodyComplete = true;
+      finish();
+    };
+
+    try {
+      signal.addEventListener('abort', onAbort, { once: true });
+      request = https.request(options, (incoming) => {
+        response = incoming;
+        if (settled) {
+          incoming.destroy();
+          return;
+        }
+        const statusCode = incoming.statusCode ?? 0;
+        if (statusCode >= 300 && statusCode < 400) {
+          fail(new Error(`HTTP redirect ${statusCode} is not allowed`));
+          return;
+        }
+        if (statusCode < 200 || statusCode >= 300) {
+          fail(new Error(`HTTP ${statusCode}: ${incoming.statusMessage ?? ''}`.trim()));
+          return;
+        }
+
+        try {
+          const length = declaredBodySize(incoming.headers);
+          if (length !== null && length > MAX_POLICY_BYTES) {
+            fail(new Error('MTA-STS response Content-Length exceeds 65536 bytes'));
+            return;
+          }
+        } catch (error) {
+          fail(error);
+          return;
+        }
+
+        incoming.on('data', onData);
+        incoming.on('end', onEnd);
+        incoming.on('error', onResponseError);
+        incoming.on('aborted', onAborted);
+        incoming.on('close', onResponseClose);
+      });
+      request.on('error', onRequestError);
+      request.setTimeout(remainingMs(deadline), onRequestTimeout);
+      if (settled) {
+        request.destroy();
+        return;
+      }
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      request.end();
+    } catch (error) {
+      fail(error);
+    }
+  });
 }
 
 /**
@@ -95,6 +331,10 @@ export async function fetchMTASTSPolicy(
   const { timeoutMs = 10000, checkAllowlist = true, expiresAt } = options || {};
   const policyUrl = `https://mta-sts.${domain}/.well-known/mta-sts.txt`;
   const startTime = Date.now();
+  const deadline = startTime + timeoutMs;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
+  const { signal } = controller;
 
   try {
     if (!isExpiryFresh(expiresAt)) {
@@ -106,9 +346,12 @@ export async function fetchMTASTSPolicy(
         responseTimeMs: Date.now() - startTime,
       };
     }
-    // SSRF check — step 1: reject bad URLs (IP literals, localhost, bad protocol)
+    if (deadline <= Date.now() || signal.aborted) {
+      throw new MTASTSProbeTimeoutError();
+    }
+
     const urlCheck = validateUrl(policyUrl);
-    if (!urlCheck.allowed) {
+    if (!urlCheck.allowed || !urlCheck.url) {
       return {
         success: false,
         domain,
@@ -118,79 +361,50 @@ export async function fetchMTASTSPolicy(
       };
     }
 
-    // SSRF check — step 2: resolve hostname and check resolved IP
-    // Closes DNS rebinding TOCTOU gap (see docs/security/probe-sandbox-review.md)
-    const targetHostname = urlCheck.url?.hostname;
-    if (targetHostname) {
-      const dnsCheck = await resolveAndCheck(targetHostname);
-      if (!dnsCheck.allowed) {
-        return {
-          success: false,
-          domain,
-          policyUrl,
-          error: `SSRF DNS rebinding blocked: ${dnsCheck.reason}`,
-          responseTimeMs: Date.now() - startTime,
-        };
-      }
+    const targetHostname = urlCheck.url.hostname;
+    if (checkAllowlist && !probeAllowlistManager.isAllowed(tenantId, targetHostname, 443)) {
+      return {
+        success: false,
+        domain,
+        policyUrl,
+        error: 'Destination not in allowlist. Generate allowlist from DNS results first.',
+        responseTimeMs: Date.now() - startTime,
+      };
     }
 
-    // Check allowlist if enabled (tenant-scoped via probeAllowlistManager)
-    if (checkAllowlist) {
-      const hostname = `mta-sts.${domain}`;
-      if (!probeAllowlistManager.isAllowed(tenantId, hostname, 443)) {
-        return {
-          success: false,
-          domain,
-          policyUrl,
-          error: 'Destination not in allowlist. Generate allowlist from DNS results first.',
-          responseTimeMs: Date.now() - startTime,
-        };
-      }
+    const pinned = await resolvePinnedAddress(targetHostname, signal);
+    if (deadline <= Date.now() || signal.aborted) {
+      throw new MTASTSProbeTimeoutError();
     }
-
-    // The semaphore or DNS/allowlist checks may have delayed the request.
-    // Recheck the persisted evidence immediately before starting the fetch.
     if (!isExpiryFresh(expiresAt)) {
-      return {
-        success: false,
-        domain,
-        policyUrl,
-        error: 'Persisted DNS evidence expired before fetch start',
-        responseTimeMs: Date.now() - startTime,
-      };
+      throw new Error('Persisted DNS evidence expired before fetch start');
     }
 
-    // Fetch policy with timeout
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    const response = await fetch(policyUrl, {
-      signal: controller.signal,
-      // SECURITY: reject all redirects — a redirect to http://127.0.0.1/...
-      // would bypass the SSRF guard because the SSRF check runs on the original
-      // URL, not on the redirect target. With 'error', the fetch throws on any
-      // 3xx response and we never follow it. See: docs/security/probe-sandbox-review.md
-      redirect: 'error',
-      headers: {
-        'User-Agent': 'DNS-Ops-Probe/1.0',
+    const response = await requestPolicy(
+      {
+        protocol: 'https:',
+        hostname: targetHostname,
+        port: 443,
+        path: `${urlCheck.url.pathname}${urlCheck.url.search}`,
+        method: 'GET',
+        agent: false,
+        servername: targetHostname,
+        rejectUnauthorized: true,
+        headers: {
+          Host: targetHostname,
+          'User-Agent': 'DNS-Ops-Probe/1.0',
+        },
+        lookup: (_hostname, _options, callback) => {
+          callback(null, pinned.address, pinned.family);
+        },
+        signal,
       },
-    });
+      signal,
+      deadline
+    );
 
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      return {
-        success: false,
-        domain,
-        policyUrl,
-        error: `HTTP ${response.status}: ${response.statusText}`,
-        responseTimeMs: Date.now() - startTime,
-      };
-    }
-
-    const rawPolicy = await response.text();
+    const rawPolicy = response.body;
     const policy = parsePolicy(rawPolicy);
-
     if (!policy) {
       return {
         success: false,
@@ -212,25 +426,17 @@ export async function fetchMTASTSPolicy(
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-
-    // Handle specific error types
-    if (errorMessage.includes('abort')) {
-      return {
-        success: false,
-        domain,
-        policyUrl,
-        error: `Timeout after ${timeoutMs}ms`,
-        responseTimeMs: Date.now() - startTime,
-      };
-    }
+    const isTimeout = signal.aborted || error instanceof MTASTSProbeTimeoutError;
 
     return {
       success: false,
       domain,
       policyUrl,
-      error: errorMessage,
+      error: isTimeout ? `Timeout after ${timeoutMs}ms` : errorMessage,
       responseTimeMs: Date.now() - startTime,
     };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/apps/collector/src/probes/mta-sts.ts
+++ b/apps/collector/src/probes/mta-sts.ts
@@ -5,7 +5,7 @@
  * Validates policy format and extracts mode/max_age/mx directives.
  */
 
-import { probeAllowlistManager } from './allowlist.js';
+import { isExpiryFresh, probeAllowlistManager } from './allowlist.js';
 import { resolveAndCheck, validateUrl } from './ssrf-guard.js';
 
 export interface MTASTSProbeResult {
@@ -89,13 +89,23 @@ export async function fetchMTASTSPolicy(
   options?: {
     timeoutMs?: number;
     checkAllowlist?: boolean;
+    expiresAt?: Date;
   }
 ): Promise<MTASTSProbeResult> {
-  const { timeoutMs = 10000, checkAllowlist = true } = options || {};
+  const { timeoutMs = 10000, checkAllowlist = true, expiresAt } = options || {};
   const policyUrl = `https://mta-sts.${domain}/.well-known/mta-sts.txt`;
   const startTime = Date.now();
 
   try {
+    if (!isExpiryFresh(expiresAt)) {
+      return {
+        success: false,
+        domain,
+        policyUrl,
+        error: 'Persisted DNS evidence expired before probe start',
+        responseTimeMs: Date.now() - startTime,
+      };
+    }
     // SSRF check — step 1: reject bad URLs (IP literals, localhost, bad protocol)
     const urlCheck = validateUrl(policyUrl);
     if (!urlCheck.allowed) {
@@ -136,6 +146,18 @@ export async function fetchMTASTSPolicy(
           responseTimeMs: Date.now() - startTime,
         };
       }
+    }
+
+    // The semaphore or DNS/allowlist checks may have delayed the request.
+    // Recheck the persisted evidence immediately before starting the fetch.
+    if (!isExpiryFresh(expiresAt)) {
+      return {
+        success: false,
+        domain,
+        policyUrl,
+        error: 'Persisted DNS evidence expired before fetch start',
+        responseTimeMs: Date.now() - startTime,
+      };
     }
 
     // Fetch policy with timeout

--- a/apps/collector/src/probes/persisted-dns-authorization.test.ts
+++ b/apps/collector/src/probes/persisted-dns-authorization.test.ts
@@ -1,0 +1,303 @@
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadPersistedMtaStsEvidence } from './persisted-dns-authorization.js';
+
+interface Row extends Record<string, unknown> {}
+
+function tableName(table: unknown): string {
+  if (!table || typeof table !== 'object') return '';
+  const record = table as Record<symbol | string, unknown>;
+  const symbolName = Symbol.for('drizzle:Name');
+  if (typeof record[symbolName] === 'string') return record[symbolName] as string;
+  const symbol = Object.getOwnPropertySymbols(record).find(
+    (candidate) => String(candidate) === 'Symbol(drizzle:Name)'
+  );
+  return symbol && typeof record[symbol] === 'string' ? (record[symbol] as string) : '';
+}
+
+function conditionValues(condition: unknown): unknown[] {
+  const values: unknown[] = [];
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== 'object') return;
+    const record = value as {
+      constructor?: { name?: string };
+      queryChunks?: unknown[];
+      value?: unknown;
+    };
+    if (record.constructor?.name === 'Param') {
+      values.push(record.value);
+      return;
+    }
+    for (const chunk of record.queryChunks ?? []) visit(chunk);
+  };
+  visit(condition);
+  return values;
+}
+
+function createDb(state: Record<string, Row[]>): IDatabaseAdapter {
+  const rows = (table: unknown): Row[] => state[tableName(table)] ?? [];
+  const matches = (row: Row, condition: unknown): boolean =>
+    conditionValues(condition).every((value) =>
+      Object.values(row).some((field) => field === value)
+    );
+
+  return {
+    type: 'postgres',
+    getDrizzle: () => undefined,
+    select: async (table: unknown) => [...rows(table)],
+    selectWhere: async (table: unknown, condition: unknown) =>
+      rows(table).filter((row) => matches(row, condition)),
+    selectOne: async (table: unknown, condition: unknown) =>
+      rows(table).find((row) => matches(row, condition)),
+    insert: async () => ({}),
+    insertMany: async () => [],
+    update: async () => [],
+    updateOne: async () => undefined,
+    delete: async () => [],
+    deleteOne: async () => undefined,
+    transaction: async () => undefined,
+  } as unknown as IDatabaseAdapter;
+}
+
+const NOW = new Date('2026-09-01T00:00:00.000Z');
+const DOMAIN = '_mta-sts.example.com';
+const TXT = 'v=STSv1; id=20260901';
+
+function recordSet(
+  id: string,
+  name: string,
+  type: string,
+  values: string[],
+  sourceObservationIds: string[]
+): Row {
+  return {
+    id,
+    snapshotId: 'snapshot-1',
+    name,
+    type,
+    ttl: 300,
+    values,
+    sourceObservationIds,
+    sourceVantages: ['1.1.1.1'],
+    isConsistent: true,
+    createdAt: NOW,
+  };
+}
+
+function observation(
+  id: string,
+  queryName: string,
+  queryType: string,
+  answerSection: Row[],
+  queriedAt = new Date(NOW.getTime() - 1_000)
+): Row {
+  return {
+    id,
+    snapshotId: 'snapshot-1',
+    queryName,
+    queryType,
+    vantageType: 'public-recursive',
+    vantageIdentifier: '1.1.1.1',
+    status: 'success',
+    queriedAt,
+    responseTimeMs: 1,
+    responseCode: 0,
+    flags: null,
+    answerSection,
+  };
+}
+
+function cnameAnswer(name: string, target: string): Row {
+  return { name, type: 'CNAME', ttl: 300, data: target };
+}
+
+function txtAnswer(name: string): Row {
+  return { name, type: 'TXT', ttl: 300, data: TXT };
+}
+
+function state(
+  overrides: { cname?: Row[]; observations?: Row[]; recordSets?: Row[]; txtOwnerName?: string } = {}
+) {
+  const txtOwnerName = overrides.txtOwnerName ?? DOMAIN;
+  return {
+    domains: [
+      {
+        id: 'domain-1',
+        name: 'example.com',
+        normalizedName: 'example.com',
+        tenantId: 'tenant-a',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ],
+    snapshots: [
+      {
+        id: 'snapshot-1',
+        domainId: 'domain-1',
+        resultState: 'complete',
+        createdAt: NOW,
+        observationCount: 3,
+      },
+    ],
+    record_sets: overrides.recordSets ?? [
+      recordSet('record-txt', txtOwnerName, 'TXT', [TXT], ['observation-txt']),
+      ...(overrides.cname ?? []),
+    ],
+    observations: overrides.observations ?? [
+      observation('observation-txt', txtOwnerName, 'TXT', [txtAnswer(txtOwnerName)]),
+    ],
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('loadPersistedMtaStsEvidence CNAME authorization', () => {
+  it('accepts direct TXT evidence when the persisted CNAME lookup is terminal NODATA', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const terminalCname = recordSet('record-cname', DOMAIN, 'CNAME', [], ['observation-cname']);
+    terminalCname.isConsistent = false;
+    const result = await loadPersistedMtaStsEvidence(
+      createDb(
+        state({
+          cname: [terminalCname],
+          observations: [
+            observation('observation-txt', DOMAIN, 'TXT', [txtAnswer(DOMAIN)]),
+            observation('observation-cname', DOMAIN, 'CNAME', []),
+          ],
+        })
+      ),
+      { domain: 'example.com', tenantId: 'tenant-a' }
+    );
+
+    expect(result).toMatchObject({ ok: true, txtRecord: TXT, txtRecordId: '20260901' });
+  });
+
+  it('follows a persisted multi-hop CNAME chain to the canonical TXT owner', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const firstTarget = '_mta-sts.canonical.example.com';
+    const finalTarget = 'mta-sts-policy.example.net';
+    const db = createDb(
+      state({
+        cname: [
+          recordSet('record-cname-1', DOMAIN, 'CNAME', [firstTarget], ['observation-cname-1']),
+          recordSet('record-cname-2', firstTarget, 'CNAME', [finalTarget], ['observation-cname-2']),
+        ],
+        txtOwnerName: finalTarget,
+        observations: [
+          observation('observation-txt', finalTarget, 'TXT', [txtAnswer(finalTarget)]),
+          observation('observation-cname-1', DOMAIN, 'CNAME', [cnameAnswer(DOMAIN, firstTarget)]),
+          observation('observation-cname-2', firstTarget, 'CNAME', [
+            cnameAnswer(firstTarget, finalTarget),
+          ]),
+        ],
+      })
+    );
+
+    const result = await loadPersistedMtaStsEvidence(db, {
+      domain: 'example.com',
+      tenantId: 'tenant-a',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.txtRecord).toBe(TXT);
+      expect(result.txtRecordId).toBe('20260901');
+      expect(result.dnsResults[0]?.answers[0]?.name).toBe(finalTarget);
+      expect(result.dnsResults).toHaveLength(3);
+      expect(result.dnsResults[1]?.query).toEqual({ name: DOMAIN, type: 'CNAME' });
+      expect(result.dnsResults[2]?.query).toEqual({ name: firstTarget, type: 'CNAME' });
+      expect(result.expiresAt.getTime()).toBe(NOW.getTime() + 299_000);
+    }
+  });
+
+  it('rejects a TXT answer from an unrelated canonical owner', async () => {
+    const cnameTarget = '_mta-sts.canonical.example.com';
+    const result = await loadPersistedMtaStsEvidence(
+      createDb(
+        state({
+          cname: [recordSet('record-cname', DOMAIN, 'CNAME', [cnameTarget], ['observation-cname'])],
+          txtOwnerName: cnameTarget,
+          observations: [
+            observation('observation-txt', cnameTarget, 'TXT', [
+              txtAnswer('unrelated.example.net'),
+            ]),
+            observation('observation-cname', DOMAIN, 'CNAME', [cnameAnswer(DOMAIN, cnameTarget)]),
+          ],
+        })
+      ),
+      { domain: 'example.com', tenantId: 'tenant-a' }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing-answer');
+  });
+
+  it('rejects CNAME loops before accepting a TXT record', async () => {
+    const target = '_mta-sts.loop.example.com';
+    const result = await loadPersistedMtaStsEvidence(
+      createDb(
+        state({
+          cname: [
+            recordSet('record-cname-1', DOMAIN, 'CNAME', [target], ['observation-cname-1']),
+            recordSet('record-cname-2', target, 'CNAME', [DOMAIN], ['observation-cname-2']),
+          ],
+          txtOwnerName: target,
+          observations: [
+            observation('observation-txt', target, 'TXT', [txtAnswer(target)]),
+            observation('observation-cname-1', DOMAIN, 'CNAME', [cnameAnswer(DOMAIN, target)]),
+            observation('observation-cname-2', target, 'CNAME', [cnameAnswer(target, DOMAIN)]),
+          ],
+        })
+      ),
+      { domain: 'example.com', tenantId: 'tenant-a' }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('cname-chain-loop');
+  });
+
+  it('rejects malformed persisted CNAME targets', async () => {
+    const target = 'not a hostname';
+    const result = await loadPersistedMtaStsEvidence(
+      createDb(
+        state({
+          cname: [recordSet('record-cname', DOMAIN, 'CNAME', [target], ['observation-cname'])],
+          observations: [
+            observation('observation-txt', DOMAIN, 'TXT', [txtAnswer(DOMAIN)]),
+            observation('observation-cname', DOMAIN, 'CNAME', [cnameAnswer(DOMAIN, target)]),
+          ],
+        })
+      ),
+      { domain: 'example.com', tenantId: 'tenant-a' }
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: 'malformed-cname-target' });
+  });
+
+  it('includes CNAME TTL freshness in the persisted evidence expiry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const target = '_mta-sts.canonical.example.com';
+    const stale = new Date(NOW.getTime() - 301_000);
+    const result = await loadPersistedMtaStsEvidence(
+      createDb(
+        state({
+          cname: [recordSet('record-cname', DOMAIN, 'CNAME', [target], ['observation-cname'])],
+          txtOwnerName: target,
+          observations: [
+            observation('observation-txt', target, 'TXT', [txtAnswer(target)]),
+            observation('observation-cname', DOMAIN, 'CNAME', [cnameAnswer(DOMAIN, target)], stale),
+          ],
+        })
+      ),
+      { domain: 'example.com', tenantId: 'tenant-a' }
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: 'stale-evidence' });
+  });
+});

--- a/apps/collector/src/probes/persisted-dns-authorization.test.ts
+++ b/apps/collector/src/probes/persisted-dns-authorization.test.ts
@@ -149,6 +149,39 @@ function state(
   };
 }
 
+function boundedChainState(hopCount: number) {
+  const owners = [
+    DOMAIN,
+    ...Array.from({ length: hopCount }, (_, index) => `cname-hop-${index + 1}.example.net`),
+  ];
+  const cname: Row[] = [];
+  const cnameObservations: Row[] = [];
+  for (let index = 0; index < hopCount; index++) {
+    const owner = owners[index];
+    const target = owners[index + 1];
+    const observationId = `observation-cname-${index + 1}`;
+    cname.push(recordSet(`record-cname-${index + 1}`, owner, 'CNAME', [target], [observationId]));
+    cnameObservations.push(
+      observation(observationId, owner, 'CNAME', [cnameAnswer(owner, target)])
+    );
+  }
+
+  const terminalOwner = owners[hopCount];
+  const terminalCnameObservationId = 'observation-cname-terminal';
+  cname.push(
+    recordSet('record-cname-terminal', terminalOwner, 'CNAME', [], [terminalCnameObservationId])
+  );
+  cnameObservations.push(observation(terminalCnameObservationId, terminalOwner, 'CNAME', []));
+  return state({
+    cname,
+    txtOwnerName: terminalOwner,
+    observations: [
+      observation('observation-txt', terminalOwner, 'TXT', [txtAnswer(terminalOwner)]),
+      ...cnameObservations,
+    ],
+  });
+}
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -213,6 +246,30 @@ describe('loadPersistedMtaStsEvidence CNAME authorization', () => {
       expect(result.dnsResults[2]?.query).toEqual({ name: firstTarget, type: 'CNAME' });
       expect(result.expiresAt.getTime()).toBe(NOW.getTime() + 299_000);
     }
+  });
+
+  it('accepts exactly five persisted CNAME hops', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const result = await loadPersistedMtaStsEvidence(createDb(boundedChainState(5)), {
+      domain: 'example.com',
+      tenantId: 'tenant-a',
+    });
+
+    expect(result).toMatchObject({ ok: true, txtRecord: TXT, txtRecordId: '20260901' });
+  });
+
+  it('rejects a persisted CNAME chain at the six-hop limit', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const result = await loadPersistedMtaStsEvidence(createDb(boundedChainState(6)), {
+      domain: 'example.com',
+      tenantId: 'tenant-a',
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'cname-chain-hop-limit' });
   });
 
   it('rejects a TXT answer from an unrelated canonical owner', async () => {

--- a/apps/collector/src/probes/persisted-dns-authorization.ts
+++ b/apps/collector/src/probes/persisted-dns-authorization.ts
@@ -65,19 +65,21 @@ function fail(status: 400 | 403, error: string, reason: string): EvidenceFailure
   return { ok: false, status, error, reason };
 }
 
-interface TrustedChain {
+interface TrustedSnapshot {
   ok: true;
   domain: string;
   snapshot: Snapshot;
+}
+
+interface TrustedChain extends TrustedSnapshot {
   recordSet: RecordSet;
   ownerName: string;
 }
 
-async function loadTrustedRecordSet(
+async function loadTrustedSnapshot(
   db: IDatabaseAdapter,
-  input: { domain: string; tenantId: string },
-  recordType: 'MX' | 'TXT'
-): Promise<TrustedChain | EvidenceFailure> {
+  input: { domain: string; tenantId: string }
+): Promise<TrustedSnapshot | EvidenceFailure> {
   const normalized = tryNormalizeDomain(input.domain);
   if (!normalized) {
     return fail(400, 'Domain is invalid', 'invalid-domain');
@@ -97,15 +99,14 @@ async function loadTrustedRecordSet(
     return fail(403, 'Latest snapshot is not complete', 'incomplete-snapshot');
   }
 
-  const ownerName = recordType === 'MX' ? domain : `_mta-sts.${domain}`;
-  const recordSet = await new RecordSetRepository(db).findByNameAndType(
-    snapshot.id,
-    ownerName,
-    recordType
-  );
-  if (!recordSet) {
-    return fail(403, `No persisted ${recordType} record set for this domain`, 'missing-record-set');
-  }
+  return { ok: true, domain, snapshot };
+}
+
+function validateTrustedRecordSet(
+  context: TrustedSnapshot,
+  recordSet: RecordSet,
+  ownerName: string
+): TrustedChain | EvidenceFailure {
   if (recordSet.isConsistent !== true) {
     return fail(403, 'Record set is inconsistent across vantages', 'inconsistent-record-set');
   }
@@ -116,7 +117,28 @@ async function loadTrustedRecordSet(
     return fail(403, 'Record set has no source observations', 'missing-source-observations');
   }
 
-  return { ok: true, domain, snapshot, recordSet, ownerName };
+  return { ...context, recordSet, ownerName };
+}
+
+async function loadTrustedRecordSet(
+  db: IDatabaseAdapter,
+  input: { domain: string; tenantId: string },
+  recordType: 'MX' | 'TXT'
+): Promise<TrustedChain | EvidenceFailure> {
+  const context = await loadTrustedSnapshot(db, input);
+  if (!context.ok) return context;
+
+  const ownerName = recordType === 'MX' ? context.domain : `_mta-sts.${context.domain}`;
+  const recordSet = await new RecordSetRepository(db).findByNameAndType(
+    context.snapshot.id,
+    ownerName,
+    recordType
+  );
+  if (!recordSet) {
+    return fail(403, `No persisted ${recordType} record set for this domain`, 'missing-record-set');
+  }
+
+  return validateTrustedRecordSet(context, recordSet, ownerName);
 }
 
 interface RelevantObservation {
@@ -127,10 +149,12 @@ interface RelevantObservation {
 async function loadRelevantObservations(
   db: IDatabaseAdapter,
   chain: TrustedChain,
-  recordType: 'MX' | 'TXT'
+  recordType: 'CNAME' | 'MX' | 'TXT',
+  options: { answerNames?: ReadonlySet<string>; allowNoAnswers?: boolean } = {}
 ): Promise<RelevantObservation[] | EvidenceFailure> {
   const obsRepo = new ObservationRepository(db);
   const relevant: RelevantObservation[] = [];
+  const answerNames = options.answerNames ?? new Set([chain.ownerName]);
 
   for (const id of chain.recordSet.sourceObservationIds) {
     const obs = await obsRepo.findById(id);
@@ -151,7 +175,7 @@ async function loadRelevantObservations(
         'observation-query-mismatch'
       );
     }
-    if (obs.status !== 'success') {
+    if (obs.status !== 'success' && !(options.allowNoAnswers && obs.status === 'nodata')) {
       return fail(403, 'Source observation was not successful', 'unsuccessful-observation');
     }
     if (obs.responseCode !== DNS_RCODE.NOERROR) {
@@ -175,9 +199,9 @@ async function loadRelevantObservations(
     }
 
     const answers = (obs.answerSection ?? []).filter(
-      (a) => a.type === recordType && normalizeDNSDomain(a.name) === chain.ownerName
+      (a) => a.type === recordType && answerNames.has(normalizeDNSDomain(a.name))
     );
-    if (answers.length === 0) {
+    if (answers.length === 0 && !options.allowNoAnswers) {
       return fail(403, 'Observation carries no answer for this record set', 'missing-answer');
     }
 
@@ -227,13 +251,161 @@ function earliestFreshExpiry(relevant: RelevantObservation[], now: Date): Date |
   return earliest;
 }
 
+interface PersistedCnameChain {
+  ok: true;
+  canonicalOwnerName: string;
+  observations: RelevantObservation[];
+}
+
+/**
+ * Resolve only CNAME rows persisted in the same complete snapshot. The
+ * source observations are checked just like MX/TXT evidence, so a row cannot
+ * redirect authorization through an unrelated owner or an untrusted vantage.
+ */
+function normalizeCnameTarget(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = normalizeDNSDomain(value.trim());
+  if (
+    !normalized ||
+    normalized.length > 253 ||
+    normalized.includes('..') ||
+    normalized
+      .split('.')
+      .some(
+        (label) =>
+          !label ||
+          label.length > 63 ||
+          label.startsWith('-') ||
+          label.endsWith('-') ||
+          !/^[a-z0-9_-]+$/i.test(label)
+      )
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+async function loadPersistedCnameChain(
+  db: IDatabaseAdapter,
+  context: TrustedSnapshot,
+  initialOwnerName: string
+): Promise<PersistedCnameChain | EvidenceFailure> {
+  const recordSetRepo = new RecordSetRepository(db);
+  const visited = new Set<string>();
+  const observations: RelevantObservation[] = [];
+  let ownerName = initialOwnerName;
+
+  while (true) {
+    if (visited.has(ownerName)) {
+      return fail(403, 'Persisted CNAME chain contains a loop', 'cname-chain-loop');
+    }
+    visited.add(ownerName);
+
+    const cnameRecordSet = await recordSetRepo.findByNameAndType(
+      context.snapshot.id,
+      ownerName,
+      'CNAME'
+    );
+    if (!cnameRecordSet) {
+      return { ok: true, canonicalOwnerName: ownerName, observations };
+    }
+    if (
+      !Array.isArray(cnameRecordSet.sourceObservationIds) ||
+      cnameRecordSet.sourceObservationIds.length === 0
+    ) {
+      return fail(
+        403,
+        'CNAME record set has no source observations',
+        'missing-cname-source-observations'
+      );
+    }
+    if (!Array.isArray(cnameRecordSet.values)) {
+      return fail(403, 'CNAME record set has no target', 'missing-cname-target');
+    }
+
+    const cnameChain: TrustedChain = {
+      ...context,
+      recordSet: cnameRecordSet,
+      ownerName,
+    };
+    const relevant = await loadRelevantObservations(db, cnameChain, 'CNAME', {
+      allowNoAnswers: true,
+    });
+    if (!Array.isArray(relevant)) return relevant;
+
+    // A successful NODATA CNAME lookup proves that this owner is the terminal
+    // name. Do not require a target on the empty CNAME record set created for
+    // that observation; the terminal TXT record is checked by the caller.
+    if (cnameRecordSet.values.length === 0) {
+      if (relevant.some(({ observation }) => (observation.answerSection ?? []).length > 0)) {
+        return fail(
+          403,
+          'CNAME record set has answers but no stored target',
+          'unbacked-cname-target'
+        );
+      }
+      return { ok: true, canonicalOwnerName: ownerName, observations };
+    }
+
+    if (cnameRecordSet.isConsistent !== true) {
+      return fail(
+        403,
+        'CNAME record set is inconsistent across vantages',
+        'inconsistent-cname-record-set'
+      );
+    }
+    if (relevant.some(({ answers }) => answers.length === 0)) {
+      return fail(403, 'CNAME observation has no answer', 'missing-answer');
+    }
+
+    const targets: string[] = [];
+    for (const { answers } of relevant) {
+      for (const answer of answers) {
+        const target = normalizeCnameTarget(answer.data);
+        if (!target) {
+          return fail(403, 'Persisted CNAME target is malformed', 'malformed-cname-target');
+        }
+        targets.push(target);
+      }
+    }
+
+    const uniqueTargets = [...new Set(targets)];
+    if (uniqueTargets.length !== 1) {
+      return fail(403, 'Persisted CNAME chain has conflicting targets', 'conflicting-cname-target');
+    }
+
+    const storedTargets = cnameRecordSet.values.map((value) => normalizeCnameTarget(value));
+    if (
+      storedTargets.some((target) => !target) ||
+      storedTargets.length !== 1 ||
+      storedTargets[0] !== uniqueTargets[0]
+    ) {
+      return fail(
+        403,
+        'Persisted CNAME target is not backed by its source',
+        'unbacked-cname-target'
+      );
+    }
+
+    observations.push(...relevant);
+    const target = uniqueTargets[0];
+    if (visited.has(target)) {
+      return fail(403, 'Persisted CNAME chain contains a loop', 'cname-chain-loop');
+    }
+    ownerName = target;
+  }
+}
+
 function toDnsResults(
   relevant: RelevantObservation[],
   ownerName: string,
-  recordType: 'MX' | 'TXT'
+  recordType: 'CNAME' | 'MX' | 'TXT'
 ): DNSQueryResult[] {
   return relevant.map(({ observation, answers }) => ({
-    query: { name: ownerName, type: recordType },
+    query: {
+      name: recordType === 'CNAME' ? normalizeDNSDomain(observation.queryName) : ownerName,
+      type: recordType,
+    },
     vantage: {
       type: observation.vantageType === 'public-recursive' ? 'public-recursive' : 'authoritative',
       identifier: observation.vantageIdentifier ?? '',
@@ -303,7 +475,22 @@ export async function loadPersistedMtaStsEvidence(
   db: IDatabaseAdapter,
   input: { domain: string; tenantId: string }
 ): Promise<PersistedMtaStsEvidence | EvidenceFailure> {
-  const chain = await loadTrustedRecordSet(db, input, 'TXT');
+  const context = await loadTrustedSnapshot(db, input);
+  if (!context.ok) return context;
+
+  const initialOwnerName = `_mta-sts.${context.domain}`;
+  const cnameChain = await loadPersistedCnameChain(db, context, initialOwnerName);
+  if (!cnameChain.ok) return cnameChain;
+
+  const txtRecordSet = await new RecordSetRepository(db).findByNameAndType(
+    context.snapshot.id,
+    cnameChain.canonicalOwnerName,
+    'TXT'
+  );
+  if (!txtRecordSet) {
+    return fail(403, 'No persisted TXT record set for this domain', 'missing-record-set');
+  }
+  const chain = validateTrustedRecordSet(context, txtRecordSet, cnameChain.canonicalOwnerName);
   if (!chain.ok) return chain;
 
   const values = Array.isArray(chain.recordSet.values) ? chain.recordSet.values : [];
@@ -327,7 +514,7 @@ export async function loadPersistedMtaStsEvidence(
   }
 
   const now = new Date();
-  const expiresAt = earliestFreshExpiry(relevant, now);
+  const expiresAt = earliestFreshExpiry([...cnameChain.observations, ...relevant], now);
   if (!(expiresAt instanceof Date)) return expiresAt;
 
   const validation = await validateMTASTSTxtRecord(chain.domain, [txtRecord]);
@@ -341,6 +528,9 @@ export async function loadPersistedMtaStsEvidence(
     txtRecord,
     txtRecordId: validation.id ?? '',
     expiresAt,
-    dnsResults: toDnsResults(relevant, chain.ownerName, 'TXT'),
+    dnsResults: [
+      ...toDnsResults(relevant, chain.ownerName, 'TXT'),
+      ...toDnsResults(cnameChain.observations, initialOwnerName, 'CNAME'),
+    ],
   };
 }

--- a/apps/collector/src/probes/persisted-dns-authorization.ts
+++ b/apps/collector/src/probes/persisted-dns-authorization.ts
@@ -28,7 +28,7 @@ import {
   type Snapshot,
   SnapshotRepository,
 } from '@dns-ops/db';
-import { normalizeDNSDomain, tryNormalizeDomain } from '@dns-ops/parsing';
+import { MAX_DNS_CNAME_HOPS, tryNormalizeDNSOwner, tryNormalizeDomain } from '@dns-ops/parsing';
 import type { DNSQueryResult } from '../dns/types.js';
 import { validateMTASTSTxtRecord } from './mta-sts.js';
 
@@ -154,7 +154,11 @@ async function loadRelevantObservations(
 ): Promise<RelevantObservation[] | EvidenceFailure> {
   const obsRepo = new ObservationRepository(db);
   const relevant: RelevantObservation[] = [];
-  const answerNames = options.answerNames ?? new Set([chain.ownerName]);
+  const answerNames = new Set(
+    [...(options.answerNames ?? new Set([chain.ownerName]))]
+      .map((name) => tryNormalizeDNSOwner(name)?.normalized)
+      .filter((name): name is string => name !== undefined)
+  );
 
   for (const id of chain.recordSet.sourceObservationIds) {
     const obs = await obsRepo.findById(id);
@@ -168,7 +172,8 @@ async function loadRelevantObservations(
         'observation-snapshot-mismatch'
       );
     }
-    if (normalizeDNSDomain(obs.queryName) !== chain.ownerName || obs.queryType !== recordType) {
+    const observationOwner = tryNormalizeDNSOwner(obs.queryName)?.normalized;
+    if (observationOwner !== chain.ownerName || obs.queryType !== recordType) {
       return fail(
         403,
         'Observation does not match the record set query',
@@ -198,9 +203,11 @@ async function loadRelevantObservations(
       );
     }
 
-    const answers = (obs.answerSection ?? []).filter(
-      (a) => a.type === recordType && answerNames.has(normalizeDNSDomain(a.name))
-    );
+    const answers = (obs.answerSection ?? []).filter((a) => {
+      if (a.type !== recordType) return false;
+      const owner = tryNormalizeDNSOwner(a.name)?.normalized;
+      return owner !== undefined && answerNames.has(owner);
+    });
     if (answers.length === 0 && !options.allowNoAnswers) {
       return fail(403, 'Observation carries no answer for this record set', 'missing-answer');
     }
@@ -263,26 +270,7 @@ interface PersistedCnameChain {
  * redirect authorization through an unrelated owner or an untrusted vantage.
  */
 function normalizeCnameTarget(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const normalized = normalizeDNSDomain(value.trim());
-  if (
-    !normalized ||
-    normalized.length > 253 ||
-    normalized.includes('..') ||
-    normalized
-      .split('.')
-      .some(
-        (label) =>
-          !label ||
-          label.length > 63 ||
-          label.startsWith('-') ||
-          label.endsWith('-') ||
-          !/^[a-z0-9_-]+$/i.test(label)
-      )
-  ) {
-    return null;
-  }
-  return normalized;
+  return typeof value === 'string' ? (tryNormalizeDNSOwner(value)?.normalized ?? null) : null;
 }
 
 async function loadPersistedCnameChain(
@@ -294,6 +282,7 @@ async function loadPersistedCnameChain(
   const visited = new Set<string>();
   const observations: RelevantObservation[] = [];
   let ownerName = initialOwnerName;
+  let hopCount = 0;
 
   while (true) {
     if (visited.has(ownerName)) {
@@ -346,6 +335,13 @@ async function loadPersistedCnameChain(
       }
       return { ok: true, canonicalOwnerName: ownerName, observations };
     }
+    if (hopCount >= MAX_DNS_CNAME_HOPS) {
+      return fail(
+        403,
+        `Persisted CNAME chain exceeds ${MAX_DNS_CNAME_HOPS} hops`,
+        'cname-chain-hop-limit'
+      );
+    }
 
     if (cnameRecordSet.isConsistent !== true) {
       return fail(
@@ -392,6 +388,7 @@ async function loadPersistedCnameChain(
     if (visited.has(target)) {
       return fail(403, 'Persisted CNAME chain contains a loop', 'cname-chain-loop');
     }
+    hopCount++;
     ownerName = target;
   }
 }
@@ -403,7 +400,10 @@ function toDnsResults(
 ): DNSQueryResult[] {
   return relevant.map(({ observation, answers }) => ({
     query: {
-      name: recordType === 'CNAME' ? normalizeDNSDomain(observation.queryName) : ownerName,
+      name:
+        recordType === 'CNAME'
+          ? (tryNormalizeDNSOwner(observation.queryName)?.normalized ?? observation.queryName)
+          : ownerName,
       type: recordType,
     },
     vantage: {
@@ -412,7 +412,12 @@ function toDnsResults(
     },
     success: true,
     responseCode: observation.responseCode ?? DNS_RCODE.NOERROR,
-    answers: answers.map((a) => ({ name: a.name, type: a.type, ttl: a.ttl ?? 0, data: a.data })),
+    answers: answers.map((a) => ({
+      name: tryNormalizeDNSOwner(a.name)?.normalized ?? a.name,
+      type: a.type,
+      ttl: a.ttl ?? 0,
+      data: a.data,
+    })),
     authority: [],
     additional: [],
     responseTime: observation.responseTimeMs ?? 0,
@@ -445,7 +450,7 @@ export async function loadPersistedMxEvidence(
         return fail(403, 'Persisted MX answer is malformed', 'malformed-mx-answer');
       }
       const priority = Number.parseInt(parts[0], 10);
-      const target = tryNormalizeDomain(parts[1]);
+      const target = tryNormalizeDNSOwner(parts[1]);
       if (!Number.isFinite(priority) || !target) {
         return fail(403, 'Persisted MX answer is malformed', 'malformed-mx-answer');
       }
@@ -478,7 +483,10 @@ export async function loadPersistedMtaStsEvidence(
   const context = await loadTrustedSnapshot(db, input);
   if (!context.ok) return context;
 
-  const initialOwnerName = `_mta-sts.${context.domain}`;
+  const initialOwnerName = tryNormalizeDNSOwner(`_mta-sts.${context.domain}`)?.normalized;
+  if (!initialOwnerName) {
+    return fail(400, 'MTA-STS owner is invalid', 'invalid-mta-sts-owner');
+  }
   const cnameChain = await loadPersistedCnameChain(db, context, initialOwnerName);
   if (!cnameChain.ok) return cnameChain;
 

--- a/apps/collector/src/probes/persisted-dns-authorization.ts
+++ b/apps/collector/src/probes/persisted-dns-authorization.ts
@@ -1,0 +1,346 @@
+/**
+ * Persisted DNS Authorization - Issue #67
+ *
+ * Loads and validates the only DNS evidence trusted for probe target
+ * authorization: the collector-created chain
+ *
+ *   tenant-owned domain → latest complete snapshot → consistent record set
+ *     → immutable source observations
+ *
+ * Caller-supplied DNS-shaped arrays (txtRecords / mxRecords / dnsResults) are
+ * never accepted here. Every observation must come from a trusted collector
+ * vantage (missing, `mock`, and `probe` provenance is rejected), authoritative
+ * answers must carry the AA flag, and every relevant answer must still be
+ * fresh, where freshness is `queriedAt + min(answer TTL, 5 minutes)` — the
+ * same ceiling the probe allowlist already enforces. Anything else fails
+ * closed.
+ */
+
+import { DNS_RCODE } from '@dns-ops/contracts';
+import {
+  type DNSRecord,
+  DomainRepository,
+  type IDatabaseAdapter,
+  type Observation,
+  ObservationRepository,
+  type RecordSet,
+  RecordSetRepository,
+  type Snapshot,
+  SnapshotRepository,
+} from '@dns-ops/db';
+import { normalizeDNSDomain, tryNormalizeDomain } from '@dns-ops/parsing';
+import type { DNSQueryResult } from '../dns/types.js';
+import { validateMTASTSTxtRecord } from './mta-sts.js';
+
+/** Freshness ceiling for persisted evidence. Mirrors the allowlist TTL. */
+const MAX_EVIDENCE_FRESHNESS_MS = 5 * 60 * 1000;
+
+export interface EvidenceFailure {
+  ok: false;
+  status: 400 | 403;
+  error: string;
+  reason: string;
+}
+
+export interface PersistedMxEvidence {
+  ok: true;
+  domain: string;
+  hosts: Array<{ hostname: string; priority: number }>;
+  expiresAt: Date;
+  /** Derived only from persisted observations; feeds the tenant allowlist. */
+  dnsResults: DNSQueryResult[];
+}
+
+export interface PersistedMtaStsEvidence {
+  ok: true;
+  domain: string;
+  txtRecord: string;
+  txtRecordId: string;
+  expiresAt: Date;
+  /** Derived only from persisted observations; feeds the tenant allowlist. */
+  dnsResults: DNSQueryResult[];
+}
+
+function fail(status: 400 | 403, error: string, reason: string): EvidenceFailure {
+  return { ok: false, status, error, reason };
+}
+
+interface TrustedChain {
+  ok: true;
+  domain: string;
+  snapshot: Snapshot;
+  recordSet: RecordSet;
+  ownerName: string;
+}
+
+async function loadTrustedRecordSet(
+  db: IDatabaseAdapter,
+  input: { domain: string; tenantId: string },
+  recordType: 'MX' | 'TXT'
+): Promise<TrustedChain | EvidenceFailure> {
+  const normalized = tryNormalizeDomain(input.domain);
+  if (!normalized) {
+    return fail(400, 'Domain is invalid', 'invalid-domain');
+  }
+  const domain = normalized.normalized;
+
+  const domainRow = await new DomainRepository(db).findByNameForTenant(domain, input.tenantId);
+  if (!domainRow || domainRow.tenantId !== input.tenantId) {
+    return fail(403, 'Domain is not registered for this tenant', 'unknown-domain');
+  }
+
+  const snapshot = await new SnapshotRepository(db).findLatestByDomain(domainRow.id);
+  if (!snapshot) {
+    return fail(403, 'No snapshot exists for this domain', 'missing-snapshot');
+  }
+  if (snapshot.resultState !== 'complete') {
+    return fail(403, 'Latest snapshot is not complete', 'incomplete-snapshot');
+  }
+
+  const ownerName = recordType === 'MX' ? domain : `_mta-sts.${domain}`;
+  const recordSet = await new RecordSetRepository(db).findByNameAndType(
+    snapshot.id,
+    ownerName,
+    recordType
+  );
+  if (!recordSet) {
+    return fail(403, `No persisted ${recordType} record set for this domain`, 'missing-record-set');
+  }
+  if (recordSet.isConsistent !== true) {
+    return fail(403, 'Record set is inconsistent across vantages', 'inconsistent-record-set');
+  }
+  if (
+    !Array.isArray(recordSet.sourceObservationIds) ||
+    recordSet.sourceObservationIds.length === 0
+  ) {
+    return fail(403, 'Record set has no source observations', 'missing-source-observations');
+  }
+
+  return { ok: true, domain, snapshot, recordSet, ownerName };
+}
+
+interface RelevantObservation {
+  observation: Observation;
+  answers: DNSRecord[];
+}
+
+async function loadRelevantObservations(
+  db: IDatabaseAdapter,
+  chain: TrustedChain,
+  recordType: 'MX' | 'TXT'
+): Promise<RelevantObservation[] | EvidenceFailure> {
+  const obsRepo = new ObservationRepository(db);
+  const relevant: RelevantObservation[] = [];
+
+  for (const id of chain.recordSet.sourceObservationIds) {
+    const obs = await obsRepo.findById(id);
+    if (!obs) {
+      return fail(403, 'Source observation is missing', 'missing-source-observation');
+    }
+    if (obs.snapshotId !== chain.snapshot.id) {
+      return fail(
+        403,
+        'Observation belongs to a different snapshot',
+        'observation-snapshot-mismatch'
+      );
+    }
+    if (normalizeDNSDomain(obs.queryName) !== chain.ownerName || obs.queryType !== recordType) {
+      return fail(
+        403,
+        'Observation does not match the record set query',
+        'observation-query-mismatch'
+      );
+    }
+    if (obs.status !== 'success') {
+      return fail(403, 'Source observation was not successful', 'unsuccessful-observation');
+    }
+    if (obs.responseCode !== DNS_RCODE.NOERROR) {
+      return fail(403, 'Source observation has a failed DNS response', 'dns-response-failure');
+    }
+
+    const identifier = (obs.vantageIdentifier ?? '').trim();
+    if (!identifier) {
+      return fail(403, 'Observation has no vantage identifier', 'missing-vantage-identifier');
+    }
+    const lowered = identifier.toLowerCase();
+    if (lowered === 'mock' || lowered === 'probe' || obs.vantageType === 'probe') {
+      return fail(403, 'Observation vantage is not trusted', 'untrusted-vantage');
+    }
+    if (obs.vantageType === 'authoritative' && obs.flags?.authoritative !== true) {
+      return fail(
+        403,
+        'Authoritative observation is missing the AA flag',
+        'authoritative-answer-flag-missing'
+      );
+    }
+
+    const answers = (obs.answerSection ?? []).filter(
+      (a) => a.type === recordType && normalizeDNSDomain(a.name) === chain.ownerName
+    );
+    if (answers.length === 0) {
+      return fail(403, 'Observation carries no answer for this record set', 'missing-answer');
+    }
+
+    relevant.push({ observation: obs, answers });
+  }
+
+  return relevant;
+}
+
+/**
+ * Freshness of one answer: queriedAt + min(answer TTL, five-minute ceiling),
+ * strictly in the future. Zero/invalid TTLs, future-dated queries, and the
+ * exact expiry boundary all fail.
+ */
+function answerExpiry(queriedAt: unknown, ttlSeconds: unknown, now: Date): Date | null {
+  const queried =
+    queriedAt instanceof Date ? queriedAt.getTime() : Date.parse(String(queriedAt ?? ''));
+  if (!Number.isFinite(queried)) {
+    return null;
+  }
+  if (!Number.isFinite(ttlSeconds as number) || (ttlSeconds as number) <= 0) {
+    return null;
+  }
+  if (queried > now.getTime()) {
+    return null;
+  }
+  const ttlMs = Math.min((ttlSeconds as number) * 1000, MAX_EVIDENCE_FRESHNESS_MS);
+  return new Date(queried + ttlMs);
+}
+
+function earliestFreshExpiry(relevant: RelevantObservation[], now: Date): Date | EvidenceFailure {
+  let earliest: Date | null = null;
+  for (const { observation, answers } of relevant) {
+    for (const answer of answers) {
+      const expiry = answerExpiry(observation.queriedAt, answer.ttl, now);
+      if (!expiry || expiry.getTime() <= now.getTime()) {
+        return fail(403, 'Persisted DNS evidence is stale', 'stale-evidence');
+      }
+      if (!earliest || expiry < earliest) {
+        earliest = expiry;
+      }
+    }
+  }
+  if (!earliest) {
+    return fail(403, 'Persisted DNS evidence has no answers', 'missing-answer');
+  }
+  return earliest;
+}
+
+function toDnsResults(
+  relevant: RelevantObservation[],
+  ownerName: string,
+  recordType: 'MX' | 'TXT'
+): DNSQueryResult[] {
+  return relevant.map(({ observation, answers }) => ({
+    query: { name: ownerName, type: recordType },
+    vantage: {
+      type: observation.vantageType === 'public-recursive' ? 'public-recursive' : 'authoritative',
+      identifier: observation.vantageIdentifier ?? '',
+    },
+    success: true,
+    responseCode: observation.responseCode ?? DNS_RCODE.NOERROR,
+    answers: answers.map((a) => ({ name: a.name, type: a.type, ttl: a.ttl ?? 0, data: a.data })),
+    authority: [],
+    additional: [],
+    responseTime: observation.responseTimeMs ?? 0,
+  }));
+}
+
+/**
+ * Load fresh, persisted MX evidence for a tenant-owned domain.
+ */
+export async function loadPersistedMxEvidence(
+  db: IDatabaseAdapter,
+  input: { domain: string; tenantId: string }
+): Promise<PersistedMxEvidence | EvidenceFailure> {
+  const chain = await loadTrustedRecordSet(db, input, 'MX');
+  if (!chain.ok) return chain;
+
+  const relevant = await loadRelevantObservations(db, chain, 'MX');
+  if (!Array.isArray(relevant)) return relevant;
+
+  const now = new Date();
+  const expiresAt = earliestFreshExpiry(relevant, now);
+  if (!(expiresAt instanceof Date)) return expiresAt;
+
+  const hosts: Array<{ hostname: string; priority: number }> = [];
+  const seen = new Set<string>();
+  for (const { answers } of relevant) {
+    for (const answer of answers) {
+      const parts = answer.data.trim().split(/\s+/);
+      if (parts.length < 2) {
+        return fail(403, 'Persisted MX answer is malformed', 'malformed-mx-answer');
+      }
+      const priority = Number.parseInt(parts[0], 10);
+      const target = tryNormalizeDomain(parts[1]);
+      if (!Number.isFinite(priority) || !target) {
+        return fail(403, 'Persisted MX answer is malformed', 'malformed-mx-answer');
+      }
+      if (!seen.has(target.normalized)) {
+        seen.add(target.normalized);
+        hosts.push({ hostname: target.normalized, priority });
+      }
+    }
+  }
+  if (hosts.length === 0) {
+    return fail(403, 'Persisted MX evidence has no targets', 'missing-answer');
+  }
+
+  return {
+    ok: true,
+    domain: chain.domain,
+    hosts,
+    expiresAt,
+    dnsResults: toDnsResults(relevant, chain.ownerName, 'MX'),
+  };
+}
+
+/**
+ * Load fresh, persisted MTA-STS TXT evidence for a tenant-owned domain.
+ */
+export async function loadPersistedMtaStsEvidence(
+  db: IDatabaseAdapter,
+  input: { domain: string; tenantId: string }
+): Promise<PersistedMtaStsEvidence | EvidenceFailure> {
+  const chain = await loadTrustedRecordSet(db, input, 'TXT');
+  if (!chain.ok) return chain;
+
+  const values = Array.isArray(chain.recordSet.values) ? chain.recordSet.values : [];
+  const txtRecord = values.find((v) => v.includes('v=STSv1'));
+  if (!txtRecord) {
+    return fail(403, 'No persisted MTA-STS TXT record', 'missing-mta-sts-txt');
+  }
+
+  const relevant = await loadRelevantObservations(db, chain, 'TXT');
+  if (!Array.isArray(relevant)) return relevant;
+
+  // The TXT value must be backed by a fresh source observation, not just the
+  // consolidated record-set row.
+  const backedByAnswer = relevant.some(({ answers }) => answers.some((a) => a.data === txtRecord));
+  if (!backedByAnswer) {
+    return fail(
+      403,
+      'MTA-STS TXT value is not backed by a source observation',
+      'unbacked-mta-sts-txt'
+    );
+  }
+
+  const now = new Date();
+  const expiresAt = earliestFreshExpiry(relevant, now);
+  if (!(expiresAt instanceof Date)) return expiresAt;
+
+  const validation = await validateMTASTSTxtRecord(chain.domain, [txtRecord]);
+  if (!validation.valid) {
+    return fail(403, validation.error ?? 'MTA-STS TXT record is invalid', 'missing-mta-sts-txt');
+  }
+
+  return {
+    ok: true,
+    domain: chain.domain,
+    txtRecord,
+    txtRecordId: validation.id ?? '',
+    expiresAt,
+    dnsResults: toDnsResults(relevant, chain.ownerName, 'TXT'),
+  };
+}

--- a/apps/collector/src/probes/smtp-starttls.e2e.test.ts
+++ b/apps/collector/src/probes/smtp-starttls.e2e.test.ts
@@ -1,255 +1,197 @@
-/**
- * SMTP STARTTLS Probe - E2E Integration Tests
- *
- * Tests the complete SMTP probe flow including:
- * - Multiline EHLO response parsing (SEC-004 fix)
- * - STARTTLS detection in any position of multiline response
- * - Edge cases in SMTP response handling
- *
- * NOTE: These tests use real network connections to localhost SMTP servers
- * if available, or skip if no SMTP server is running.
- */
+/** Deterministic SMTP STARTTLS integration fixtures. */
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { probeSMTPStarttls } from './smtp-starttls.js';
 
-// Track if we have a local SMTP server to test against
-let hasLocalSMTP = false;
+interface FixtureSocketView {
+  connectArgs: { port: number; host: string } | null;
+  writes: string[];
+  destroyed: boolean;
+  ended: boolean;
+}
 
-beforeAll(async () => {
-  // Check if localhost:25 or localhost:1025 (maildev) is available
-  try {
-    const { default: dns } = await import('node:dns');
-    const { promisify } = await import('node:util');
-    const lookup = promisify(dns.lookup);
+interface FixtureTlsSocketView {
+  options: Record<string, unknown>;
+  writes: string[];
+  destroyed: boolean;
+  ended: boolean;
+}
 
-    // Try to resolve localhost
-    await lookup('localhost');
+const fixtureState = vi.hoisted(() => ({
+  sockets: [] as FixtureSocketView[],
+  tlsSockets: [] as FixtureTlsSocketView[],
+  lookup: vi.fn(),
+  tlsConnect: vi.fn(),
+}));
 
-    // Try TCP connection to common SMTP ports
-    const { default: net } = await import('node:net');
-    const ports = [25, 1025, 2525, 587];
+vi.mock('node:dns', () => ({
+  promises: {
+    lookup: fixtureState.lookup,
+  },
+}));
 
-    for (const port of ports) {
-      const connected = await new Promise<boolean>((resolve) => {
-        const socket = new net.Socket();
-        socket.setTimeout(1000);
-        socket.on('connect', () => {
-          socket.destroy();
-          resolve(true);
-        });
-        socket.on('timeout', () => {
-          socket.destroy();
-          resolve(false);
-        });
-        socket.on('error', () => {
-          socket.destroy();
-          resolve(false);
-        });
-        socket.connect(port, '127.0.0.1');
-      });
+vi.mock('node:net', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:net')>();
+  const { EventEmitter } = await import('node:events');
 
-      if (connected) {
-        hasLocalSMTP = true;
-        break;
-      }
+  class FixtureSocket extends EventEmitter {
+    connectArgs: { port: number; host: string } | null = null;
+    writes: string[] = [];
+    timeoutMs: number | undefined;
+    destroyed = false;
+    ended = false;
+
+    constructor() {
+      super();
+      fixtureState.sockets.push(this);
     }
-  } catch {
-    // DNS or other errors - skip
+
+    connect(port: number, host: string): this {
+      this.connectArgs = { port, host };
+      queueMicrotask(() => {
+        this.emit('connect');
+        queueMicrotask(() =>
+          this.emit('data', Buffer.from('220 mail.fixture.example ESMTP ready\r\n'))
+        );
+      });
+      return this;
+    }
+
+    setTimeout(timeoutMs: number): this {
+      this.timeoutMs = timeoutMs;
+      return this;
+    }
+
+    write(chunk: string): boolean {
+      this.writes.push(chunk);
+      if (chunk.startsWith('EHLO')) {
+        queueMicrotask(() => {
+          this.emit(
+            'data',
+            Buffer.from('250-mail.fixture.example\r\n250-SIZE 102400\r\n250-START')
+          );
+          queueMicrotask(() => this.emit('data', Buffer.from('TLS\r\n250 HELP\r\n')));
+        });
+      } else if (chunk.startsWith('STARTTLS')) {
+        queueMicrotask(() => this.emit('data', Buffer.from('220 2.0.0 Ready to start TLS\r\n')));
+      }
+      return true;
+    }
+
+    destroy(): this {
+      this.destroyed = true;
+      return this;
+    }
+
+    end(): this {
+      this.ended = true;
+      return this;
+    }
   }
+
+  return { ...actual, Socket: FixtureSocket };
 });
 
-afterAll(() => {
-  // Cleanup if needed
+vi.mock('node:tls', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:tls')>();
+  const { EventEmitter } = await import('node:events');
+
+  class FixtureTlsSocket extends EventEmitter {
+    readonly options: Record<string, unknown>;
+    writes: string[] = [];
+    timeoutMs: number | undefined;
+    destroyed = false;
+    ended = false;
+
+    constructor(options: Record<string, unknown>) {
+      super();
+      this.options = options;
+      fixtureState.tlsSockets.push(this);
+    }
+
+    setTimeout(timeoutMs: number): this {
+      this.timeoutMs = timeoutMs;
+      return this;
+    }
+
+    getCipher() {
+      return { name: 'TLS_AES_128_GCM_SHA256', version: 'TLSv1.3' };
+    }
+
+    getPeerCertificate() {
+      return {
+        subject: { CN: 'mail.fixture.example' },
+        issuer: { CN: 'fixture-ca' },
+        valid_from: 'Jan 1 00:00:00 2026 GMT',
+        valid_to: 'Jan 1 00:00:00 2027 GMT',
+        fingerprint: 'AA:BB:CC',
+      };
+    }
+
+    write(chunk: string): boolean {
+      this.writes.push(chunk);
+      return true;
+    }
+
+    end(): this {
+      this.ended = true;
+      return this;
+    }
+
+    destroy(): this {
+      this.destroyed = true;
+      return this;
+    }
+  }
+
+  fixtureState.tlsConnect.mockImplementation((options: Record<string, unknown>) => {
+    const socket = new FixtureTlsSocket(options);
+    queueMicrotask(() => socket.emit('secureConnect'));
+    return socket;
+  });
+
+  return { ...actual, connect: fixtureState.tlsConnect };
 });
 
-describe('SMTP STARTTLS Probe E2E', () => {
-  describe('Multiline Response Parsing (SEC-004)', () => {
-    /**
-     * SEC-004 Bug: Previously only checked the last line for STARTTLS.
-     * This test verifies the fix works for STARTTLS in middle of response.
-     *
-     * SMTP multiline format:
-     * 250-Line1\r\n
-     * 250-Line2\r\n
-     * 250 OK\r\n
-     *
-     * The last line has SPACE after code, continuation lines have HYPHEN.
-     */
-    it('should detect STARTTLS capability regardless of position in multiline response', async () => {
-      if (!hasLocalSMTP) {
-        // Cannot test without local SMTP server
-        // The multiline parsing is tested in unit tests
-        expect(true).toBe(true);
-        return;
-      }
-
-      // Real SMTP test - should work against any properly configured SMTP server
-      const result = await probeSMTPStarttls('127.0.0.1', {
-        port: 25,
-        timeoutMs: 5000,
-        checkAllowlist: false, // Bypass allowlist for localhost
-      });
-
-      // Even if STARTTLS is not supported, the probe should complete without error
-      expect(result).toHaveProperty('success');
-      expect(result).toHaveProperty('supportsStarttls');
-      expect(result).toHaveProperty('smtpBanner');
-
-      // The key assertion: if smtpBanner exists and contains EHLO response,
-      // we should have correctly parsed it
-      if (result.smtpBanner) {
-        // Banner should be a string (not undefined or empty)
-        expect(typeof result.smtpBanner).toBe('string');
-        expect(result.smtpBanner.length).toBeGreaterThan(0);
-      }
-    });
-
-    it('should handle empty SMTP banner gracefully', async () => {
-      if (!hasLocalSMTP) {
-        expect(true).toBe(true);
-        return;
-      }
-
-      // Even with minimal SMTP response, should not crash
-      const result = await probeSMTPStarttls('127.0.0.1', {
-        port: 25,
-        timeoutMs: 3000,
-        checkAllowlist: false,
-      });
-
-      expect(result).toHaveProperty('success');
-      expect(result).toHaveProperty('responseTimeMs');
-      expect(result.responseTimeMs).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should report correct error when connection fails', async () => {
-      // Connect to a port that's not running SMTP
-      const result = await probeSMTPStarttls('127.0.0.1', {
-        port: 59999, // Unlikely to have SMTP here
-        timeoutMs: 3000,
-        checkAllowlist: false,
-      });
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
-      // Should have an error message (exact text varies by OS)
-      expect(result.error?.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('STARTTLS Detection Edge Cases', () => {
-    it('should handle STARTTLS in various capitalizations', async () => {
-      if (!hasLocalSMTP) {
-        expect(true).toBe(true);
-        return;
-      }
-
-      // The code converts to uppercase, so variations should all work
-      const result = await probeSMTPStarttls('127.0.0.1', {
-        port: 25,
-        timeoutMs: 5000,
-        checkAllowlist: false,
-      });
-
-      // Should have checked for STARTTLS regardless of capitalization
-      expect(result).toHaveProperty('supportsStarttls');
-    });
-
-    it('should handle SMTP servers that only support TLS from the start (implicit TLS)', async () => {
-      // Some SMTP servers use implicit TLS on port 465
-      const result = await probeSMTPStarttls('127.0.0.1', {
-        port: 465,
-        timeoutMs: 3000,
-        checkAllowlist: false,
-      });
-
-      // Implicit TLS servers won't respond to plaintext EHLO
-      // The probe should handle this gracefully
-      expect(result).toHaveProperty('success');
-    });
-  });
-
-  describe('Response Buffer Handling', () => {
-    it('should handle responses split across multiple TCP packets', async () => {
-      if (!hasLocalSMTP) {
-        expect(true).toBe(true);
-        return;
-      }
-
-      // Real network can deliver responses in chunks
-      const result = await probeSMTPStarttls('127.0.0.1', {
-        port: 25,
-        timeoutMs: 5000,
-        checkAllowlist: false,
-      });
-
-      // Should complete successfully even with chunked delivery
-      expect(result).toHaveProperty('responseTimeMs');
-      expect(result.responseTimeMs).toBeGreaterThan(0);
-    });
-
-    it('should handle rapid sequential responses', async () => {
-      if (!hasLocalSMTP) {
-        expect(true).toBe(true);
-        return;
-      }
-
-      // Probe multiple servers in quick succession
-      const results = await Promise.all([
-        probeSMTPStarttls('127.0.0.1', { port: 25, timeoutMs: 5000, checkAllowlist: false }),
-        probeSMTPStarttls('127.0.0.1', { port: 25, timeoutMs: 5000, checkAllowlist: false }),
-      ]);
-
-      // Both should complete
-      expect(results).toHaveLength(2);
-      expect(results[0]).toHaveProperty('success');
-      expect(results[1]).toHaveProperty('success');
-    });
-  });
+beforeEach(() => {
+  fixtureState.lookup.mockReset().mockResolvedValue({ address: '93.184.216.34', family: 4 });
+  fixtureState.tlsConnect.mockClear();
+  fixtureState.sockets.length = 0;
+  fixtureState.tlsSockets.length = 0;
 });
 
-/**
- * Regression test for SEC-004
- *
- * The original bug: readResponse only checked lastLine for STARTTLS
- * causing servers that put STARTTLS in middle of multiline response to
- * be incorrectly reported as not supporting STARTTLS.
- *
- * This test documents the expected behavior.
- */
-describe('SEC-004 Regression Tests', () => {
-  it('should detect STARTTLS when it appears on any line of multiline response', async () => {
-    // This test documents the fix
-    // In real SMTP, STARTTLS could appear on any line:
-    //
-    // 250-mail.example.com Hello [x12345]
-    // 250-SIZE 10240000
-    // 250-8BITMIME
-    // 250-STARTTLS     <-- Position 4
-    // 250 HELP
-    //
-    // Old code: only checked line 5 ("250 HELP") - no STARTTLS
-    // New code: joins all lines, checks entire response - finds STARTTLS
+describe('SMTP STARTTLS deterministic fixture', () => {
+  it('negotiates fragmented multiline EHLO and cleans up pinned sockets', async () => {
+    const result = await probeSMTPStarttls('mail.fixture.example', 'tenant-fixture', {
+      timeoutMs: 1000,
+      checkAllowlist: false,
+      ehloDomain: 'fixture-client.example',
+    });
 
-    expect(true).toBe(true); // Test documents the requirement
-  });
+    expect(result).toMatchObject({
+      success: true,
+      hostname: 'mail.fixture.example',
+      port: 25,
+      supportsStarttls: true,
+      tlsVersion: 'TLSv1.3',
+      tlsCipher: 'TLS_AES_128_GCM_SHA256',
+    });
+    expect(fixtureState.lookup).toHaveBeenCalledWith('mail.fixture.example');
 
-  it('should correctly identify final line by space (not hyphen) after code', async () => {
-    // SMTP format:
-    // - Continuation: "250-<text>" (hyphen)
-    // - Final: "250 <text>" (space)
-    //
-    // Old regex: only matched last line
-    // New logic: uses space vs hyphen to detect final line
+    const socket = fixtureState.sockets[0];
+    expect(socket?.connectArgs).toEqual({ port: 25, host: '93.184.216.34' });
+    expect(socket?.writes).toEqual(['EHLO fixture-client.example\r\n', 'STARTTLS\r\n']);
+    expect(fixtureState.tlsConnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socket,
+        servername: 'mail.fixture.example',
+      })
+    );
 
-    const finalLinePattern = /^(\d{3})\s/;
-    const continuationLinePattern = /^(\d{3})-/;
-
-    expect(finalLinePattern.test('250 OK')).toBe(true);
-    expect(finalLinePattern.test('250-OK')).toBe(false);
-
-    expect(continuationLinePattern.test('250-OK')).toBe(true);
-    expect(continuationLinePattern.test('250 OK')).toBe(false);
+    const tlsSocket = fixtureState.tlsSockets[0];
+    expect(tlsSocket?.writes).toEqual(['QUIT\r\n']);
+    expect(socket?.destroyed).toBe(true);
+    expect(tlsSocket?.destroyed).toBe(true);
+    expect(tlsSocket?.ended).toBe(true);
   });
 });

--- a/apps/collector/src/probes/smtp-starttls.test.ts
+++ b/apps/collector/src/probes/smtp-starttls.test.ts
@@ -15,8 +15,10 @@
 
 import { promises as dnsPromises } from 'node:dns';
 import { Socket } from 'node:net';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { probeSMTPStarttls } from './smtp-starttls.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { probeAllowlistManager } from './allowlist.js';
+import { resetProbeSemaphore } from './semaphore.js';
+import { probeMXHosts, probeSMTPStarttls } from './smtp-starttls.js';
 
 vi.mock('node:dns', () => ({
   promises: {
@@ -44,14 +46,16 @@ vi.mock('node:net', async (importOriginal) => {
 
     connect(port: number, host: string): this {
       this.connectArgs = { port, host };
-      setImmediate(() => {
+      const emitResponse = () => {
         this.emit('connect');
         // Data arrives after the connect promise continuation has
         // registered the banner reader.
         setImmediate(() => {
           this.emit('data', Buffer.from('220 fake-mx.example ESMTP ready\r\n'));
         });
-      });
+      };
+      if (socketConnectDelayMs > 0) setTimeout(emitResponse, socketConnectDelayMs);
+      else setImmediate(emitResponse);
       return this;
     }
 
@@ -81,6 +85,7 @@ vi.mock('node:net', async (importOriginal) => {
 });
 
 const mockLookup = dnsPromises.lookup as ReturnType<typeof vi.fn>;
+let socketConnectDelayMs = 0;
 
 /** Sockets created since the last reset (real module code news one per probe). */
 function createdSockets(): Array<{ connectArgs: { port: number; host: string } | null }> {
@@ -95,7 +100,15 @@ function resetSockets(): void {
 
 beforeEach(() => {
   mockLookup.mockReset();
+  socketConnectDelayMs = 0;
   resetSockets();
+  resetProbeSemaphore(5);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetProbeSemaphore(5);
+  probeAllowlistManager.clearAll();
 });
 
 describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)', () => {
@@ -173,5 +186,68 @@ describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)'
     expect(result.error).toContain('mail.example.com');
     expect(result.error).toContain('ENOTFOUND');
     expect(createdSockets()).toHaveLength(0);
+  });
+
+  it('bounds concurrent batch requests with the global semaphore', async () => {
+    resetProbeSemaphore(1);
+    socketConnectDelayMs = 100;
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    const allowlist = probeAllowlistManager.getTenantAllowlist('tenant-a');
+    for (const hostname of ['first.example.com', 'second.example.com']) {
+      allowlist.addCustomEntry(hostname, 25, 'test', 'concurrency test');
+    }
+
+    const first = probeMXHosts([{ hostname: 'first.example.com', priority: 10 }], 'tenant-a', {
+      concurrency: 1,
+    });
+    const second = probeMXHosts([{ hostname: 'second.example.com', priority: 20 }], 'tenant-a', {
+      concurrency: 1,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(createdSockets()).toHaveLength(1);
+
+    const results = await Promise.all([first, second]);
+    expect(results.flat()).toHaveLength(2);
+    expect(createdSockets()).toHaveLength(2);
+  });
+
+  it('does not start a later batch after shared evidence expires', async () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-09-01T00:00:00.000Z');
+    vi.setSystemTime(now);
+    socketConnectDelayMs = 100;
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    const allowlist = probeAllowlistManager.getTenantAllowlist('tenant-a');
+    allowlist.addCustomEntry('first.example.com', 25, 'test', 'expiry test');
+    allowlist.addCustomEntry('second.example.com', 25, 'test', 'expiry test');
+
+    const resultsPromise = probeMXHosts(
+      [
+        { hostname: 'first.example.com', priority: 10 },
+        { hostname: 'second.example.com', priority: 20 },
+      ],
+      'tenant-a',
+      { concurrency: 1, expiresAt: new Date(now.getTime() + 50) }
+    );
+
+    for (let i = 0; i < 100 && createdSockets().length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(createdSockets()).toHaveLength(1);
+    vi.advanceTimersByTime(100);
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      vi.runAllTimers();
+    }
+    const results = await resultsPromise;
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.success).toBe(true);
+    expect(results[1]).toMatchObject({
+      success: false,
+      error: 'Persisted DNS evidence expired before probe start',
+    });
+    expect(createdSockets()).toHaveLength(1);
   });
 });

--- a/apps/collector/src/probes/smtp-starttls.test.ts
+++ b/apps/collector/src/probes/smtp-starttls.test.ts
@@ -217,8 +217,13 @@ describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)'
     expect(createdSockets()).toHaveLength(0);
   });
 
-  it('fails closed when the hostname resolves to a private IPv6 address', async () => {
-    mockLookup.mockResolvedValue({ address: 'fc00::1', family: 6 });
+  it.each([
+    'fc00::1',
+    'fec0::1',
+    '2606:4700:4700::1111',
+    '::ffff:93.184.216.34',
+  ])('fails closed for every IPv6 answer (%s) and never creates a socket', async (address) => {
+    mockLookup.mockResolvedValue({ address, family: 6 });
 
     const result = await probeSMTPStarttls('rebind6.attacker.example', 'tenant-a', {
       checkAllowlist: false,
@@ -227,7 +232,7 @@ describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)'
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('SSRF');
-    expect(result.error).toContain('fc00::1');
+    expect(result.error).toContain(address);
     expect(createdSockets()).toHaveLength(0);
   });
 

--- a/apps/collector/src/probes/smtp-starttls.test.ts
+++ b/apps/collector/src/probes/smtp-starttls.test.ts
@@ -38,6 +38,7 @@ vi.mock('node:net', async (importOriginal) => {
     static instances: FakeSocket[] = [];
 
     connectArgs: { port: number; host: string } | null = null;
+    destroyed = false;
 
     constructor() {
       super();
@@ -46,13 +47,18 @@ vi.mock('node:net', async (importOriginal) => {
 
     connect(port: number, host: string): this {
       this.connectArgs = { port, host };
+      if (stallPhase === 'connect') return this;
       const emitResponse = () => {
         this.emit('connect');
         // Data arrives after the connect promise continuation has
         // registered the banner reader.
-        setImmediate(() => {
-          this.emit('data', Buffer.from('220 fake-mx.example ESMTP ready\r\n'));
-        });
+        const emitBanner = () => {
+          if (stallPhase !== 'banner') {
+            this.emit('data', Buffer.from('220 fake-mx.example ESMTP ready\r\n'));
+          }
+        };
+        if (responseDelayMs > 0) setTimeout(emitBanner, responseDelayMs);
+        else setImmediate(emitBanner);
       };
       if (socketConnectDelayMs > 0) setTimeout(emitResponse, socketConnectDelayMs);
       else setImmediate(emitResponse);
@@ -64,15 +70,22 @@ vi.mock('node:net', async (importOriginal) => {
     }
 
     write(chunk: string): boolean {
-      if (chunk.startsWith('EHLO')) {
-        setImmediate(() => {
-          this.emit('data', Buffer.from('250-fake-mx.example\r\n250 HELP\r\n'));
-        });
+      if (chunk.startsWith('EHLO') && stallPhase !== 'ehlo') {
+        const emitEhlo = () => {
+          this.emit('data', Buffer.from('250-fake-mx.example\r\n250-STARTTLS\r\n250 HELP\r\n'));
+        };
+        if (responseDelayMs > 0) setTimeout(emitEhlo, responseDelayMs);
+        else setImmediate(emitEhlo);
+      } else if (chunk.startsWith('STARTTLS') && stallPhase !== 'starttls') {
+        const emitStarttls = () => this.emit('data', Buffer.from('220 Ready\r\n'));
+        if (responseDelayMs > 0) setTimeout(emitStarttls, responseDelayMs);
+        else setImmediate(emitStarttls);
       }
       return true;
     }
 
     destroy(): this {
+      this.destroyed = true;
       return this;
     }
 
@@ -84,13 +97,74 @@ vi.mock('node:net', async (importOriginal) => {
   return { ...actual, Socket: FakeSocket };
 });
 
+vi.mock('node:tls', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:tls')>();
+  const { EventEmitter } = await import('node:events');
+
+  class FakeTlsSocket extends EventEmitter {
+    destroyed = false;
+
+    constructor() {
+      super();
+      const entry = { destroyed: false, setTimeoutMs: undefined as number | undefined };
+      tlsInstances.push(entry);
+      if (stallPhase !== 'tls') setImmediate(() => this.emit('secureConnect'));
+    }
+
+    setTimeout(timeoutMs: number): this {
+      const entry = tlsInstances[tlsInstances.length - 1];
+      if (entry) entry.setTimeoutMs = timeoutMs;
+      return this;
+    }
+
+    getCipher() {
+      return { name: 'TLS_AES_128_GCM_SHA256', version: 'TLSv1.3' };
+    }
+
+    getPeerCertificate() {
+      return {
+        subject: { CN: 'fake-mx.example' },
+        issuer: { CN: 'fake-ca' },
+        valid_from: 'Jan 1 00:00:00 2026 GMT',
+        valid_to: 'Jan 1 00:00:00 2027 GMT',
+        fingerprint: 'AA:BB',
+      };
+    }
+
+    write(): boolean {
+      return true;
+    }
+
+    end(): this {
+      return this;
+    }
+
+    destroy(): this {
+      this.destroyed = true;
+      const entry = tlsInstances[tlsInstances.length - 1];
+      if (entry) entry.destroyed = true;
+      return this;
+    }
+  }
+
+  return { ...actual, connect: vi.fn(() => new FakeTlsSocket()) };
+});
+
 const mockLookup = dnsPromises.lookup as ReturnType<typeof vi.fn>;
+type StallPhase = 'none' | 'dns' | 'connect' | 'banner' | 'ehlo' | 'starttls' | 'tls';
+let stallPhase: StallPhase = 'none';
 let socketConnectDelayMs = 0;
+let responseDelayMs = 0;
+const tlsInstances: Array<{ destroyed: boolean; setTimeoutMs?: number }> = [];
 
 /** Sockets created since the last reset (real module code news one per probe). */
-function createdSockets(): Array<{ connectArgs: { port: number; host: string } | null }> {
+function createdSockets(): Array<{
+  connectArgs: { port: number; host: string } | null;
+  destroyed: boolean;
+}> {
   return (Socket as unknown as { instances: unknown[] }).instances as Array<{
     connectArgs: { port: number; host: string } | null;
+    destroyed: boolean;
   }>;
 }
 
@@ -100,7 +174,10 @@ function resetSockets(): void {
 
 beforeEach(() => {
   mockLookup.mockReset();
+  stallPhase = 'none';
   socketConnectDelayMs = 0;
+  responseDelayMs = 0;
+  tlsInstances.length = 0;
   resetSockets();
   resetProbeSemaphore(5);
 });
@@ -154,6 +231,24 @@ describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)'
     expect(createdSockets()).toHaveLength(0);
   });
 
+  it.each([
+    ['100.64.0.0', '100.64.0.0/10'],
+    ['100.127.255.255', '100.64.0.0/10'],
+    ['198.18.0.0', '198.18.0.0/15'],
+    ['198.19.255.255', '198.18.0.0/15'],
+  ])('rejects an IANA special-purpose resolved address at the %s boundary (%s)', async (address) => {
+    mockLookup.mockResolvedValue({ address, family: 4 });
+
+    const result = await probeSMTPStarttls('rebind-special.example', 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect(result.error).toContain(`resolves to ${address}`);
+    expect(createdSockets()).toHaveLength(0);
+  });
+
   it('connects to the checked public IP, not the hostname', async () => {
     mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
 
@@ -164,7 +259,7 @@ describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)'
     });
 
     expect(result.success).toBe(true);
-    expect(result.supportsStarttls).toBe(false);
+    expect(result.supportsStarttls).toBe(true);
     expect(mockLookup).toHaveBeenCalledWith('mail.example.com');
 
     const sockets = createdSockets();
@@ -213,9 +308,7 @@ describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)'
   });
 
   it('does not start a later batch after shared evidence expires', async () => {
-    vi.useFakeTimers();
-    const now = new Date('2026-09-01T00:00:00.000Z');
-    vi.setSystemTime(now);
+    const now = new Date();
     socketConnectDelayMs = 100;
     mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
     const allowlist = probeAllowlistManager.getTenantAllowlist('tenant-a');
@@ -235,11 +328,6 @@ describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)'
       await Promise.resolve();
     }
     expect(createdSockets()).toHaveLength(1);
-    vi.advanceTimersByTime(100);
-    for (let i = 0; i < 5; i++) {
-      await Promise.resolve();
-      vi.runAllTimers();
-    }
     const results = await resultsPromise;
 
     expect(results).toHaveLength(2);
@@ -249,5 +337,118 @@ describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)'
       error: 'Persisted DNS evidence expired before probe start',
     });
     expect(createdSockets()).toHaveLength(1);
+  });
+
+  it.each([
+    'dns',
+    'connect',
+    'banner',
+    'ehlo',
+    'starttls',
+    'tls',
+  ] as StallPhase[])('returns within the cumulative deadline when %s stalls', async (phase) => {
+    vi.useFakeTimers();
+    stallPhase = phase;
+    if (phase === 'dns') {
+      mockLookup.mockReturnValue(new Promise(() => undefined));
+    } else {
+      mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    }
+
+    const resultPromise = probeSMTPStarttls(`stall-${phase}.example.com`, 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(25);
+    const result = await resultPromise;
+
+    expect(result).toMatchObject({ success: false, error: 'Timeout after 25ms' });
+    if (phase !== 'dns') expect(createdSockets()[0]?.destroyed).toBe(true);
+  });
+
+  it('destroys a socket when it emits timeout', async () => {
+    stallPhase = 'banner';
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    const resultPromise = probeSMTPStarttls('socket-timeout.example.com', 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    const socket = (Socket as unknown as { instances: Array<{ emit: (event: string) => void }> })
+      .instances[0];
+    socket?.emit('timeout');
+
+    const result = await resultPromise;
+    expect(result).toMatchObject({ success: false, error: 'Timeout after 1000ms' });
+    expect(createdSockets()[0]?.destroyed).toBe(true);
+  });
+
+  it('keeps phase timeouts cumulative instead of resetting after each response', async () => {
+    vi.useFakeTimers();
+    socketConnectDelayMs = 10;
+    responseDelayMs = 10;
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+
+    const resultPromise = probeSMTPStarttls('cumulative.example.com', 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(25);
+    const result = await resultPromise;
+
+    expect(result).toMatchObject({ success: false, error: 'Timeout after 25ms' });
+  });
+
+  it('rejects an oversized SMTP response and destroys the socket', async () => {
+    stallPhase = 'banner';
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    const resultPromise = probeSMTPStarttls('oversized.example.com', 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    const socket = (
+      Socket as unknown as { instances: Array<{ emit: (event: string, data: Buffer) => void }> }
+    ).instances[0];
+    socket?.emit('data', Buffer.alloc(65 * 1024));
+
+    const result = await resultPromise;
+    expect(result).toMatchObject({ success: false, error: 'SMTP response exceeded 65536 bytes' });
+    expect(createdSockets()[0]?.destroyed).toBe(true);
+  });
+
+  it('releases a global permit when a stalled batch host times out', async () => {
+    vi.useFakeTimers();
+    resetProbeSemaphore(1);
+    stallPhase = 'connect';
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    const allowlist = probeAllowlistManager.getTenantAllowlist('tenant-a');
+    allowlist.addCustomEntry('stalled.example.com', 25, 'test', 'timeout test');
+    allowlist.addCustomEntry('next.example.com', 25, 'test', 'timeout test');
+
+    const first = probeMXHosts([{ hostname: 'stalled.example.com', priority: 10 }], 'tenant-a', {
+      concurrency: 1,
+      timeoutMs: 20,
+    });
+    const second = probeMXHosts([{ hostname: 'next.example.com', priority: 20 }], 'tenant-a', {
+      concurrency: 1,
+      timeoutMs: 20,
+    });
+    await vi.advanceTimersByTimeAsync(20);
+    await vi.advanceTimersByTimeAsync(20);
+    const results = await Promise.all([first, second]);
+
+    expect(results).toHaveLength(2);
+    expect(results.flat()).toHaveLength(2);
+    expect(createdSockets()).toHaveLength(2);
+    expect(results.flat().every((result) => result.error === 'Timeout after 20ms')).toBe(true);
   });
 });

--- a/apps/collector/src/probes/smtp-starttls.test.ts
+++ b/apps/collector/src/probes/smtp-starttls.test.ts
@@ -1,0 +1,177 @@
+/**
+ * SMTP STARTTLS SSRF unit tests — DNS rebinding mitigation (Issue #67 review, P1)
+ *
+ * A persisted MX hostname can pass the hostname-string SSRF check and still
+ * resolve (at connect time) to a private/reserved address. These tests prove
+ * that the probe:
+ * - fails closed when the hostname resolves to a private/loopback IP;
+ * - pins the socket connection to the IP that passed the SSRF check (Node
+ *   never re-resolves the hostname);
+ * - fails closed on DNS resolution errors instead of falling back to
+ *   hostname-based connect (which would re-open the TOCTOU gap).
+ *
+ * No real network is used: node:dns and the net.Socket are mocked.
+ */
+
+import { promises as dnsPromises } from 'node:dns';
+import { Socket } from 'node:net';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { probeSMTPStarttls } from './smtp-starttls.js';
+
+vi.mock('node:dns', () => ({
+  promises: {
+    lookup: vi.fn(),
+  },
+}));
+
+vi.mock('node:net', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:net')>();
+  const { EventEmitter } = await import('node:events');
+
+  /**
+   * Minimal fake SMTP socket that records the connect target and serves a
+   * fixed 220 banner plus an EHLO response without STARTTLS.
+   */
+  class FakeSocket extends EventEmitter {
+    static instances: FakeSocket[] = [];
+
+    connectArgs: { port: number; host: string } | null = null;
+
+    constructor() {
+      super();
+      FakeSocket.instances.push(this);
+    }
+
+    connect(port: number, host: string): this {
+      this.connectArgs = { port, host };
+      setImmediate(() => {
+        this.emit('connect');
+        // Data arrives after the connect promise continuation has
+        // registered the banner reader.
+        setImmediate(() => {
+          this.emit('data', Buffer.from('220 fake-mx.example ESMTP ready\r\n'));
+        });
+      });
+      return this;
+    }
+
+    setTimeout(_ms: number): this {
+      return this;
+    }
+
+    write(chunk: string): boolean {
+      if (chunk.startsWith('EHLO')) {
+        setImmediate(() => {
+          this.emit('data', Buffer.from('250-fake-mx.example\r\n250 HELP\r\n'));
+        });
+      }
+      return true;
+    }
+
+    destroy(): this {
+      return this;
+    }
+
+    end(): this {
+      return this;
+    }
+  }
+
+  return { ...actual, Socket: FakeSocket };
+});
+
+const mockLookup = dnsPromises.lookup as ReturnType<typeof vi.fn>;
+
+/** Sockets created since the last reset (real module code news one per probe). */
+function createdSockets(): Array<{ connectArgs: { port: number; host: string } | null }> {
+  return (Socket as unknown as { instances: unknown[] }).instances as Array<{
+    connectArgs: { port: number; host: string } | null;
+  }>;
+}
+
+function resetSockets(): void {
+  (Socket as unknown as { instances: unknown[] }).instances = [];
+}
+
+beforeEach(() => {
+  mockLookup.mockReset();
+  resetSockets();
+});
+
+describe('probeSMTPStarttls — resolved-IP SSRF pinning (Issue #67 review, P1)', () => {
+  it('fails closed when the hostname resolves to a loopback IP and never creates a socket', async () => {
+    mockLookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+
+    const result = await probeSMTPStarttls('rebind.attacker.example', 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('SSRF');
+    expect(result.error).toContain('127.0.0.1');
+    expect(createdSockets()).toHaveLength(0);
+  });
+
+  it('fails closed when the hostname resolves to a private IP and never creates a socket', async () => {
+    mockLookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
+
+    const result = await probeSMTPStarttls('rebind.attacker.example', 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('SSRF');
+    expect(result.error).toContain('10.0.0.1');
+    expect(createdSockets()).toHaveLength(0);
+  });
+
+  it('fails closed when the hostname resolves to a private IPv6 address', async () => {
+    mockLookup.mockResolvedValue({ address: 'fc00::1', family: 6 });
+
+    const result = await probeSMTPStarttls('rebind6.attacker.example', 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('SSRF');
+    expect(result.error).toContain('fc00::1');
+    expect(createdSockets()).toHaveLength(0);
+  });
+
+  it('connects to the checked public IP, not the hostname', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+
+    const result = await probeSMTPStarttls('mail.example.com', 'tenant-a', {
+      port: 25,
+      checkAllowlist: false,
+      timeoutMs: 5000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.supportsStarttls).toBe(false);
+    expect(mockLookup).toHaveBeenCalledWith('mail.example.com');
+
+    const sockets = createdSockets();
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].connectArgs).toEqual({ port: 25, host: '93.184.216.34' });
+  });
+
+  it('fails closed on DNS resolution errors instead of reconnecting by hostname', async () => {
+    mockLookup.mockRejectedValue(
+      Object.assign(new Error('getaddrinfo ENOTFOUND mail.example.com'), { code: 'ENOTFOUND' })
+    );
+
+    const result = await probeSMTPStarttls('mail.example.com', 'tenant-a', {
+      checkAllowlist: false,
+      timeoutMs: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('mail.example.com');
+    expect(result.error).toContain('ENOTFOUND');
+    expect(createdSockets()).toHaveLength(0);
+  });
+});

--- a/apps/collector/src/probes/smtp-starttls.ts
+++ b/apps/collector/src/probes/smtp-starttls.ts
@@ -37,81 +37,272 @@ interface SMTPResponse {
   lines: string[];
 }
 
-/**
- * Read SMTP response from socket
- *
- * SMTP responses can be multiline (ESMTP). Format:
- * - Continuation lines start with "xxx-" (same code, more data)
- * - Final line starts with "xxx " (space after code indicates end)
- *
- * SEC-004: Fixed to read ALL lines of multiline responses.
- * Previously only read the last line, missing STARTTLS in middle of EHLO response.
- */
-function readResponse(socket: net.Socket, timeoutMs: number): Promise<SMTPResponse> {
-  return new Promise((resolve, reject) => {
-    let buffer = '';
-    const timeout = setTimeout(() => {
-      reject(new Error(`Timeout waiting for SMTP response`));
-    }, timeoutMs);
+const MAX_SMTP_RESPONSE_BYTES = 64 * 1024;
 
-    const onData = (data: Buffer) => {
-      buffer += data.toString();
+class SMTPProbeTimeoutError extends Error {
+  constructor() {
+    super('SMTP probe deadline exceeded');
+    this.name = 'SMTPProbeTimeoutError';
+  }
+}
 
-      // Check for complete response - need to find final line
-      // Final line format: "xxx <text>" (space after 3-digit code)
-      // Continuation format: "xxx-<text>" (hyphen after 3-digit code)
-      // Note: After splitting by \r?\n, lines should not contain \r, but we filter empty strings
-      const lines = buffer.split(/\r?\n/).filter((l) => l.trim());
+function remainingMs(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
+}
 
-      if (lines.length === 0) return;
+/** Race an operation against the probe's cumulative abort signal. */
+function withAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new SMTPProbeTimeoutError());
 
-      const lastLine = lines[lines.length - 1];
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
 
-      // Check if this is the final line (space after code, not hyphen)
-      const finalLineMatch = lastLine.match(/^(\d{3})\s/);
-      if (finalLineMatch) {
-        clearTimeout(timeout);
-        socket.off('data', onData);
-
-        // SEC-004: Join all lines for complete response
-        const allLines = lines.join('\n');
-        resolve({
-          code: parseInt(finalLineMatch[1], 10),
-          message: allLines,
-          lines: lines,
-        });
-      }
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort);
+    };
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new SMTPProbeTimeoutError());
     };
 
-    socket.on('data', onData);
-    socket.on('error', (err) => {
-      clearTimeout(timeout);
-      reject(err);
-    });
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      }
+    );
   });
 }
 
 /**
- * Send SMTP command
+ * Read one complete SMTP response. The caller owns the cumulative deadline;
+ * this helper never starts a fresh per-response timeout.
  */
-function sendCommand(socket: net.Socket, command: string): void {
+function readResponse(
+  socket: net.Socket,
+  signal: AbortSignal,
+  deadline: number
+): Promise<SMTPResponse> {
+  return new Promise((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    let settled = false;
+
+    const cleanup = () => {
+      socket.off('data', onData);
+      socket.off('error', onError);
+      socket.off('close', onClose);
+      socket.off('timeout', onTimeout);
+      signal.removeEventListener('abort', onAbort);
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const finish = (response: SMTPResponse) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(response);
+    };
+    const onAbort = () => {
+      const error = new SMTPProbeTimeoutError();
+      fail(error);
+      socket.destroy();
+    };
+    const onClose = () => {
+      fail(new Error('SMTP socket closed before response'));
+    };
+    const onError = (error: Error) => {
+      fail(error);
+    };
+    const onTimeout = () => {
+      const error = new SMTPProbeTimeoutError();
+      fail(error);
+      socket.destroy();
+    };
+    const onData = (data: Buffer | string) => {
+      const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      if (buffer.byteLength + chunk.byteLength > MAX_SMTP_RESPONSE_BYTES) {
+        const error = new Error('SMTP response exceeded 65536 bytes');
+        fail(error);
+        socket.destroy();
+        return;
+      }
+      buffer = Buffer.concat([buffer, chunk]);
+
+      const text = buffer.toString('utf8');
+      if (!text.endsWith('\n')) return;
+      const lines = text
+        .split(/\r?\n/)
+        .slice(0, -1)
+        .filter((line) => line.trim().length > 0);
+      const lastLine = lines[lines.length - 1];
+      const finalLineMatch = lastLine?.match(/^(\d{3})\s/);
+      if (!finalLineMatch) return;
+
+      finish({
+        code: Number.parseInt(finalLineMatch[1], 10),
+        message: lines.join('\n'),
+        lines,
+      });
+    };
+
+    try {
+      socket.on('data', onData);
+      socket.on('error', onError);
+      socket.on('close', onClose);
+      socket.on('timeout', onTimeout);
+      signal.addEventListener('abort', onAbort, { once: true });
+      if (signal.aborted || deadline <= Date.now()) {
+        onTimeout();
+        return;
+      }
+      socket.setTimeout(remainingMs(deadline));
+    } catch (error) {
+      fail(error);
+    }
+  });
+}
+
+function sendCommand(socket: net.Socket, command: string, signal: AbortSignal): void {
+  if (signal.aborted) throw new SMTPProbeTimeoutError();
   socket.write(`${command}\r\n`);
+}
+
+function connectSocket(
+  socket: net.Socket,
+  port: number,
+  address: string,
+  signal: AbortSignal,
+  deadline: number
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      socket.off('connect', onConnect);
+      socket.off('error', onError);
+      socket.off('close', onClose);
+      socket.off('timeout', onTimeout);
+      signal.removeEventListener('abort', onAbort);
+    };
+    const finish = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error === undefined) resolve();
+      else reject(error);
+    };
+    const onAbort = () => {
+      const error = new SMTPProbeTimeoutError();
+      finish(error);
+      socket.destroy();
+    };
+    const onClose = () => {
+      finish(new Error('SMTP socket closed before connect'));
+    };
+    const onConnect = () => finish();
+    const onError = (error: Error) => finish(error);
+    const onTimeout = () => {
+      const error = new SMTPProbeTimeoutError();
+      finish(error);
+      socket.destroy();
+    };
+
+    try {
+      socket.once('connect', onConnect);
+      socket.once('error', onError);
+      socket.once('close', onClose);
+      socket.once('timeout', onTimeout);
+      signal.addEventListener('abort', onAbort, { once: true });
+      if (signal.aborted || deadline <= Date.now()) {
+        onAbort();
+        return;
+      }
+      socket.setTimeout(remainingMs(deadline));
+      socket.connect(port, address);
+    } catch (error) {
+      finish(error);
+    }
+  });
+}
+
+function waitForTls(socket: tls.TLSSocket, signal: AbortSignal, deadline: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      socket.off('secureConnect', onSecureConnect);
+      socket.off('error', onError);
+      socket.off('close', onClose);
+      socket.off('timeout', onTimeout);
+      signal.removeEventListener('abort', onAbort);
+    };
+    const finish = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error === undefined) resolve();
+      else reject(error);
+    };
+    const onAbort = () => {
+      const error = new SMTPProbeTimeoutError();
+      finish(error);
+      socket.destroy();
+    };
+    const onSecureConnect = () => finish();
+    const onError = (error: Error) => finish(error);
+    const onClose = () => finish(new Error('TLS socket closed before handshake'));
+    const onTimeout = () => {
+      const error = new SMTPProbeTimeoutError();
+      finish(error);
+      socket.destroy();
+    };
+
+    try {
+      socket.once('secureConnect', onSecureConnect);
+      socket.once('error', onError);
+      socket.once('close', onClose);
+      socket.once('timeout', onTimeout);
+      signal.addEventListener('abort', onAbort, { once: true });
+      if (signal.aborted || deadline <= Date.now()) {
+        onAbort();
+        return;
+      }
+      socket.setTimeout(remainingMs(deadline));
+    } catch (error) {
+      finish(error);
+    }
+  });
 }
 
 /**
  * Resolve a probe hostname through the SSRF guard and return the checked IP
- * to pin the connection to (Issue #67 review, P1).
- *
- * Fail closed: unlike resolveAndCheck() (which tolerates DNS failure for
- * HTTP fetches), any resolution failure blocks the probe — connecting by
- * hostname afterwards would let Node re-resolve it and re-open the TOCTOU
- * gap.
+ * to pin the connection to. DNS failures fail closed so a later hostname
+ * connect cannot re-open the DNS rebinding window.
  */
 async function resolveCheckedTarget(
-  hostname: string
+  hostname: string,
+  signal: AbortSignal
 ): Promise<{ ok: true; ip: string } | { ok: false; error: string }> {
   try {
-    const { address } = await dns.promises.lookup(hostname);
+    const result = await withAbort(dns.promises.lookup(hostname), signal);
+    const address = typeof result === 'string' ? result : result.address;
+    if (!address) return { ok: false, error: `DNS resolution returned no address for ${hostname}` };
+
     const check = checkSSRF(address);
     if (!check.allowed) {
       return {
@@ -121,6 +312,7 @@ async function resolveCheckedTarget(
     }
     return { ok: true, ip: address };
   } catch (error) {
+    if (signal.aborted || error instanceof SMTPProbeTimeoutError) throw error;
     const message = error instanceof Error ? error.message : String(error);
     return { ok: false, error: `DNS resolution failed for ${hostname}: ${message}` };
   }
@@ -151,8 +343,18 @@ export async function probeSMTPStarttls(
     ehloDomain = 'dns-ops-probe.local',
     expiresAt,
   } = options || {};
-
   const startTime = Date.now();
+  const deadline = startTime + timeoutMs;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
+  const { signal } = controller;
+  let rawSocket: net.Socket | undefined;
+  let tlsSocket: tls.TLSSocket | undefined;
+  const destroyActiveSockets = () => {
+    rawSocket?.destroy();
+    tlsSocket?.destroy();
+  };
+  signal.addEventListener('abort', destroyActiveSockets, { once: true });
 
   try {
     if (!isExpiryFresh(expiresAt)) {
@@ -165,7 +367,10 @@ export async function probeSMTPStarttls(
         responseTimeMs: Date.now() - startTime,
       };
     }
-    // SSRF check
+    if (deadline <= Date.now() || signal.aborted) {
+      throw new SMTPProbeTimeoutError();
+    }
+
     const ssrfCheck = checkSSRF(hostname);
     if (!ssrfCheck.allowed) {
       return {
@@ -178,7 +383,6 @@ export async function probeSMTPStarttls(
       };
     }
 
-    // Allowlist check (tenant-scoped via probeAllowlistManager)
     if (checkAllowlist && !probeAllowlistManager.isAllowed(tenantId, hostname, port)) {
       return {
         success: false,
@@ -190,10 +394,7 @@ export async function probeSMTPStarttls(
       };
     }
 
-    // SSRF check — resolve the hostname, check the resolved address, and
-    // pin the connection to the checked IP so Node never re-resolves it at
-    // connect time (closes the DNS rebinding TOCTOU gap).
-    const resolved = await resolveCheckedTarget(hostname);
+    const resolved = await resolveCheckedTarget(hostname, signal);
     if (!resolved.ok) {
       return {
         success: false,
@@ -205,44 +406,25 @@ export async function probeSMTPStarttls(
       };
     }
 
-    // The DNS/allowlist checks above may have delayed the request. Do not
-    // create or connect a socket after the persisted evidence expires.
-    if (!isExpiryFresh(expiresAt)) {
+    if (!isExpiryFresh(expiresAt) || signal.aborted) {
       return {
         success: false,
         hostname,
         port,
         supportsStarttls: false,
-        error: 'Persisted DNS evidence expired before socket start',
+        error: signal.aborted
+          ? `Timeout after ${timeoutMs}ms`
+          : 'Persisted DNS evidence expired before socket start',
         responseTimeMs: Date.now() - startTime,
       };
     }
 
-    // Create socket connection
-    const socket = new net.Socket();
+    rawSocket = new net.Socket();
+    await connectSocket(rawSocket, port, resolved.ip, signal, deadline);
 
-    // Set timeout
-    socket.setTimeout(timeoutMs);
-
-    // Connect to the pinned, checked IP (SNI/cert checks still use the
-    // original hostname in the TLS upgrade below).
-    await new Promise<void>((resolve, reject) => {
-      if (!isExpiryFresh(expiresAt)) {
-        socket.destroy();
-        reject(new Error('Persisted DNS evidence expired before socket start'));
-        return;
-      }
-      socket.once('connect', resolve);
-      socket.once('error', reject);
-      socket.connect(port, resolved.ip);
-    });
-
-    // Read banner
-    const banner = await readResponse(socket, 10000);
+    const banner = await readResponse(rawSocket, signal, deadline);
     const smtpBanner = banner.message;
-
     if (banner.code !== 220) {
-      socket.destroy();
       return {
         success: false,
         hostname,
@@ -254,12 +436,9 @@ export async function probeSMTPStarttls(
       };
     }
 
-    // Send EHLO
-    sendCommand(socket, `EHLO ${ehloDomain}`);
-    const ehloResponse = await readResponse(socket, 10000);
-
+    sendCommand(rawSocket, `EHLO ${ehloDomain}`, signal);
+    const ehloResponse = await readResponse(rawSocket, signal, deadline);
     if (ehloResponse.code !== 250) {
-      socket.destroy();
       return {
         success: false,
         hostname,
@@ -271,11 +450,8 @@ export async function probeSMTPStarttls(
       };
     }
 
-    // Check for STARTTLS in capabilities
     const supportsStarttls = ehloResponse.message.toUpperCase().includes('STARTTLS');
-
     if (!supportsStarttls) {
-      socket.destroy();
       return {
         success: true,
         hostname,
@@ -286,12 +462,9 @@ export async function probeSMTPStarttls(
       };
     }
 
-    // Try STARTTLS
-    sendCommand(socket, 'STARTTLS');
-    const starttlsResponse = await readResponse(socket, 10000);
-
+    sendCommand(rawSocket, 'STARTTLS', signal);
+    const starttlsResponse = await readResponse(rawSocket, signal, deadline);
     if (starttlsResponse.code !== 220) {
-      socket.destroy();
       return {
         success: true,
         hostname,
@@ -303,23 +476,15 @@ export async function probeSMTPStarttls(
       };
     }
 
-    // Upgrade to TLS
-    const tlsSocket = tls.connect({
-      socket,
+    tlsSocket = tls.connect({
+      socket: rawSocket,
       servername: hostname,
-      rejectUnauthorized: false, // Allow self-signed for probing
+      rejectUnauthorized: false,
     });
+    await waitForTls(tlsSocket, signal, deadline);
 
-    await new Promise<void>((resolve, reject) => {
-      tlsSocket.once('secureConnect', resolve);
-      tlsSocket.once('error', reject);
-    });
-
-    // Get TLS info
     const tlsInfo = tlsSocket.getCipher();
     const cert = tlsSocket.getPeerCertificate();
-
-    // Close connection gracefully
     tlsSocket.write('QUIT\r\n');
     tlsSocket.end();
 
@@ -345,9 +510,10 @@ export async function probeSMTPStarttls(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     const isTimeout =
+      signal.aborted ||
+      error instanceof SMTPProbeTimeoutError ||
       errorMessage.toLowerCase().includes('timeout') ||
-      errorMessage.toLowerCase().includes('etimedout') ||
-      errorMessage.includes('ETIMEDOUT');
+      errorMessage.toLowerCase().includes('etimedout');
 
     return {
       success: false,
@@ -357,6 +523,13 @@ export async function probeSMTPStarttls(
       error: isTimeout ? `Timeout after ${timeoutMs}ms` : errorMessage,
       responseTimeMs: Date.now() - startTime,
     };
+  } finally {
+    signal.removeEventListener('abort', destroyActiveSockets);
+    clearTimeout(timeoutId);
+    tlsSocket?.destroy();
+    rawSocket?.destroy();
+    tlsSocket?.removeAllListeners();
+    rawSocket?.removeAllListeners();
   }
 }
 

--- a/apps/collector/src/probes/smtp-starttls.ts
+++ b/apps/collector/src/probes/smtp-starttls.ts
@@ -8,7 +8,8 @@
 import * as dns from 'node:dns';
 import * as net from 'node:net';
 import * as tls from 'node:tls';
-import { probeAllowlistManager } from './allowlist.js';
+import { isExpiryFresh, probeAllowlistManager } from './allowlist.js';
+import { getProbeSemaphore } from './semaphore.js';
 import { checkSSRF } from './ssrf-guard.js';
 
 export interface SMTPProbeResult {
@@ -140,6 +141,7 @@ export async function probeSMTPStarttls(
     timeoutMs?: number;
     checkAllowlist?: boolean;
     ehloDomain?: string;
+    expiresAt?: Date;
   }
 ): Promise<SMTPProbeResult> {
   const {
@@ -147,11 +149,22 @@ export async function probeSMTPStarttls(
     timeoutMs = 30000,
     checkAllowlist = true,
     ehloDomain = 'dns-ops-probe.local',
+    expiresAt,
   } = options || {};
 
   const startTime = Date.now();
 
   try {
+    if (!isExpiryFresh(expiresAt)) {
+      return {
+        success: false,
+        hostname,
+        port,
+        supportsStarttls: false,
+        error: 'Persisted DNS evidence expired before probe start',
+        responseTimeMs: Date.now() - startTime,
+      };
+    }
     // SSRF check
     const ssrfCheck = checkSSRF(hostname);
     if (!ssrfCheck.allowed) {
@@ -192,6 +205,19 @@ export async function probeSMTPStarttls(
       };
     }
 
+    // The DNS/allowlist checks above may have delayed the request. Do not
+    // create or connect a socket after the persisted evidence expires.
+    if (!isExpiryFresh(expiresAt)) {
+      return {
+        success: false,
+        hostname,
+        port,
+        supportsStarttls: false,
+        error: 'Persisted DNS evidence expired before socket start',
+        responseTimeMs: Date.now() - startTime,
+      };
+    }
+
     // Create socket connection
     const socket = new net.Socket();
 
@@ -201,6 +227,11 @@ export async function probeSMTPStarttls(
     // Connect to the pinned, checked IP (SNI/cert checks still use the
     // original hostname in the TLS upgrade below).
     await new Promise<void>((resolve, reject) => {
+      if (!isExpiryFresh(expiresAt)) {
+        socket.destroy();
+        reject(new Error('Persisted DNS evidence expired before socket start'));
+        return;
+      }
       socket.once('connect', resolve);
       socket.once('error', reject);
       socket.connect(port, resolved.ip);
@@ -338,17 +369,33 @@ export async function probeMXHosts(
   options?: {
     timeoutMs?: number;
     concurrency?: number;
+    expiresAt?: Date;
   }
 ): Promise<SMTPProbeResult[]> {
-  const { timeoutMs = 30000, concurrency = 3 } = options || {};
+  const { timeoutMs = 30000, concurrency = 3, expiresAt } = options || {};
 
   const results: SMTPProbeResult[] = [];
+  const semaphore = getProbeSemaphore();
 
-  // Process in batches to limit concurrency
+  // Process in local batches while acquiring the same process-wide permit for
+  // each host. The local bound controls one request; the semaphore controls
+  // all simultaneous batch and single-host requests together.
   for (let i = 0; i < hosts.length; i += concurrency) {
     const batch = hosts.slice(i, i + concurrency);
     const batchPromises = batch.map((host) =>
-      probeSMTPStarttls(host.hostname, tenantId, { timeoutMs })
+      semaphore.run(async () => {
+        if (!isExpiryFresh(expiresAt)) {
+          return {
+            success: false,
+            hostname: host.hostname,
+            port: 25,
+            supportsStarttls: false,
+            error: 'Persisted DNS evidence expired before probe start',
+            responseTimeMs: 0,
+          };
+        }
+        return probeSMTPStarttls(host.hostname, tenantId, { timeoutMs, expiresAt });
+      })
     );
 
     const batchResults = await Promise.all(batchPromises);

--- a/apps/collector/src/probes/smtp-starttls.ts
+++ b/apps/collector/src/probes/smtp-starttls.ts
@@ -5,6 +5,7 @@
  * Performs limited SMTP handshake to detect TLS support.
  */
 
+import * as dns from 'node:dns';
 import * as net from 'node:net';
 import * as tls from 'node:tls';
 import { probeAllowlistManager } from './allowlist.js';
@@ -97,6 +98,34 @@ function sendCommand(socket: net.Socket, command: string): void {
 }
 
 /**
+ * Resolve a probe hostname through the SSRF guard and return the checked IP
+ * to pin the connection to (Issue #67 review, P1).
+ *
+ * Fail closed: unlike resolveAndCheck() (which tolerates DNS failure for
+ * HTTP fetches), any resolution failure blocks the probe — connecting by
+ * hostname afterwards would let Node re-resolve it and re-open the TOCTOU
+ * gap.
+ */
+async function resolveCheckedTarget(
+  hostname: string
+): Promise<{ ok: true; ip: string } | { ok: false; error: string }> {
+  try {
+    const { address } = await dns.promises.lookup(hostname);
+    const check = checkSSRF(address);
+    if (!check.allowed) {
+      return {
+        ok: false,
+        error: `SSRF blocked: ${hostname} resolves to ${address} (${check.reason})`,
+      };
+    }
+    return { ok: true, ip: address };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `DNS resolution failed for ${hostname}: ${message}` };
+  }
+}
+
+/**
  * Probe SMTP server for STARTTLS capability
  *
  * @param hostname - Target SMTP server hostname
@@ -148,17 +177,33 @@ export async function probeSMTPStarttls(
       };
     }
 
+    // SSRF check — resolve the hostname, check the resolved address, and
+    // pin the connection to the checked IP so Node never re-resolves it at
+    // connect time (closes the DNS rebinding TOCTOU gap).
+    const resolved = await resolveCheckedTarget(hostname);
+    if (!resolved.ok) {
+      return {
+        success: false,
+        hostname,
+        port,
+        supportsStarttls: false,
+        error: resolved.error,
+        responseTimeMs: Date.now() - startTime,
+      };
+    }
+
     // Create socket connection
     const socket = new net.Socket();
 
     // Set timeout
     socket.setTimeout(timeoutMs);
 
-    // Connect
+    // Connect to the pinned, checked IP (SNI/cert checks still use the
+    // original hostname in the TLS upgrade below).
     await new Promise<void>((resolve, reject) => {
       socket.once('connect', resolve);
       socket.once('error', reject);
-      socket.connect(port, hostname);
+      socket.connect(port, resolved.ip);
     });
 
     // Read banner

--- a/apps/collector/src/probes/ssrf-guard.resolve.test.ts
+++ b/apps/collector/src/probes/ssrf-guard.resolve.test.ts
@@ -9,16 +9,13 @@
  *   could connect to a private IP. resolveAndCheck() pre-resolves and checks
  *   the address; strict callers must pin their client to the result.
  *
- * BUG-008: DNS resolution failure was treated as a block.
- *   Initial implementation returned { allowed: false } when dns.lookup
- *   threw ENOTFOUND. This broke all webhook tests that use mock URLs
- *   (example.com, webhook.test.com) because those don't resolve.
- *   DNS failure ≠ rebinding attack. Fix: allow through, let fetch()
- *   handle the connection error naturally.
+ * BUG-008: DNS resolution failure was treated as a block in one caller but
+ *   allowed through in the webhook path. Every outbound path now fails closed
+ *   on DNS errors and never falls back to hostname-based connection.
  *
  * BUG-009: MTA-STS fetch was missing a resolved-address check entirely.
- *   It now has a dedicated fail-closed pinned `https.request` path; this
- *   compatibility test documents the separate fail-open webhook helper.
+ *   It now has a dedicated fail-closed pinned `https.request` path, as does
+ *   webhook delivery.
  */
 
 import { promises as dnsPromises } from 'node:dns';
@@ -94,7 +91,7 @@ describe('resolveAndCheck — DNS rebinding mitigation (BUG-007)', () => {
   });
 
   describe('DNS failure handling (BUG-008)', () => {
-    it('allows through when DNS resolution fails (ENOTFOUND)', async () => {
+    it('fails closed when DNS resolution fails (ENOTFOUND)', async () => {
       mockLookup.mockRejectedValue(
         Object.assign(new Error('getaddrinfo ENOTFOUND nonexistent.invalid.test'), {
           code: 'ENOTFOUND',
@@ -102,16 +99,17 @@ describe('resolveAndCheck — DNS rebinding mitigation (BUG-007)', () => {
       );
 
       const result = await resolveAndCheck('nonexistent.invalid.test');
-      expect(result.allowed).toBe(true);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toContain('ENOTFOUND');
     });
 
-    it('allows through when DNS resolution fails (any error)', async () => {
+    it('fails closed when DNS resolution fails (any error)', async () => {
       mockLookup.mockRejectedValue(new Error('ESERVFAIL'));
 
       const result = await resolveAndCheck('timeout.test');
 
-      // Must allow — DNS failure is not a rebinding attack
-      expect(result.allowed).toBe(true);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toContain('ESERVFAIL');
     });
 
     it('blocks hostname that resolves to private IPv6', async () => {
@@ -126,14 +124,14 @@ describe('resolveAndCheck — DNS rebinding mitigation (BUG-007)', () => {
       }
     });
 
-    it('allows hostname that resolves to public IPv6', async () => {
+    it('fails closed when a hostname resolves to public IPv6', async () => {
       mockLookup.mockResolvedValue({ address: '2606:4700:4700::1111', family: 6 });
 
       const result = await resolveAndCheck('cloudflare-dns.com');
 
-      expect(result.allowed).toBe(true);
-      if (result.allowed) {
-        expect(result.ip).toBe('2606:4700:4700::1111');
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toContain('2606:4700:4700::1111');
       }
     });
 
@@ -143,6 +141,17 @@ describe('resolveAndCheck — DNS rebinding mitigation (BUG-007)', () => {
       if (!result.allowed) {
         expect(result.reason).toContain('empty hostname');
       }
+    });
+
+    it('returns a blocked result when DNS resolution is aborted', async () => {
+      mockLookup.mockReturnValue(new Promise(() => {}));
+      const controller = new AbortController();
+      const resultPromise = resolveAndCheck('slow.example.com', controller.signal);
+      controller.abort();
+
+      const result = await resultPromise;
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) expect(result.reason).toContain('aborted');
     });
   });
 });

--- a/apps/collector/src/probes/ssrf-guard.resolve.test.ts
+++ b/apps/collector/src/probes/ssrf-guard.resolve.test.ts
@@ -5,9 +5,9 @@
  *
  * BUG-007: validateUrl() checked hostname string but not resolved IP.
  *   A domain like evil.attacker.com that resolves to 10.0.0.1 passed
- *   validateUrl() (hostname isn't on the blocklist) but the fetch()
- *   would connect to a private IP. resolveAndCheck() closes this gap
- *   by pre-resolving and checking the resolved IP.
+ *   validateUrl() (hostname isn't on the blocklist) but a downstream client
+ *   could connect to a private IP. resolveAndCheck() pre-resolves and checks
+ *   the address; strict callers must pin their client to the result.
  *
  * BUG-008: DNS resolution failure was treated as a block.
  *   Initial implementation returned { allowed: false } when dns.lookup
@@ -16,9 +16,9 @@
  *   DNS failure ≠ rebinding attack. Fix: allow through, let fetch()
  *   handle the connection error naturally.
  *
- * BUG-009: MTA-STS fetch was missing resolveAndCheck() entirely.
- *   webhook.ts was protected but mta-sts.ts still used only validateUrl().
- *   Same TOCTOU gap in a different call site. Both must be checked.
+ * BUG-009: MTA-STS fetch was missing a resolved-address check entirely.
+ *   It now has a dedicated fail-closed pinned `https.request` path; this
+ *   compatibility test documents the separate fail-open webhook helper.
  */
 
 import { promises as dnsPromises } from 'node:dns';

--- a/apps/collector/src/probes/ssrf-guard.test.ts
+++ b/apps/collector/src/probes/ssrf-guard.test.ts
@@ -546,17 +546,16 @@ describe('PR-06.1: RFC 6890 Special-Purpose Addresses', () => {
     expect(result.allowed).toBe(false);
   });
 
-  it('should block 100.64.0.0/10 (Shared Address Space, CGN)', () => {
-    // 100.64.0.0 - 100.127.255.255
-    const result = checkSSRF('100.64.0.0');
-    // Currently not blocked, but could be considered for CGN
-    expect(result.allowed).toBe(true); // Not in standard blocklist
-  });
-
-  it('should block 198.18.0.0/15 (Benchmarking)', () => {
-    // 198.18.0.0 - 198.19.255.255
-    const result = checkSSRF('198.18.0.0');
-    expect(result.allowed).toBe(true); // Not in standard blocklist
+  it.each([
+    ['100.64.0.0', '100.64.0.0/10 (shared address space)'],
+    ['100.127.255.255', '100.64.0.0/10 (shared address space)'],
+    ['198.18.0.0', '198.18.0.0/15 (benchmarking)'],
+    ['198.19.255.255', '198.18.0.0/15 (benchmarking)'],
+  ])('should block %s at the IANA special-purpose range boundary', (address, range) => {
+    const result = checkSSRF(address);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain(range);
+    expect(result.blockedCategory).toBe('reserved');
   });
 });
 

--- a/apps/collector/src/probes/ssrf-guard.test.ts
+++ b/apps/collector/src/probes/ssrf-guard.test.ts
@@ -254,67 +254,62 @@ describe('PR-06.1: IPv4 Full 127.x Range Coverage', () => {
   });
 });
 
-describe('PR-06.1: IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)', () => {
-  // IPv4-mapped IPv6 (RFC 4291 §2.5.5.2): ::ffff:a.b.c.d
-  // These embed a real IPv4 address inside an IPv6 literal. A naive guard that
-  // only checks IPv6 prefix would misclassify or miss these entirely.
-  // The fix: extract the embedded IPv4 and run it through checkIPv4.
+describe('PR-06.1: IPv4-mapped IPv6 addresses fail closed', () => {
+  // IPv4-mapped and IPv4-compatible forms are IPv6 targets. They remain
+  // blocked until a complete, maintained IPv6 policy exists.
 
-  it('should block ::ffff:127.0.0.1 with category loopback', () => {
+  it('should block ::ffff:127.0.0.1', () => {
     const result = checkSSRF('::ffff:127.0.0.1');
     expect(result.allowed, `expected blocked, got: ${JSON.stringify(result)}`).toBe(false);
-    expect(result.blockedCategory).toBe('loopback');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('should block ::ffff:10.0.0.1 with category private', () => {
+  it('should block ::ffff:10.0.0.1', () => {
     const result = checkSSRF('::ffff:10.0.0.1');
     expect(result.allowed, `expected blocked, got: ${JSON.stringify(result)}`).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('should block ::ffff:192.168.1.1 with category private', () => {
+  it('should block ::ffff:192.168.1.1', () => {
     const result = checkSSRF('::ffff:192.168.1.1');
     expect(result.allowed, `expected blocked, got: ${JSON.stringify(result)}`).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('should block ::ffff:172.16.0.1 with category private', () => {
+  it('should block ::ffff:172.16.0.1', () => {
     const result = checkSSRF('::ffff:172.16.0.1');
     expect(result.allowed, `expected blocked, got: ${JSON.stringify(result)}`).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('should block ::ffff:169.254.169.254 with category link-local (AWS metadata)', () => {
+  it('should block ::ffff:169.254.169.254 (AWS metadata)', () => {
     const result = checkSSRF('::ffff:169.254.169.254');
     expect(result.allowed, `expected blocked, got: ${JSON.stringify(result)}`).toBe(false);
-    expect(result.blockedCategory).toBe('link-local');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('should ALLOW ::ffff:8.8.8.8 (public IPv4 in mapped form)', () => {
-    // A public IP wrapped in IPv4-mapped form should be allowed, since the
-    // embedded IPv4 is public. Blocking it would be an over-block.
+  it('should block ::ffff:8.8.8.8 even when the embedded IPv4 is public', () => {
     const result = checkSSRF('::ffff:8.8.8.8');
-    expect(result.allowed, `expected allowed, got: ${JSON.stringify(result)}`).toBe(true);
+    expect(result.allowed, `expected blocked, got: ${JSON.stringify(result)}`).toBe(false);
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block ::ffff:7f00:0001 (hex form of 127.0.0.1)', () => {
-    // Hex notation: 0x7f = 127, 0x00 = 0, 0x00 = 0, 0x01 = 1
     const result = checkSSRF('::ffff:7f00:0001');
     expect(result.allowed, `expected blocked, got: ${JSON.stringify(result)}`).toBe(false);
-    expect(result.blockedCategory).toBe('loopback');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block ::ffff:c0a8:0101 (hex form of 192.168.1.1)', () => {
-    // 0xc0 = 192, 0xa8 = 168, 0x01 = 1, 0x01 = 1
     const result = checkSSRF('::ffff:c0a8:0101');
     expect(result.allowed, `expected blocked, got: ${JSON.stringify(result)}`).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('uppercase ::FFFF:127.0.0.1 should also be blocked', () => {
     const result = checkSSRF('::FFFF:127.0.0.1');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('loopback');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it.each([
@@ -324,11 +319,11 @@ describe('PR-06.1: IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)', () => {
   ])('blocks expanded IPv4-mapped loopback %s', (address) => {
     const result = checkSSRF(address);
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('loopback');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('allows expanded mapped public IPv4', () => {
-    expect(checkSSRF('0:0:0:0:0:ffff:8.8.8.8').allowed).toBe(true);
+  it('blocks expanded mapped public IPv4', () => {
+    expect(checkSSRF('0:0:0:0:0:ffff:8.8.8.8').allowed).toBe(false);
   });
 
   it.each([
@@ -341,20 +336,14 @@ describe('PR-06.1: IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)', () => {
     expect(result.blockedCategory).toBe('invalid');
   });
 
-  // Well-known IPv6 addresses unrelated to IPv4-mapped
-  it('should allow 64:ff9b:: (IPv4/IPv6 translation prefix, RFC 6052)', () => {
-    const result = checkSSRF('64:ff9b::');
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should allow 2001::1 (Teredo tunnel, RFC 4380)', () => {
-    const result = checkSSRF('2001::1');
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should allow 2001:db8::1 (documentation prefix, RFC 3849)', () => {
-    const result = checkSSRF('2001:db8::1');
-    expect(result.allowed).toBe(true);
+  it.each([
+    '64:ff9b::',
+    '2001::1',
+    '2001:db8::1',
+  ])('blocks IPv6 target %s until the maintained policy exists', (address) => {
+    const result = checkSSRF(address);
+    expect(result.allowed).toBe(false);
+    expect(result.blockedCategory).toBe('reserved');
   });
 });
 
@@ -381,7 +370,7 @@ describe('PR-06.1: Link-Local Full Range Coverage (169.254.x)', () => {
   it('should block fe80:: (start of IPv6 link-local)', () => {
     const result = checkSSRF('fe80::');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('link-local');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it.each([
@@ -391,7 +380,7 @@ describe('PR-06.1: Link-Local Full Range Coverage (169.254.x)', () => {
   ])('should block %s across the complete fe80::/10 range', (address) => {
     const result = checkSSRF(address);
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('link-local');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it.each([
@@ -401,15 +390,16 @@ describe('PR-06.1: Link-Local Full Range Coverage (169.254.x)', () => {
   ])('should block %s across the complete ff00::/8 range', (address) => {
     const result = checkSSRF(address);
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('multicast');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('should allow fec0:: (old site-local, now reserved)', () => {
-    // fec0::/10 was deprecated in RFC 3879, now treated as reserved
-    // Current implementation may or may not block this
-    const result = checkSSRF('fec0::1');
-    // This is now in the unique local range fc00::/7
-    expect(result).toBeDefined();
+  it.each([
+    'fec0::',
+    'feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+  ])('blocks deprecated site-local IPv6 target %s', (address) => {
+    const result = checkSSRF(address);
+    expect(result.allowed).toBe(false);
+    expect(result.blockedCategory).toBe('reserved');
   });
 });
 
@@ -444,13 +434,8 @@ describe('PR-06.1: DNS Rebinding Attack Simulation', () => {
     expect(result.blockedCategory).toBe('link-local');
   });
 
-  // Note: TOCTOU (Time-of-Check vs Time-of-Use) protection requires:
-  // 1. DNS rebinding protection at the application level
-  // 2. Low TTL enforcement
-  // 3. Re-checking IP after DNS resolution
-  // The SSRF guard blocks resolved IPs, but TOCTOU protection
-  // is typically handled at the DNS resolver level or with
-  // custom lookup callbacks in the HTTP client.
+  // Strict transports resolve once, check the address, and pin their native
+  // socket lookup to prevent a second DNS decision.
 });
 
 describe('PR-06.1: Redirect-to-Private Attack Simulation', () => {
@@ -478,13 +463,13 @@ describe('PR-06.1: Redirect-to-Private Attack Simulation', () => {
   it('should identify private redirect target ::1', () => {
     const result = checkSSRF('::1');
     expect(result.allowed).toBe(false);
-    expect(result.reason).toContain('loopback');
+    expect(result.reason).toContain('IPv6 targets');
   });
 
   it('should identify private redirect target fe80::1', () => {
     const result = checkSSRF('fe80::1');
     expect(result.allowed).toBe(false);
-    expect(result.reason).toContain('link-local');
+    expect(result.reason).toContain('IPv6 targets');
   });
 
   // The validateUrl function should be called on redirect targets
@@ -627,57 +612,55 @@ describe('SSRF Guard - IPv6 Blocked', () => {
   it('should block ::1 (loopback)', () => {
     const result = checkSSRF('::1');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('loopback');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block fe80::1 (link-local)', () => {
     const result = checkSSRF('fe80::1');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('link-local');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block fe80::1234:5678:abcd:ef01 (link-local full)', () => {
     const result = checkSSRF('fe80::1234:5678:abcd:ef01');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('link-local');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block fc00::1 (unique local, start of fc00::/7)', () => {
     const result = checkSSRF('fc00::1');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('should block fc10::1 (unique local — was missed by old fc00: prefix)', () => {
-    // fc00::/7 covers fc00:: through fdff:: (first byte 0xfc or 0xfd)
-    // Old prefix 'fc00:' would NOT catch fc10::1. Fixed in PR-06.
+  it('should block fc10::1 (unique local)', () => {
     const result = checkSSRF('fc10::1');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
-  it('should block fcff::1 (unique local mid-range, previously uncovered)', () => {
+  it('should block fcff::1 (unique local mid-range)', () => {
     const result = checkSSRF('fcff::1');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block fd00::1 (unique local, fd range)', () => {
     const result = checkSSRF('fd00::1');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block fdff::ffff (unique local, end of fc00::/7)', () => {
     const result = checkSSRF('fdff::ffff');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('private');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block ff00::1 (multicast)', () => {
     const result = checkSSRF('ff00::1');
     expect(result.allowed).toBe(false);
-    expect(result.blockedCategory).toBe('multicast');
+    expect(result.blockedCategory).toBe('reserved');
   });
 
   it('should block :: (unspecified)', () => {
@@ -687,18 +670,17 @@ describe('SSRF Guard - IPv6 Blocked', () => {
 });
 
 // =============================================================================
-// IPv6 Allowed Addresses
+// IPv6 Fail-Closed Policy
 // =============================================================================
 
-describe('SSRF Guard - IPv6 Allowed', () => {
-  it('should allow 2001:4860:4860::8888 (Google DNS)', () => {
-    const result = checkSSRF('2001:4860:4860::8888');
-    expect(result.allowed).toBe(true);
-  });
-
-  it('should allow 2606:4700:4700::1111 (Cloudflare DNS)', () => {
-    const result = checkSSRF('2606:4700:4700::1111');
-    expect(result.allowed).toBe(true);
+describe('SSRF Guard - IPv6 fail closed', () => {
+  it.each([
+    '2001:4860:4860::8888',
+    '2606:4700:4700::1111',
+  ])('blocks public IPv6 target %s until the maintained policy exists', (address) => {
+    const result = checkSSRF(address);
+    expect(result.allowed).toBe(false);
+    expect(result.blockedCategory).toBe('reserved');
   });
 });
 
@@ -893,7 +875,7 @@ describe('SSRF Guard - Edge Cases', () => {
     it('should handle uppercase IPv6', () => {
       const result = checkSSRF('FE80::1');
       expect(result.allowed).toBe(false);
-      expect(result.blockedCategory).toBe('link-local');
+      expect(result.blockedCategory).toBe('reserved');
     });
   });
 

--- a/apps/collector/src/probes/ssrf-guard.ts
+++ b/apps/collector/src/probes/ssrf-guard.ts
@@ -9,7 +9,7 @@ import { isIP } from 'node:net';
  * - Link-local addresses
  * - Multicast addresses
  * - Reserved addresses
- * - IPv4-mapped IPv6 addresses that embed private/loopback IPv4
+ * - All IPv6 targets until a complete public-address policy is maintained
  *
  * Security review: docs/security/probe-sandbox-review.md
  */
@@ -91,65 +91,17 @@ function checkIPv4(ip: string): SSRFCheckResult {
 }
 
 /**
- * Extract the embedded IPv4 address from an IPv4-mapped IPv6 address.
- *
- * IPv4-mapped IPv6 format: ::ffff:a.b.c.d  (RFC 4291 §2.5.5.2)
- *
- * These addresses represent IPv4 nodes in an IPv6 address space. An SSRF
- * bypass would occur if we checked the outer IPv6 form and missed that the
- * embedded IPv4 is private/loopback. We extract and check through checkIPv4.
- *
- * @returns The dotted-decimal IPv4 string, or null if not IPv4-mapped.
- */
-function extractIPv4FromMapped(normalized: string): string | null {
-  let address = normalized;
-  const dottedTail = address.match(/(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (dottedTail) {
-    const octets = dottedTail.slice(1).map(Number);
-    if (octets.some((octet) => octet < 0 || octet > 255)) return null;
-    const high = ((octets[0] << 8) | octets[1]).toString(16);
-    const low = ((octets[2] << 8) | octets[3]).toString(16);
-    address = `${address.slice(0, dottedTail.index)}${high}:${low}`;
-  }
-
-  const compressedParts = address.split('::');
-  if (compressedParts.length > 2) return null;
-  const left = compressedParts[0] ? compressedParts[0].split(':') : [];
-  const right =
-    compressedParts.length === 2 && compressedParts[1] ? compressedParts[1].split(':') : [];
-  const missing = compressedParts.length === 2 ? 8 - left.length - right.length : 0;
-  const parts =
-    compressedParts.length === 2
-      ? [...left, ...Array(Math.max(0, missing)).fill('0'), ...right]
-      : left;
-  if (parts.length !== 8 || parts.some((part) => !/^[0-9a-f]{1,4}$/.test(part))) return null;
-  const hextets = parts.map((part) => Number.parseInt(part, 16));
-  const mappedPrefix = hextets.slice(0, 5).every((part) => part === 0) && hextets[5] === 0xffff;
-  const compatiblePrefix = hextets.slice(0, 6).every((part) => part === 0);
-  if (!mappedPrefix && !compatiblePrefix) return null;
-
-  const high = hextets[6];
-  const low = hextets[7];
-  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
-}
-
-/**
- * Normalize and check IPv6 address.
- *
- * SECURITY: IPv4-mapped IPv6 (::ffff:x.x.x.x) is handled first by extracting
- * the embedded IPv4 and running it through checkIPv4. This ensures correct
- * classification (loopback/private/public) rather than a blanket "unspecified"
- * block.
+ * Reject IPv6 targets until a complete, maintained IPv6 public-address policy
+ * exists. This intentionally includes IPv4-mapped and IPv4-compatible forms:
+ * the controlled live harness accepts only validated public IPv4 answers, and
+ * active probes must enforce the same boundary.
  */
 function checkIPv6(ip: string): SSRFCheckResult {
-  // Normalize IPv6 (lowercase, strip brackets)
   const normalized = ip
     .toLowerCase()
     .trim()
     .replace(/^\[|\]$/g, '');
 
-  // Zone identifiers are meaningful only in a local interface context and are
-  // never valid outbound probe targets. Reject rather than normalize them.
   if (normalized.includes('%')) {
     return {
       allowed: false,
@@ -158,65 +110,15 @@ function checkIPv6(ip: string): SSRFCheckResult {
     };
   }
 
-  if (normalized === '::1') {
-    return { allowed: false, reason: 'Blocked: ::1/128 (loopback)', blockedCategory: 'loopback' };
-  }
-  if (normalized === '::') {
-    return { allowed: false, reason: 'Blocked: ::/128 (unspecified)', blockedCategory: 'reserved' };
-  }
-
-  // --- IPv4-mapped IPv6 (::ffff:a.b.c.d or ::ffff:hhhh:hhhh) ---
-  // Must be checked BEFORE the generic prefix list because ::ffff: starts
-  // with :: and would otherwise be caught as "unspecified" with wrong category.
-  const embeddedIPv4 = extractIPv4FromMapped(normalized);
-  if (embeddedIPv4 !== null) {
-    const ipv4Result = checkIPv4(embeddedIPv4);
-    if (!ipv4Result.allowed) {
-      // Preserve exact category from the IPv4 check (loopback, private, etc.)
-      return {
-        allowed: false,
-        reason: `Blocked: IPv4-mapped IPv6 embeds blocked IPv4 – ${ipv4Result.reason}`,
-        blockedCategory: ipv4Result.blockedCategory,
-      };
-    }
-    // Embedded IPv4 is public — allow the mapped address
-    return { allowed: true };
-  }
-
   if (isIP(normalized) !== 6) {
     return { allowed: false, reason: 'Invalid IPv6 address', blockedCategory: 'invalid' };
   }
 
-  // Classify the complete CIDR range from the first 16-bit hextet rather than
-  // matching one textual spelling. This covers compressed and expanded forms.
-  const firstHextetText = normalized.split(':').find((part) => part.length > 0);
-  const firstHextet = firstHextetText ? Number.parseInt(firstHextetText, 16) : Number.NaN;
-  if (!Number.isFinite(firstHextet) || firstHextet < 0 || firstHextet > 0xffff) {
-    return { allowed: false, reason: 'Invalid IPv6 address', blockedCategory: 'invalid' };
-  }
-  if ((firstHextet & 0xffc0) === 0xfe80) {
-    return {
-      allowed: false,
-      reason: 'Blocked: fe80::/10 (link-local)',
-      blockedCategory: 'link-local',
-    };
-  }
-  if ((firstHextet & 0xfe00) === 0xfc00) {
-    return {
-      allowed: false,
-      reason: 'Blocked: fc00::/7 (unique local)',
-      blockedCategory: 'private',
-    };
-  }
-  if ((firstHextet & 0xff00) === 0xff00) {
-    return {
-      allowed: false,
-      reason: 'Blocked: ff00::/8 (multicast)',
-      blockedCategory: 'multicast',
-    };
-  }
-
-  return { allowed: true };
+  return {
+    allowed: false,
+    reason: 'Blocked: IPv6 targets are not permitted until a complete maintained policy exists',
+    blockedCategory: 'reserved',
+  };
 }
 
 /**
@@ -296,41 +198,64 @@ export function checkResolvedIP(ip: string): SSRFCheckResult {
   return checkSSRF(ip);
 }
 
+/** Race DNS resolution against a caller-owned cumulative deadline. */
+function withAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return operation;
+  if (signal.aborted) return Promise.reject(new Error('DNS resolution aborted'));
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener('abort', onAbort);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error('DNS resolution aborted'));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      }
+    );
+  });
+}
+
 /**
- * Resolve a hostname and verify the resolved IP is safe.
- *
- * Pre-checks the DNS result against the DNS rebinding case: validateUrl()
- * checks the hostname string, while a downstream client may resolve DNS
- * independently. This function resolves first, checks the result, and returns
- * the address so strict callers can pin their connection to it. It retains
- * fail-open behavior on DNS errors for compatibility-sensitive webhook callers.
- *
- * NOTE: This helper intentionally retains its fail-open DNS-error behavior
- * for compatibility-sensitive webhook callers. Callers that need strict
- * pinning must resolve with a fail-closed policy and pass a static `lookup`
- * callback to their native Node request, as the MTA-STS probe does.
- *
- * @returns The resolved IP address if safe, or an SSRFCheckResult if blocked.
+ * Resolve a hostname and verify a public IPv4 address before a caller pins it.
+ * DNS failures are rejected rather than falling back to hostname resolution.
  */
 export async function resolveAndCheck(
-  hostname: string
+  hostname: string,
+  signal?: AbortSignal
 ): Promise<{ allowed: true; ip: string } | (SSRFCheckResult & { allowed: false })> {
-  // Check hostname/IP against SSRF blocklists first (covers empty, localhost, IP literals)
+  // Check hostname/IP against SSRF blocklists first (covers empty, localhost, IP literals).
   const ssrfResult = checkSSRF(hostname);
   if (!ssrfResult.allowed) {
     return { ...ssrfResult, allowed: false as const };
   }
 
-  // Skip resolution for IP literals — we already checked them above
-  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname) || hostname.includes(':')) {
+  // Public IPv4 literals are already resolved and checked.
+  if (isIP(hostname) === 4) {
     return { allowed: true, ip: hostname };
   }
 
   try {
     const { promises: dnsPromises } = await import('node:dns');
-    const { address } = await dnsPromises.lookup(hostname);
+    const resolved = await withAbort(dnsPromises.lookup(hostname, { family: 4 }), signal);
+    const address = typeof resolved === 'string' ? resolved : resolved.address;
+    const family = typeof resolved === 'string' ? isIP(address) : resolved.family;
     const ipCheck = checkSSRF(address);
-
     if (!ipCheck.allowed) {
       return {
         allowed: false,
@@ -338,12 +263,21 @@ export async function resolveAndCheck(
         blockedCategory: ipCheck.blockedCategory,
       };
     }
+    if (family !== 4 || isIP(address) !== 4) {
+      return {
+        allowed: false,
+        reason: `DNS resolution did not return a public IPv4 address for ${hostname}`,
+        blockedCategory: 'invalid',
+      };
+    }
 
     return { allowed: true, ip: address };
-  } catch {
-    // DNS resolution failure (ENOTFOUND, ESERVFAIL, etc.) is NOT treated as a
-    // rebinding block for compatibility-sensitive webhook callers. Strict
-    // probe callers use their own fail-closed resolution path instead.
-    return { allowed: true, ip: hostname };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      allowed: false,
+      reason: `DNS resolution failed for ${hostname}: ${message}`,
+      blockedCategory: 'invalid',
+    };
   }
 }

--- a/apps/collector/src/probes/ssrf-guard.ts
+++ b/apps/collector/src/probes/ssrf-guard.ts
@@ -20,19 +20,29 @@ export interface SSRFCheckResult {
   blockedCategory?: 'private' | 'loopback' | 'link-local' | 'multicast' | 'reserved' | 'invalid';
 }
 
-// IPv4 private ranges (RFC 1918 + others)
+// Conservative denylist for the complete IANA IPv4 Special-Purpose Address
+// Registry plus multicast. Entries covering a smaller registered allocation
+// deliberately deny their entire enclosing prefix; keep this list in sync with
+// NON_GLOBAL_IPV4_CIDRS in tools/controlled-live-harness/runner.mjs.
 const BLOCKED_IPV4_RANGES = [
   { start: 0x00000000, end: 0x00ffffff, name: '0.0.0.0/8 (this network)' },
-  { start: 0x7f000000, end: 0x7fffffff, name: '127.0.0.0/8 (loopback)' },
   { start: 0x0a000000, end: 0x0affffff, name: '10.0.0.0/8 (private)' },
-  { start: 0xac100000, end: 0xac1fffff, name: '172.16.0.0/12 (private)' },
-  { start: 0xc0a80000, end: 0xc0a8ffff, name: '192.168.0.0/16 (private)' },
+  { start: 0x64400000, end: 0x647fffff, name: '100.64.0.0/10 (shared address space)' },
+  { start: 0x7f000000, end: 0x7fffffff, name: '127.0.0.0/8 (loopback)' },
   { start: 0xa9fe0000, end: 0xa9feffff, name: '169.254.0.0/16 (link-local)' },
+  { start: 0xac100000, end: 0xac1fffff, name: '172.16.0.0/12 (private)' },
+  { start: 0xc0000000, end: 0xc00000ff, name: '192.0.0.0/24 (IETF protocol assignments)' },
+  { start: 0xc0000200, end: 0xc00002ff, name: '192.0.2.0/24 (documentation)' },
+  { start: 0xc01fc400, end: 0xc01fc4ff, name: '192.31.196.0/24 (AS112-v4)' },
+  { start: 0xc034c100, end: 0xc034c1ff, name: '192.52.193.0/24 (AMT)' },
+  { start: 0xc0586300, end: 0xc05863ff, name: '192.88.99.0/24 (deprecated 6to4 relay anycast)' },
+  { start: 0xc0a80000, end: 0xc0a8ffff, name: '192.168.0.0/16 (private)' },
+  { start: 0xc0af3000, end: 0xc0af30ff, name: '192.175.48.0/24 (direct delegation AS112 service)' },
+  { start: 0xc6120000, end: 0xc613ffff, name: '198.18.0.0/15 (benchmarking)' },
+  { start: 0xc6336400, end: 0xc63364ff, name: '198.51.100.0/24 (documentation)' },
+  { start: 0xcb007100, end: 0xcb0071ff, name: '203.0.113.0/24 (documentation)' },
   { start: 0xe0000000, end: 0xefffffff, name: '224.0.0.0/4 (multicast)' },
   { start: 0xf0000000, end: 0xffffffff, name: '240.0.0.0/4 (reserved)' },
-  { start: 0xc0000200, end: 0xc00002ff, name: '192.0.2.0/24 (TEST-NET-1)' },
-  { start: 0xc6336400, end: 0xc63364ff, name: '198.51.100.0/24 (TEST-NET-2)' },
-  { start: 0xcb007100, end: 0xcb0071ff, name: '203.0.113.0/24 (TEST-NET-3)' },
 ];
 
 /**
@@ -289,18 +299,16 @@ export function checkResolvedIP(ip: string): SSRFCheckResult {
 /**
  * Resolve a hostname and verify the resolved IP is safe.
  *
- * Closes the DNS rebinding TOCTOU gap: validateUrl() checks the hostname
- * string, but fetch() resolves DNS independently. An attacker can register
- * a domain that resolves to a public IP on first query and a private IP
- * on the second. This function resolves first, checks the result, then
- * returns the resolved IP for the caller to connect to directly.
+ * Pre-checks the DNS result against the DNS rebinding case: validateUrl()
+ * checks the hostname string, while a downstream client may resolve DNS
+ * independently. This function resolves first, checks the result, and returns
+ * the address so strict callers can pin their connection to it. It retains
+ * fail-open behavior on DNS errors for compatibility-sensitive webhook callers.
  *
- * NOTE: This narrows but does not fully close the TOCTOU window. Node's
- * `fetch()` re-resolves DNS independently — a sub-millisecond TTL switch
- * between our check and fetch's resolution is theoretically possible.
- * Full closure requires `net.connect({ lookup })` which only applies to
- * raw TCP/TLS (probe system), not HTTP fetch. The two-step check is the
- * industry-standard mitigation for HTTP-based SSRF.
+ * NOTE: This helper intentionally retains its fail-open DNS-error behavior
+ * for compatibility-sensitive webhook callers. Callers that need strict
+ * pinning must resolve with a fail-closed policy and pass a static `lookup`
+ * callback to their native Node request, as the MTA-STS probe does.
  *
  * @returns The resolved IP address if safe, or an SSRFCheckResult if blocked.
  */
@@ -333,10 +341,9 @@ export async function resolveAndCheck(
 
     return { allowed: true, ip: address };
   } catch {
-    // DNS resolution failure (ENOTFOUND, ESERVFAIL, etc.) is NOT a rebinding
-    // attack — it means the hostname doesn't exist. Let fetch() handle the
-    // connection error naturally. Only block when resolution succeeds to a
-    // private IP.
+    // DNS resolution failure (ENOTFOUND, ESERVFAIL, etc.) is NOT treated as a
+    // rebinding block for compatibility-sensitive webhook callers. Strict
+    // probe callers use their own fail-closed resolution path instead.
     return { allowed: true, ip: hostname };
   }
 }

--- a/apps/web/hono/routes/api.runtime.test.ts
+++ b/apps/web/hono/routes/api.runtime.test.ts
@@ -21,11 +21,19 @@ function getTableName(table: unknown): string {
   return '';
 }
 
-function getConditionParam(condition: unknown): unknown {
+function getConditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
   const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
   };
-  return sql.queryChunks?.find((chunk) => chunk?.constructor?.name === 'Param')?.value;
+  if (sql.constructor?.name === 'Param') return [sql.value];
+  return (sql.queryChunks ?? []).flatMap(getConditionParams);
+}
+
+function getConditionParam(condition: unknown): unknown {
+  return getConditionParams(condition)[0];
 }
 
 function createMockDb(state: MockState): IDatabaseAdapter {
@@ -43,9 +51,13 @@ function createMockDb(state: MockState): IDatabaseAdapter {
       const tableName = getTableName(table);
       const param = getConditionParam(condition);
       if (tableName === 'domains') {
+        const params = getConditionParams(condition);
         return state.domains.filter(
           (domain) =>
-            domain.id === param || domain.normalizedName === param || domain.name === param
+            (domain.id === params[0] ||
+              domain.normalizedName === params[0] ||
+              domain.name === params[0]) &&
+            (params.length < 2 || domain.tenantId === params[1])
         );
       }
       if (tableName === 'snapshots') {
@@ -69,7 +81,14 @@ function createMockDb(state: MockState): IDatabaseAdapter {
         );
       }
       if (tableName === 'snapshots') {
-        return state.snapshots.find((snapshot) => snapshot.id === param);
+        const byId = state.snapshots.find((snapshot) => snapshot.id === param);
+        if (byId) return byId;
+        return [...state.snapshots]
+          .filter((snapshot) => snapshot.domainId === param)
+          .sort(
+            (a, b) =>
+              new Date(b.createdAt as string).getTime() - new Date(a.createdAt as string).getTime()
+          )[0];
       }
       return undefined;
     }),

--- a/apps/web/hono/routes/delegation.tenant-isolation.test.ts
+++ b/apps/web/hono/routes/delegation.tenant-isolation.test.ts
@@ -43,11 +43,19 @@ function getTableName(table: unknown): string {
 }
 
 // Extract condition parameter value from SQL condition
-function getConditionParam(condition: unknown): unknown {
+function getConditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
   const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
   };
-  return sql.queryChunks?.find((chunk) => chunk?.constructor?.name === 'Param')?.value;
+  if (sql.constructor?.name === 'Param') return [sql.value];
+  return (sql.queryChunks ?? []).flatMap(getConditionParams);
+}
+
+function getConditionParam(condition: unknown): unknown {
+  return getConditionParams(condition)[0];
 }
 
 function createMockDb(state: MockState): IDatabaseAdapter {
@@ -79,8 +87,11 @@ function createMockDb(state: MockState): IDatabaseAdapter {
       const tableName = getTableName(table);
       const condVal = getConditionParam(condition);
       if (tableName === 'domains') {
+        const params = getConditionParams(condition);
         return state.domains.filter(
-          (d) => d.id === condVal || d.normalizedName === condVal || d.name === condVal
+          (d) =>
+            (d.id === params[0] || d.normalizedName === params[0] || d.name === params[0]) &&
+            (params.length < 2 || d.tenantId === params[1])
         );
       }
       if (tableName === 'observations') {

--- a/apps/web/hono/routes/domain-profile.test.ts
+++ b/apps/web/hono/routes/domain-profile.test.ts
@@ -75,7 +75,8 @@ function createApp(
   const db = {
     async selectWhere(table: unknown, condition: unknown) {
       const values = params(condition);
-      if (table === domains) return values.includes('example.com') ? [domain] : [];
+      if (table === domains)
+        return values.includes('example.com') && domainTenantId === tenantId ? [domain] : [];
       if (table === snapshots) return values.includes('domain-1') ? snapshotsForDomain : [];
       if (table === probeObservations) return values.includes('snapshot-1') ? probes : [];
       if (table === domainProfiles)

--- a/apps/web/hono/routes/legacy-tools.tenant-isolation.test.ts
+++ b/apps/web/hono/routes/legacy-tools.tenant-isolation.test.ts
@@ -53,11 +53,19 @@ function getTableName(table: unknown): string {
   return '';
 }
 
-function getConditionParam(condition: unknown): unknown {
+function getConditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
   const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
   };
-  return sql.queryChunks?.find((c) => c?.constructor?.name === 'Param')?.value;
+  if (sql.constructor?.name === 'Param') return [sql.value];
+  return (sql.queryChunks ?? []).flatMap(getConditionParams);
+}
+
+function getConditionParam(condition: unknown): unknown {
+  return getConditionParams(condition)[0];
 }
 
 function createMockDb(state: MockState): IDatabaseAdapter {
@@ -78,7 +86,12 @@ function createMockDb(state: MockState): IDatabaseAdapter {
         return state.shadowComparisons.filter((r) => r.domain === param);
       if (name === 'snapshots') return state.snapshots.filter((r) => r.domainName === param);
       if (name === 'findings') return state.findings.filter((r) => r.snapshotId === param);
-      if (name === 'domains') return state.domains.filter((r) => r.normalizedName === param);
+      if (name === 'domains') {
+        const params = getConditionParams(condition);
+        return state.domains.filter(
+          (r) => r.normalizedName === params[0] && (params.length < 2 || r.tenantId === params[1])
+        );
+      }
       return [];
     }),
     selectOne: vi.fn(async () => null),

--- a/apps/web/hono/routes/monitoring.runtime.test.ts
+++ b/apps/web/hono/routes/monitoring.runtime.test.ts
@@ -30,11 +30,19 @@ function getTableName(table: unknown): string {
   return '';
 }
 
-function getConditionParam(condition: unknown): unknown {
+function getConditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
   const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
   };
-  return sql.queryChunks?.find((chunk) => chunk?.constructor?.name === 'Param')?.value;
+  if (sql.constructor?.name === 'Param') return [sql.value];
+  return (sql.queryChunks ?? []).flatMap(getConditionParams);
+}
+
+function getConditionParam(condition: unknown): unknown {
+  return getConditionParams(condition)[0];
 }
 
 function createMockDb(state: MockState): IDatabaseAdapter {
@@ -51,8 +59,11 @@ function createMockDb(state: MockState): IDatabaseAdapter {
       const tableName = getTableName(table);
       const param = getConditionParam(condition);
       if (tableName === 'domains') {
+        const params = getConditionParams(condition);
         return state.domains.filter(
-          (row) => row.id === param || row.normalizedName === param || row.name === param
+          (row) =>
+            (row.id === params[0] || row.normalizedName === params[0] || row.name === params[0]) &&
+            (params.length < 2 || row.tenantId === params[1])
         );
       }
       if (tableName === 'monitored_domains') {

--- a/apps/web/hono/routes/portfolio.test.ts
+++ b/apps/web/hono/routes/portfolio.test.ts
@@ -194,11 +194,19 @@ function getTableName(table: unknown): string {
   return '';
 }
 
-function getConditionParam(condition: unknown): unknown {
+function getConditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
   const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
   };
-  return sql.queryChunks?.find((chunk) => chunk?.constructor?.name === 'Param')?.value;
+  if (sql.constructor?.name === 'Param') return [sql.value];
+  return (sql.queryChunks ?? []).flatMap(getConditionParams);
+}
+
+function getConditionParam(condition: unknown): unknown {
+  return getConditionParams(condition)[0];
 }
 
 function createMockDb(data: MockData) {
@@ -264,9 +272,18 @@ function createMockDb(data: MockData) {
       if (tableName === 'auditEvents') return [...data.auditEvents];
       return [];
     }),
-    selectWhere: vi.fn(async (table: unknown, _condition: unknown) => {
+    selectWhere: vi.fn(async (table: unknown, condition: unknown) => {
       const tableName = getTable(table);
-      if (tableName === 'domains') return [...data.domains];
+      if (tableName === 'domains') {
+        const params = getConditionParams(condition);
+        return data.domains.filter(
+          (domain) =>
+            (domain.id === params[0] ||
+              domain.normalizedName === params[0] ||
+              domain.name === params[0]) &&
+            (params.length < 2 || domain.tenantId === params[1])
+        );
+      }
       if (tableName === 'domainNotes') return [...data.domainNotes];
       if (tableName === 'domainTags') return [...data.domainTags];
       if (tableName === 'auditEvents') return [...data.auditEvents];

--- a/apps/web/hono/routes/snapshot-history.integration.test.ts
+++ b/apps/web/hono/routes/snapshot-history.integration.test.ts
@@ -121,11 +121,19 @@ function getTableName(table: unknown): string {
   return '';
 }
 
-function getConditionParam(condition: unknown): unknown {
+function getConditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
   const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
   };
-  return sql.queryChunks?.find((chunk) => chunk?.constructor?.name === 'Param')?.value;
+  if (sql.constructor?.name === 'Param') return [sql.value];
+  return (sql.queryChunks ?? []).flatMap(getConditionParams);
+}
+
+function getConditionParam(condition: unknown): unknown {
+  return getConditionParams(condition)[0];
 }
 
 function createMockDb(state: MockState): IDatabaseAdapter {
@@ -147,8 +155,11 @@ function createMockDb(state: MockState): IDatabaseAdapter {
       const name = getTableName(table);
       const param = getConditionParam(condition);
       if (name === 'domains') {
+        const params = getConditionParams(condition);
         return state.domains.filter(
-          (r) => r.id === param || r.normalizedName === param || r.name === param
+          (r) =>
+            (r.id === params[0] || r.normalizedName === params[0] || r.name === params[0]) &&
+            (params.length < 2 || r.tenantId === params[1])
         );
       }
       if (name === 'snapshots')

--- a/apps/web/hono/routes/snapshots.runtime.test.ts
+++ b/apps/web/hono/routes/snapshots.runtime.test.ts
@@ -30,11 +30,19 @@ function getTableName(table: unknown): string {
   return '';
 }
 
-function getConditionParam(condition: unknown): unknown {
+function getConditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
   const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
   };
-  return sql.queryChunks?.find((chunk) => chunk?.constructor?.name === 'Param')?.value;
+  if (sql.constructor?.name === 'Param') return [sql.value];
+  return (sql.queryChunks ?? []).flatMap(getConditionParams);
+}
+
+function getConditionParam(condition: unknown): unknown {
+  return getConditionParams(condition)[0];
 }
 
 function createMockDb(state: MockState): IDatabaseAdapter {
@@ -56,8 +64,11 @@ function createMockDb(state: MockState): IDatabaseAdapter {
       const tableName = getTableName(table);
       const param = getConditionParam(condition);
       if (tableName === 'domains') {
+        const params = getConditionParams(condition);
         return state.domains.filter(
-          (row) => row.id === param || row.normalizedName === param || row.name === param
+          (row) =>
+            (row.id === params[0] || row.normalizedName === params[0] || row.name === params[0]) &&
+            (params.length < 2 || row.tenantId === params[1])
         );
       }
       if (tableName === 'snapshots')
@@ -79,7 +90,16 @@ function createMockDb(state: MockState): IDatabaseAdapter {
         return state.domains.find(
           (row) => row.id === param || row.normalizedName === param || row.name === param
         );
-      if (tableName === 'snapshots') return state.snapshots.find((row) => row.id === param);
+      if (tableName === 'snapshots') {
+        const byId = state.snapshots.find((row) => row.id === param);
+        if (byId) return byId;
+        return [...state.snapshots]
+          .filter((row) => row.domainId === param)
+          .sort(
+            (a, b) =>
+              new Date(b.createdAt as string).getTime() - new Date(a.createdAt as string).getTime()
+          )[0];
+      }
       return undefined;
     }),
     insert: vi.fn(),

--- a/apps/web/hono/routes/snapshots.tenant-isolation.test.ts
+++ b/apps/web/hono/routes/snapshots.tenant-isolation.test.ts
@@ -35,11 +35,19 @@ function getTableName(table: unknown): string {
   return '';
 }
 
-function getConditionParam(condition: unknown): unknown {
+function getConditionParams(condition: unknown): unknown[] {
+  if (!condition || typeof condition !== 'object') return [];
   const sql = condition as {
-    queryChunks?: Array<{ constructor?: { name?: string }; value?: unknown }>;
+    constructor?: { name?: string };
+    value?: unknown;
+    queryChunks?: unknown[];
   };
-  return sql.queryChunks?.find((chunk) => chunk?.constructor?.name === 'Param')?.value;
+  if (sql.constructor?.name === 'Param') return [sql.value];
+  return (sql.queryChunks ?? []).flatMap(getConditionParams);
+}
+
+function getConditionParam(condition: unknown): unknown {
+  return getConditionParams(condition)[0];
 }
 
 function createMockDb(state: MockState): IDatabaseAdapter {
@@ -61,8 +69,11 @@ function createMockDb(state: MockState): IDatabaseAdapter {
       const tableName = getTableName(table);
       const param = getConditionParam(condition);
       if (tableName === 'domains') {
+        const params = getConditionParams(condition);
         return state.domains.filter(
-          (row) => row.id === param || row.normalizedName === param || row.name === param
+          (row) =>
+            (row.id === params[0] || row.normalizedName === params[0] || row.name === params[0]) &&
+            (params.length < 2 || row.tenantId === params[1])
         );
       }
       if (tableName === 'snapshots')
@@ -86,7 +97,19 @@ function createMockDb(state: MockState): IDatabaseAdapter {
             (row) => row.id === param || row.normalizedName === param || row.name === param
           ) || null
         );
-      if (tableName === 'snapshots') return state.snapshots.find((row) => row.id === param) || null;
+      if (tableName === 'snapshots') {
+        const byId = state.snapshots.find((row) => row.id === param);
+        if (byId) return byId;
+        return (
+          [...state.snapshots]
+            .filter((row) => row.domainId === param)
+            .sort(
+              (a, b) =>
+                new Date(b.createdAt as string).getTime() -
+                new Date(a.createdAt as string).getTime()
+            )[0] ?? null
+        );
+      }
       return null;
     }),
     insert: vi.fn(),

--- a/docs/security/probe-sandbox-review.md
+++ b/docs/security/probe-sandbox-review.md
@@ -297,15 +297,27 @@ patterns.
 
 ### Before enabling in untrusted-tenant environments
 
-Implement the `safeLookup` DNS rebinding mitigation described above. Until
-then, DNS rebinding remains a residual risk for deployments where tenants can
-import MX records from domains they do not fully control.
+The DNS rebinding residual is now limited to the **MTA-STS HTTPS fetch**
+(the SMTP probe pins the checked IP; see §DNS Rebinding / TOCTOU Residual
+Risk). `fetch()` re-resolves `mta-sts.{domain}` internally, so a TTL switch
+between `resolveAndCheck()` and the fetch's own resolution can still land the
+connection on a private address. A feasible mitigation exists without adding
+dependencies: fetch the policy over a connection pinned to the checked IP —
+resolve once, run the address through the SSRF guard, then `tls.connect` to
+the resolved IP literal with `servername: 'mta-sts.{domain}'` (preserving
+SNI and certificate validation) and issue the HTTP GET over that socket,
+mirroring the SMTP probe's checked-IP pinning. Node's global `fetch()` exposes
+no lookup override, which is why the pin has to happen below it. Until that
+lands, treat MTA-STS fetch destinations as a residual risk for deployments
+where tenants can import MX records from domains they do not fully control,
+and restrict collector egress to public unicast destinations at the network
+layer as a compensating control.
 
 ### Remaining gaps
 
 | Gap | Severity | Recommendation |
 |-----|----------|---------------|
-| DNS rebinding / TOCTOU | Medium | Implement `safeLookup` callback (documented above) |
+| MTA-STS fetch DNS re-resolution (TOCTOU) | Medium | SMTP is fixed via checked-IP pinning; pin the MTA-STS fetch the same way — `tls.connect` to the checked IP with `servername` for SNI, HTTP over that socket (documented above). Interim: network-layer egress restriction to public unicast |
 | `::` covers non-mapped IPv6 addresses broadly | Low | Acceptable — probe targets should be standard FQDN hostnames resolved from DNS, not raw IPv6 literals |
 
 ---

--- a/docs/security/probe-sandbox-review.md
+++ b/docs/security/probe-sandbox-review.md
@@ -16,7 +16,7 @@ vulnerabilities plus one wiring deficiency:
 
 | Finding | Severity | Status |
 |---------|----------|--------|
-| IPv4-mapped IPv6 bypass (`::ffff:127.0.0.1`) | High | **Fixed** |
+| IPv6 target policy bypass (including `fec0::/10` and mapped forms) | High | **Fixed — all IPv6 targets fail closed** |
 | Redirect-to-private bypass (MTA-STS 3xx) | High | **Fixed** |
 | `PROBE_CONCURRENCY` / `PROBE_TIMEOUT_MS` not wired | Medium | **Fixed** |
 | No global semaphore (per-request only) | Medium | **Fixed** |
@@ -35,7 +35,7 @@ the PR-06 fixes.
 |--------|----------|------------|---------|
 | SSRF — private network access | Critical | SSRF guard + allowlist | ✅ |
 | SSRF — cloud metadata services (169.254.169.254) | Critical | Link-local block | ✅ |
-| SSRF — IPv4-mapped IPv6 (`::ffff:x.x.x.x`) | High | IPv4 extraction in checkIPv6 | ✅ Fixed in PR-06 |
+| SSRF — IPv4-mapped IPv6 (`::ffff:x.x.x.x`) | High | IPv6 fail-closed policy | ✅ Fixed in PR-06.1 |
 | SSRF — redirect-to-private (HTTP 3xx) | High | Native HTTPS rejects every 3xx | ✅ Fixed |
 | DNS rebinding (TOCTOU) | Medium | Checked-address pinning for SMTP and MTA-STS | ✅ Fixed |
 | Concurrency abuse (probe flood) | Medium | Global semaphore | ✅ Fixed in PR-06 |
@@ -71,27 +71,23 @@ All blocking is implemented in `apps/collector/src/probes/ssrf-guard.ts`.
 | `192.0.2.0/24` | TEST-NET-1 | `checkIPv4` range table |
 | `198.51.100.0/24` | TEST-NET-2 | `checkIPv4` range table |
 | `203.0.113.0/24` | TEST-NET-3 | `checkIPv4` range table |
-| `::1/128` | IPv6 loopback | `checkIPv6` prefix match |
-| `fe80::/10` | IPv6 link-local | `checkIPv6` prefix match |
-| `fc00::/7`, `fd::/8` | Unique local | `checkIPv6` prefix match |
-| `ff00::/8` | IPv6 multicast | `checkIPv6` prefix match |
-| `::ffff:x.x.x.x/96` | IPv4-mapped IPv6 | `extractIPv4FromMapped` → `checkIPv4` |
+| All IPv6 addresses, including `fec0::/10` | IPv6 policy not yet complete and maintained | `checkIPv6` fail-closed policy |
+| IPv4-mapped and IPv4-compatible IPv6 forms | IPv6 policy is intentionally fail closed | `checkIPv6` fail-closed policy |
 
-### Gap Fixed: IPv4-mapped IPv6 (`::ffff:x.x.x.x`)
+### IPv6 fail-closed policy
 
-**What was wrong (v1.0):** `checkIPv6` used prefix string matching. Addresses
-like `::ffff:127.0.0.1` start with `::` and were caught by the `::/128`
-(unspecified) prefix — meaning they were blocked, but with the wrong category
-(`reserved` instead of `loopback`). More importantly, `::ffff:8.8.8.8`
-(a public IPv4 in mapped form) was also incorrectly blocked.
+The controlled live harness accepts only checked public IPv4 answers. The
+active-probe SSRF guard follows the same boundary: every IPv6 literal is
+rejected until a complete, maintained IPv6 public-address policy exists. This
+includes unique-local, deprecated site-local (`fec0::/10`), documentation,
+multicast, IPv4-mapped, and IPv4-compatible forms. SMTP resolution and
+MTA-STS resolution both reject such answers before creating a socket or HTTPS
+request.
 
-**The fix (PR-06):** `checkIPv6` now detects `::ffff:` prefix and calls
-`extractIPv4FromMapped()`, which parses both dot-decimal (`::ffff:127.0.0.1`)
-and hex (`::ffff:7f00:0001`) notations, then routes the extracted IPv4 through
-`checkIPv4`. This gives correct classification (loopback/private/public) and
-correctly allows public IPv4-mapped addresses.
-
-**Test coverage:** `ssrf-guard.test.ts` PR-06.1 section; `probe-security.e2e.test.ts`.
+**Test coverage:** IPv6 boundary and mapped-form cases in
+`ssrf-guard.test.ts`, resolved-address cases in `smtp-starttls.test.ts` and
+`mta-sts.test.ts`, and the controlled policy in
+`tools/controlled-live-harness/runner.mjs`.
 
 ### Gap Fixed: Redirect-to-Private via HTTP 3xx
 
@@ -116,20 +112,22 @@ separate operations, the private IP is used without ever being checked.
 
 ### Current mitigation
 
-Both active probes resolve their target before opening a connection, reject
-failed or unsafe resolution, and prevent a second DNS decision:
+All active outbound paths resolve their target before opening a connection,
+reject failed or unsafe resolution, and prevent a second DNS decision:
 
 - **SMTP probe (`smtp-starttls.ts`):** resolves with `dns.promises.lookup`,
-  checks the address through `checkSSRF`, and connects to the checked IP
-  literal. DNS failures fail closed.
+  checks the address through `checkSSRF`, and connects to the checked IPv4
+  literal. DNS failures and every IPv6 answer fail closed.
 - **MTA-STS probe (`mta-sts.ts`):** resolves every address with
-  `dns.promises.lookup(..., { all: true })`, rejects unsafe or malformed output,
-  and passes a static `lookup` callback to native `https.request`. The request
-  uses `servername` and `Host` for the original hostname while the TCP
-  connection remains pinned to the checked address.
+  `dns.promises.lookup(..., { all: true })`, rejects unsafe, malformed, and
+  IPv6 output, and passes a static `lookup` callback to native
+  `https.request`. The request uses `servername` and `Host` for the original
+  hostname while the TCP connection remains pinned to the checked address.
+- **Webhook delivery (`notifications/webhook.ts`):** resolves a single public
+  IPv4, rejects DNS errors, and uses native HTTPS with a static lookup/address
+  pin. Redirects are rejected and the response is bounded and consumed under
+  one cumulative deadline.
 
-The compatibility-sensitive `resolveAndCheck()` helper remains fail-open on
-DNS errors for webhook callers; MTA-STS does not use it.
 
 ### Hardening note
 
@@ -282,7 +280,7 @@ public unicast destinations at the network layer as defense in depth.
 
 | Gap | Severity | Recommendation |
 |-----|----------|---------------|
-| `::` covers non-mapped IPv6 addresses broadly | Low | Acceptable — probe targets should be standard FQDN hostnames resolved from DNS, not raw IPv6 literals |
+| Complete public IPv6 policy is not yet maintained | Medium | All IPv6 literals and DNS answers fail closed until the policy exists |
 
 ---
 
@@ -292,6 +290,7 @@ public unicast destinations at the network layer as defense in depth.
 |---------|------|---------|
 | 1.0.0 | 2024-03-24 | Initial (unverified — incorrectly claimed zero remaining gaps) |
 | 2.0.0 | 2026-04-04 | PR-06 security audit; fixed IPv4-mapped IPv6, redirect handling, config wiring, semaphore gaps, DNS pinning, and body/deadline limits |
+| 2.1.0 | 2026-09-01 | Fail closed for all IPv6 active-probe targets; pin webhook HTTPS delivery and reject DNS failures, redirects, and oversized bodies |
 
 ---
 

--- a/docs/security/probe-sandbox-review.md
+++ b/docs/security/probe-sandbox-review.md
@@ -180,26 +180,49 @@ trusted-tenant deployments.
 
 ## Allowlist Derivation Strategy
 
+### Authorization source (Issue #67)
+
+Probe routes derive every allowlist entry — and every probe target — from
+**fresh persisted DNS evidence only**: the tenant-owned domain → latest
+complete snapshot → consistent record set → immutable source observations
+chain created by the collector. Caller-supplied DNS-shaped payloads
+(`txtRecords`, `mxRecords`, `dnsResults`) are rejected with `403` and never
+mixed with trusted evidence.
+
+Every request revalidates the persisted chain and fails closed unless:
+
+- the domain is registered for the requesting tenant;
+- the latest snapshot is `complete`;
+- the exact MX / `_mta-sts` TXT record set is consistent and has source
+  observations;
+- each observation is a successful `NOERROR` query from a trusted collector
+  vantage (missing, `mock`, and `probe` provenance is rejected, and
+  authoritative answers must carry the AA flag);
+- every relevant answer is still fresh, where freshness is
+  `queriedAt + min(answer TTL, 5 minutes)` — zero TTL, future-dated, and
+  boundary-expired evidence all fail;
+- an optional SMTP hostname exactly matches a persisted MX target, and only
+  port 25 is permitted.
+
 ### Derivation rules
 
 | Source | Entry type | Port | TTL |
 |--------|-----------|------|-----|
-| DNS MX record answer | `mx` | 25 | 5 min |
-| MTA-STS DNS TXT record | `mta-sts` | 443 | 5 min |
-| Manual (`addCustomEntry`) | `custom` | Any | 5 min |
+| Persisted DNS MX record answer | `mx` | 25 | 5 min |
+| Persisted MTA-STS DNS TXT record | `mta-sts` | 443 | 5 min |
 
 All entries carry a `derivedFrom` audit trail (domain, query type, raw answer
-data, requestedBy) for incident investigation.
+data) for incident investigation. The routes no longer create `custom`
+entries; `addCustomEntry` remains available to in-process callers but is not
+used by any HTTP route.
 
-### Why MX-only?
+### Why persisted MX only?
 
 MX records represent the operator's declared mail infrastructure. They are
 authoritative DNS responses that the operator controls. Allowing arbitrary
-hostnames would require trusting user-supplied input directly.
-
-Custom entries exist for programmatic use (e.g., probe API), but are still
-logged with a `requestedBy` field and subject to the same SSRF check at
-probe time.
+hostnames would require trusting user-supplied input directly, which is
+exactly what the pre-Issue-#67 routes did (caller `mxRecords`/`dnsResults`
+and a fabricated `vantageIdentifier: "mock"` result).
 
 ### Tenant isolation
 

--- a/docs/security/probe-sandbox-review.md
+++ b/docs/security/probe-sandbox-review.md
@@ -17,14 +17,13 @@ vulnerabilities plus one wiring deficiency:
 | Finding | Severity | Status |
 |---------|----------|--------|
 | IPv4-mapped IPv6 bypass (`::ffff:127.0.0.1`) | High | **Fixed** |
-| Redirect-to-private bypass (`fetch()` following 3xx) | High | **Fixed** |
+| Redirect-to-private bypass (MTA-STS 3xx) | High | **Fixed** |
 | `PROBE_CONCURRENCY` / `PROBE_TIMEOUT_MS` not wired | Medium | **Fixed** |
 | No global semaphore (per-request only) | Medium | **Fixed** |
-| DNS rebinding / TOCTOU residual risk | Medium | **Documented, partially mitigated** |
+| DNS rebinding / TOCTOU | Medium | **Fixed for active probes** |
 
 The probe sandbox is safe to enable with standard precautions **after** applying
-the PR-06 fixes. Remaining risk (DNS rebinding) is documented below with a
-specific remediation path.
+the PR-06 fixes.
 
 ---
 
@@ -37,8 +36,8 @@ specific remediation path.
 | SSRF — private network access | Critical | SSRF guard + allowlist | ✅ |
 | SSRF — cloud metadata services (169.254.169.254) | Critical | Link-local block | ✅ |
 | SSRF — IPv4-mapped IPv6 (`::ffff:x.x.x.x`) | High | IPv4 extraction in checkIPv6 | ✅ Fixed in PR-06 |
-| SSRF — redirect-to-private (HTTP 3xx) | High | `redirect:'error'` in MTA-STS fetch | ✅ Fixed in PR-06 |
-| DNS rebinding (TOCTOU) | Medium | Partially — see §DNS Rebinding | ⚠️ Residual |
+| SSRF — redirect-to-private (HTTP 3xx) | High | Native HTTPS rejects every 3xx | ✅ Fixed |
+| DNS rebinding (TOCTOU) | Medium | Checked-address pinning for SMTP and MTA-STS | ✅ Fixed |
 | Concurrency abuse (probe flood) | Medium | Global semaphore | ✅ Fixed in PR-06 |
 | Timeout exhaustion | Medium | `PROBE_TIMEOUT_MS` enforced | ✅ Fixed in PR-06 |
 | Arbitrary target probing | Critical | MX-only allowlist | ✅ |
@@ -96,24 +95,17 @@ correctly allows public IPv4-mapped addresses.
 
 ### Gap Fixed: Redirect-to-Private via HTTP 3xx
 
-**What was wrong (v1.0):** `fetchMTASTSPolicy` used `fetch(url, { ... })` with
-default redirect behavior (`follow`). A MITM or attacker-controlled server at
-`https://mta-sts.attacker.com` returning `301 → http://127.0.0.1/exfil` would
-cause the `fetch` to silently follow the redirect without SSRF-checking the
-target URL.
+**What was wrong (v1.0):** the MTA-STS policy fetch followed redirects by
+default. A server returning `301 → http://127.0.0.1/exfil` could therefore
+bypass the SSRF check on the original URL.
 
-**The fix (PR-06):** `redirect: 'error'` added to the `fetch` call in
-`mta-sts.ts`. Any 3xx response from the MTA-STS endpoint is now treated as a
-fetch error, preventing redirect-following entirely.
-
-**Why not check the redirect target with the SSRF guard?** Node.js `fetch` does
-not expose a redirect callback at the response layer; the only safe option is
-to reject all redirects. MTA-STS policy URLs should be served directly from
-`https://mta-sts.{domain}/.well-known/mta-sts.txt` with no redirects.
+**The fix:** `mta-sts.ts` uses native `https.request`, which does not follow
+redirects, and explicitly rejects every 3xx response. MTA-STS policy URLs are
+served directly from `https://mta-sts.{domain}/.well-known/mta-sts.txt`.
 
 ---
 
-## DNS Rebinding / TOCTOU Residual Risk
+## DNS Rebinding / TOCTOU Protection
 
 ### What is DNS rebinding?
 
@@ -124,41 +116,26 @@ separate operations, the private IP is used without ever being checked.
 
 ### Current mitigation
 
-The allowlist restricts probe targets to MX-derived hostnames. An attacker
-cannot add an arbitrary hostname to the allowlist. For DNS rebinding to succeed,
-the attacker would need to:
+Both active probes resolve their target before opening a connection, reject
+failed or unsafe resolution, and prevent a second DNS decision:
 
-1. Control the DNS for a domain whose MX record a tenant has legitimately added
-   to their allowlist, **AND**
-2. Rebind that MX hostname's IP to a private range after the allowlist was
-   generated.
+- **SMTP probe (`smtp-starttls.ts`):** resolves with `dns.promises.lookup`,
+  checks the address through `checkSSRF`, and connects to the checked IP
+  literal. DNS failures fail closed.
+- **MTA-STS probe (`mta-sts.ts`):** resolves every address with
+  `dns.promises.lookup(..., { all: true })`, rejects unsafe or malformed output,
+  and passes a static `lookup` callback to native `https.request`. The request
+  uses `servername` and `Host` for the original hostname while the TCP
+  connection remains pinned to the checked address.
 
-This is a high bar but not impossible (e.g., if a tenant imports a compromised
-domain's MX record).
-
-### Residual exposure
-
-- **SMTP probe (`smtp-starttls.ts`): FIXED (Issue #67 review, P1). The
-  probe resolves the hostname itself (`dns.promises.lookup`), runs the
-  resolved address through `checkSSRF`, and connects to the checked IP
-  literal — `net.connect` never re-resolves the hostname, and DNS
-  resolution failures (e.g. `ENOTFOUND`) fail closed instead of falling
-  back to hostname-based connect.
-
-- **MTA-STS probe (`mta-sts.ts`):** Uses `fetch()`, which re-resolves the
-  hostname internally. `resolveAndCheck()` validates the resolved IP before
-  the fetch, but a sub-millisecond TTL switch between the check and the
-  fetch's own resolution remains theoretically possible (the two-step check
-  is the industry-standard mitigation for HTTP-based SSRF).
+The compatibility-sensitive `resolveAndCheck()` helper remains fail-open on
+DNS errors for webhook callers; MTA-STS does not use it.
 
 ### Hardening note
 
-The earlier "future hardening path" (a custom `lookup` for
-`net.connect`/`tls.connect`) has been implemented for the SMTP probe as
-checked-IP pinning instead: the probe resolves once, checks the address,
-and connects to the IP literal directly. Lookup-function pinning is not
-available to HTTP-fetch probes (`mta-sts.ts`), which keep the
-`resolveAndCheck()` pre-resolution mitigation and its documented residual.
+Native HTTPS is used with `agent: false`, `rejectUnauthorized: true`, and no
+redirect following. The request deadline remains active while the response
+body is streamed, with a 64 KiB declared and actual body limit.
 
 ---
 
@@ -297,27 +274,14 @@ patterns.
 
 ### Before enabling in untrusted-tenant environments
 
-The DNS rebinding residual is now limited to the **MTA-STS HTTPS fetch**
-(the SMTP probe pins the checked IP; see §DNS Rebinding / TOCTOU Residual
-Risk). `fetch()` re-resolves `mta-sts.{domain}` internally, so a TTL switch
-between `resolveAndCheck()` and the fetch's own resolution can still land the
-connection on a private address. A feasible mitigation exists without adding
-dependencies: fetch the policy over a connection pinned to the checked IP —
-resolve once, run the address through the SSRF guard, then `tls.connect` to
-the resolved IP literal with `servername: 'mta-sts.{domain}'` (preserving
-SNI and certificate validation) and issue the HTTP GET over that socket,
-mirroring the SMTP probe's checked-IP pinning. Node's global `fetch()` exposes
-no lookup override, which is why the pin has to happen below it. Until that
-lands, treat MTA-STS fetch destinations as a residual risk for deployments
-where tenants can import MX records from domains they do not fully control,
-and restrict collector egress to public unicast destinations at the network
-layer as a compensating control.
+The active probes now pin their checked DNS results and enforce public-unicast
+SSRF policy at the connection layer. Continue to restrict collector egress to
+public unicast destinations at the network layer as defense in depth.
 
 ### Remaining gaps
 
 | Gap | Severity | Recommendation |
 |-----|----------|---------------|
-| MTA-STS fetch DNS re-resolution (TOCTOU) | Medium | SMTP is fixed via checked-IP pinning; pin the MTA-STS fetch the same way — `tls.connect` to the checked IP with `servername` for SNI, HTTP over that socket (documented above). Interim: network-layer egress restriction to public unicast |
 | `::` covers non-mapped IPv6 addresses broadly | Low | Acceptable — probe targets should be standard FQDN hostnames resolved from DNS, not raw IPv6 literals |
 
 ---
@@ -327,7 +291,7 @@ layer as a compensating control.
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0.0 | 2024-03-24 | Initial (unverified — incorrectly claimed zero remaining gaps) |
-| 2.0.0 | 2026-04-03 | PR-06 security audit; found and fixed IPv4-mapped IPv6, redirect-to-private, config wiring, semaphore gaps; documented DNS rebinding residual risk |
+| 2.0.0 | 2026-04-04 | PR-06 security audit; fixed IPv4-mapped IPv6, redirect handling, config wiring, semaphore gaps, DNS pinning, and body/deadline limits |
 
 ---
 
@@ -337,7 +301,7 @@ layer as a compensating control.
 |------|---------|
 | `apps/collector/src/probes/ssrf-guard.ts` | SSRF guard — IP/URL validation |
 | `apps/collector/src/probes/allowlist.ts` | Tenant-scoped probe allowlist |
-| `apps/collector/src/probes/mta-sts.ts` | MTA-STS policy fetch (redirect:'error' fix) |
+| `apps/collector/src/probes/mta-sts.ts` | Pinned MTA-STS policy fetch and body limits |
 | `apps/collector/src/probes/semaphore.ts` | Global concurrency semaphore |
 | `apps/collector/src/probes/ssrf-guard.test.ts` | SSRF guard unit tests |
 | `apps/collector/src/probes/probe-ratelimit.test.ts` | Rate-limit/concurrency tests |

--- a/docs/security/probe-sandbox-review.md
+++ b/docs/security/probe-sandbox-review.md
@@ -138,43 +138,27 @@ domain's MX record).
 
 ### Residual exposure
 
-- **SMTP probe (`smtp-starttls.ts`):** Uses raw `net.connect(port, hostname)`.
-  Node.js resolves the hostname internally; there is no hook to check the
-  resolved IP before connecting.
+- **SMTP probe (`smtp-starttls.ts`): FIXED (Issue #67 review, P1). The
+  probe resolves the hostname itself (`dns.promises.lookup`), runs the
+  resolved address through `checkSSRF`, and connects to the checked IP
+  literal — `net.connect` never re-resolves the hostname, and DNS
+  resolution failures (e.g. `ENOTFOUND`) fail closed instead of falling
+  back to hostname-based connect.
 
-- **MTA-STS probe (`mta-sts.ts`):** Uses `fetch()`. Same limitation.
+- **MTA-STS probe (`mta-sts.ts`):** Uses `fetch()`, which re-resolves the
+  hostname internally. `resolveAndCheck()` validates the resolved IP before
+  the fetch, but a sub-millisecond TTL switch between the check and the
+  fetch's own resolution remains theoretically possible (the two-step check
+  is the industry-standard mitigation for HTTP-based SSRF).
 
-### Future hardening path
+### Hardening note
 
-Pass a custom `lookup` function to `net.connect` / `tls.connect` that:
-1. Resolves the hostname via DNS.
-2. Passes the resolved IP through `checkSSRF`.
-3. Rejects with `EACCES` if blocked.
-
-Example (Node.js `net.connect` option):
-```typescript
-import { lookup } from 'node:dns/promises';
-import { checkSSRF } from './ssrf-guard.js';
-
-const safeLookup = async (
-  hostname: string,
-  opts: dns.LookupOptions,
-  cb: (err: Error | null, address: string, family: number) => void
-) => {
-  const result = await lookup(hostname, opts);
-  const check = checkSSRF(result.address);
-  if (!check.allowed) {
-    cb(new Error(`SSRF blocked resolved IP ${result.address}: ${check.reason}`), '', 0);
-    return;
-  }
-  cb(null, result.address, result.family);
-};
-```
-
-**Recommendation:** Implement `safeLookup` before enabling the probe flag in
-environments where probe targets may be controlled by untrusted parties.
-Until then, the MX-only allowlist provides sufficient isolation for
-trusted-tenant deployments.
+The earlier "future hardening path" (a custom `lookup` for
+`net.connect`/`tls.connect`) has been implemented for the SMTP probe as
+checked-IP pinning instead: the probe resolves once, checks the address,
+and connects to the IP literal directly. Lookup-function pinning is not
+available to HTTP-fetch probes (`mta-sts.ts`), which keep the
+`resolveAndCheck()` pre-resolution mitigation and its documented residual.
 
 ---
 

--- a/packages/db/src/database/simple-adapter.ts
+++ b/packages/db/src/database/simple-adapter.ts
@@ -63,10 +63,12 @@ export class SimpleDatabaseAdapter {
    */
   async selectOne<T extends PgTable>(
     table: T,
-    condition: SQL
+    condition: SQL,
+    orderBy?: SQL
   ): Promise<T['$inferSelect'] | undefined> {
     const db = this.db as NodePgDatabase<Schema>;
-    const results = await db.select().from(table).where(condition).limit(1);
+    const query = db.select().from(table).where(condition);
+    const results = orderBy ? await query.orderBy(orderBy).limit(1) : await query.limit(1);
     return results[0];
   }
 

--- a/packages/db/src/repos/domain.find-or-create.test.ts
+++ b/packages/db/src/repos/domain.find-or-create.test.ts
@@ -49,14 +49,14 @@ const globalDomainData: NewDomain = {
  * Create a mock database adapter for testing findOrCreate.
  * The mock must provide:
  * - getDrizzle(): returns an object with insert() for the atomic upsert
- * - select(): used by findByNameAndTenant fallback after conflict
+ * - selectWhere(): used by tenant-scoped fallback after conflict
  */
 function createMockAdapter(config: {
   /** Domain returned by getDrizzle insert onConflictDoNothing (null = conflict) */
   upsertResult?: Domain | null;
-  /** Domain returned by select() in findByNameAndTenant fallback */
+  /** Rows returned by selectWhere() for fallback lookups */
   selectResult?: Domain[];
-  /** Domain returned by selectOne() in findByName fallback */
+  /** Domain returned by selectOne() for unscoped lookups */
   findByNameResult?: Domain | undefined;
 }) {
   return {
@@ -149,33 +149,33 @@ describe('DomainRepository.findOrCreate atomic upsert', () => {
 
       const mockAdapter = createMockAdapter({
         upsertResult: null, // onConflictDoNothing returns empty = conflict detected
-        selectResult: [existingDomain], // fallback findByNameAndTenant returns domain
+        selectResult: [existingDomain],
       });
 
       const repo = new DomainRepository(mockAdapter as never);
       const result = await repo.findOrCreate(newDomainData);
 
       expect(result.id).toBe(mockDomain.id);
-      expect(mockAdapter.selectWhere).toHaveBeenCalled(); // fallback query was called
+      expect(mockAdapter.selectWhere).toHaveBeenCalled(); // tenant-scoped fallback query was called
     });
 
     it('finds existing domain using normalizedName in fallback (not data.name)', async () => {
       // This test verifies the fix for the bug where data.name was used instead of
-      // normalizedName in fallback queries. The mock's select() returns the domain
+      // normalizedName in fallback queries. The mock's selectWhere() returns the domain
       // when called correctly, proving the fallback uses normalizedName.
       const existingDomain: Domain = { ...mockDomain };
 
       const mockAdapter = createMockAdapter({
         upsertResult: null, // conflict detected
-        selectResult: [existingDomain], // findByNameAndTenant returns domain
+        selectResult: [existingDomain],
       });
 
       const repo = new DomainRepository(mockAdapter as never);
       const result = await repo.findOrCreate(newDomainData);
 
-      // If bug existed (using data.name), select() wouldn't return domain → result would be undefined
+      // If bug existed (using data.name), selectWhere() would not return the domain → result undefined
       expect(result.id).toBe(mockDomain.id);
-      // select() was called as part of the fallback query
+      // selectWhere() was called as part of the tenant-scoped fallback query
       expect(mockAdapter.selectWhere).toHaveBeenCalled();
     });
   });
@@ -186,7 +186,7 @@ describe('DomainRepository.findOrCreate atomic upsert', () => {
       let callCount = 0;
 
       const mockAdapter = {
-        selectOne: vi.fn().mockResolvedValue(null),
+        selectOne: vi.fn().mockResolvedValue(createdDomain),
         selectWhere: vi.fn().mockResolvedValue([createdDomain]),
         select: vi.fn().mockResolvedValue([createdDomain]),
         insert: vi.fn(),
@@ -277,7 +277,7 @@ describe('DomainRepository.findOrCreate atomic upsert', () => {
 
       const mockAdapter = createMockAdapter({
         upsertResult: null, // conflict detected
-        selectResult: [existingDomain], // findByNameAndTenant returns domain
+        selectResult: [existingDomain],
       });
 
       const repo = new DomainRepository(mockAdapter as never);
@@ -363,16 +363,55 @@ describe('DomainRepository tenant-scoped lookup isolation', () => {
       id: 'domain-foreign-id',
       tenantId: 'tenant-2',
     };
-    const mockAdapter = createMockAdapter({
-      selectResult: [],
-      findByNameResult: foreignDomain,
-    });
+    const selectWhere = vi.fn().mockResolvedValue([]);
+    const selectOne = vi.fn();
+    const mockAdapter = {
+      ...createMockAdapter({ selectResult: [foreignDomain] }),
+      selectOne,
+      selectWhere,
+    };
 
     const repo = new DomainRepository(mockAdapter as never);
     const result = await repo.findByNameAndTenant('example.com', 'test-tenant');
 
     expect(result).toBeUndefined();
-    expect(mockAdapter.selectWhere).toHaveBeenCalled();
-    expect(mockAdapter.selectOne).not.toHaveBeenCalled();
+    expect(selectWhere).toHaveBeenCalledTimes(1);
+    expect(selectOne).not.toHaveBeenCalled();
+  });
+
+  it('constrains normalized name and tenant ID in the same query', async () => {
+    const selectWhere = vi.fn().mockResolvedValue([]);
+    const mockAdapter = {
+      ...createMockAdapter({}),
+      selectWhere,
+    };
+
+    const repo = new DomainRepository(mockAdapter as never);
+    await repo.findByNameAndTenant('  Example.COM. ', 'tenant-a');
+
+    const condition = selectWhere.mock.calls[0]?.[1] as {
+      queryChunks?: Array<{
+        queryChunks?: unknown[];
+        constructor?: { name?: string };
+        value?: unknown;
+      }>;
+    };
+    const values: unknown[] = [];
+    const visit = (value: unknown): void => {
+      if (!value || typeof value !== 'object') return;
+      const part = value as {
+        queryChunks?: unknown[];
+        constructor?: { name?: string };
+        value?: unknown;
+      };
+      if (part.constructor?.name === 'Param') {
+        values.push(part.value);
+        return;
+      }
+      for (const chunk of part.queryChunks ?? []) visit(chunk);
+    };
+    visit(condition);
+
+    expect(values).toEqual(['example.com', 'tenant-a']);
   });
 });

--- a/packages/db/src/repos/domain.ts
+++ b/packages/db/src/repos/domain.ts
@@ -4,7 +4,7 @@
  * Repository pattern for domain operations using the database adapter.
  */
 
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { IDatabaseAdapter } from '../database/simple-adapter.js';
 import type * as schema from '../schema/index.js';
@@ -40,14 +40,11 @@ export class DomainRepository {
    * This is the preferred method for multi-tenant lookups.
    */
   async findByNameAndTenant(normalizedName: string, tenantId: string): Promise<Domain | undefined> {
-    const matches = await this.db.selectWhere(
-      domains,
-      eq(domains.normalizedName, normalizedName.toLowerCase())
-    );
-    const normalized = normalizedName.toLowerCase();
-    return matches.find(
-      (domain) => domain.normalizedName === normalized && domain.tenantId === tenantId
-    );
+    const normalized = normalizedName.trim().toLowerCase().replace(/\.$/, '');
+    const condition = and(eq(domains.normalizedName, normalized), eq(domains.tenantId, tenantId));
+    if (!condition) return undefined;
+    const matches = await this.db.selectWhere(domains, condition);
+    return matches[0];
   }
 
   /**
@@ -163,23 +160,14 @@ export class DomainRepository {
 
     // Conflict occurred - another caller inserted first
     // Query for the existing record using normalizedName (not data.name)
-    if (data.tenantId) {
-      const existing = await this.findByNameAndTenant(normalizedName, data.tenantId);
-      if (existing) {
-        return existing;
-      }
-      // Fallback: query by normalized name directly (should exist after conflict)
-      const fallback = await this.findByName(normalizedName);
-      if (fallback) {
-        return fallback;
-      }
-    } else {
-      const existing = await this.findByName(normalizedName);
-      if (existing) {
-        return existing;
-      }
+    const existing = data.tenantId
+      ? await this.findByNameAndTenant(normalizedName, data.tenantId)
+      : await this.findByName(normalizedName);
+    if (existing) {
+      return existing;
     }
-    // This shouldn't happen if insert failed due to conflict
+
+    // This shouldn't happen if insert failed due to conflict.
     throw new Error(`Domain ${data.name} not found after conflict resolution`);
   }
 

--- a/packages/db/src/repos/recordset.test.ts
+++ b/packages/db/src/repos/recordset.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IDatabaseAdapter } from '../database/simple-adapter.js';
+import { recordSets } from '../schema/index.js';
+import { RecordSetRepository } from './recordset.js';
+
+function parameterValues(condition: unknown): unknown[] {
+  const values: unknown[] = [];
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== 'object') return;
+    const record = value as {
+      queryChunks?: unknown[];
+      constructor?: { name?: string };
+      value?: unknown;
+    };
+    if (record.constructor?.name === 'Param') {
+      values.push(record.value);
+      return;
+    }
+    for (const chunk of record.queryChunks ?? []) visit(chunk);
+  };
+  visit(condition);
+  return values;
+}
+
+describe('RecordSetRepository.findByNameAndType', () => {
+  it('uses one constrained query with normalized snapshot, name, and type', async () => {
+    const selectOne = vi.fn().mockResolvedValue(null);
+    const select = vi.fn();
+    const db = { selectOne, select } as unknown as IDatabaseAdapter;
+
+    await new RecordSetRepository(db).findByNameAndType(
+      'snapshot-1',
+      '  _MTA-STS.Example.COM. ',
+      ' txt '
+    );
+
+    expect(select).not.toHaveBeenCalled();
+    expect(selectOne).toHaveBeenCalledTimes(1);
+    expect(selectOne.mock.calls[0]?.[0]).toBe(recordSets);
+    expect(parameterValues(selectOne.mock.calls[0]?.[1])).toEqual([
+      'snapshot-1',
+      '_mta-sts.example.com',
+      'TXT',
+    ]);
+  });
+});

--- a/packages/db/src/repos/recordset.ts
+++ b/packages/db/src/repos/recordset.ts
@@ -1,6 +1,14 @@
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import type { IDatabaseAdapter } from '../database/simple-adapter.js';
 import { type NewRecordSet, type RecordSet, recordSets } from '../schema/index.js';
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase().replace(/\.$/, '');
+}
+
+function normalizeType(type: string): string {
+  return type.trim().toUpperCase();
+}
 
 export class RecordSetRepository {
   constructor(private db: IDatabaseAdapter) {}
@@ -25,11 +33,15 @@ export class RecordSetRepository {
     name: string,
     type: string
   ): Promise<RecordSet | null> {
-    const results = await this.db.select(recordSets);
-    const match = results.find(
-      (r) => r.snapshotId === snapshotId && r.name === name && r.type === type
+    const condition = and(
+      eq(recordSets.snapshotId, snapshotId),
+      eq(recordSets.name, normalizeName(name)),
+      eq(recordSets.type, normalizeType(type))
     );
-    return match || null;
+    if (!condition) throw new Error('Expected record-set lookup predicates');
+
+    const result = await this.db.selectOne(recordSets, condition);
+    return result || null;
   }
 
   async create(data: NewRecordSet): Promise<RecordSet> {

--- a/packages/db/src/repos/snapshot.test.ts
+++ b/packages/db/src/repos/snapshot.test.ts
@@ -30,6 +30,27 @@ function createMockDb(snapshots: Record<string, unknown>[] = []) {
 }
 
 describe('SnapshotRepository', () => {
+  describe('findLatestByDomain', () => {
+    it('uses one ordered limited lookup instead of loading all snapshots', async () => {
+      const latest = { id: 'snapshot-latest', domainId: 'domain-1', createdAt: new Date() };
+      const mockDb = createMockDb([latest]);
+      const repo = new SnapshotRepository(
+        mockDb as unknown as import('../database/simple-adapter.js').IDatabaseAdapter
+      );
+
+      const result = await repo.findLatestByDomain('domain-1');
+
+      expect(result).toBe(latest);
+      expect(mockDb.selectOne).toHaveBeenCalledTimes(1);
+      expect(mockDb.selectWhere).not.toHaveBeenCalled();
+      expect(mockDb.selectOne).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+  });
+
   describe('findRecentByDomain', () => {
     it('returns undefined when no snapshots exist', async () => {
       const mockDb = createMockDb([]);

--- a/packages/db/src/repos/snapshot.ts
+++ b/packages/db/src/repos/snapshot.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EvaluationCoverage } from '@dns-ops/contracts';
-import { eq } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import type { IDatabaseAdapter } from '../database/simple-adapter.js';
 import { type NewSnapshot, type Snapshot, snapshots } from '../schema/index.js';
 
@@ -35,11 +35,11 @@ export class SnapshotRepository {
    * Get the most recent snapshot for a domain
    */
   async findLatestByDomain(domainId: string): Promise<Snapshot | undefined> {
-    const results = await this.db.selectWhere(snapshots, eq(snapshots.domainId, domainId));
-    // Sort by createdAt desc and return first
-    return results.sort(
-      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    )[0];
+    return this.db.selectOne(
+      snapshots,
+      eq(snapshots.domainId, domainId),
+      desc(snapshots.createdAt)
+    );
   }
 
   /**

--- a/packages/parsing/src/dns/index.test.ts
+++ b/packages/parsing/src/dns/index.test.ts
@@ -1,0 +1,39 @@
+/** DNS owner normalization tests. */
+
+import { describe, expect, it } from 'vitest';
+import { MAX_DNS_CNAME_HOPS, tryNormalizeDNSOwner } from './index.js';
+
+describe('tryNormalizeDNSOwner', () => {
+  it('normalizes mixed-case underscore service owners and one root dot', () => {
+    expect(tryNormalizeDNSOwner('_Policy._MTA-STS.Example.NET.')).toEqual({
+      original: '_Policy._MTA-STS.Example.NET.',
+      normalized: '_policy._mta-sts.example.net',
+    });
+  });
+
+  it('accepts valid hyphens and underscores in labels', () => {
+    expect(tryNormalizeDNSOwner('_smtp._tls.mail-example.example')).toMatchObject({
+      normalized: '_smtp._tls.mail-example.example',
+    });
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['.', 'root only'],
+    ['example..net', 'empty label'],
+    ['example.net..', 'repeated root dots'],
+    ['*.example.net', 'wildcard'],
+    ['example .net', 'space'],
+    ['-example.net', 'leading hyphen'],
+    ['example-.net', 'trailing hyphen'],
+    [`${'a'.repeat(64)}.example`, 'label too long'],
+    [`${'a'.repeat(250)}.example`, 'total name too long'],
+    ['münchen.example', 'unsupported non-ASCII observation'],
+  ])('rejects %s (%s)', (owner) => {
+    expect(tryNormalizeDNSOwner(owner)).toBeNull();
+  });
+
+  it('shares the five-hop authorization bound', () => {
+    expect(MAX_DNS_CNAME_HOPS).toBe(5);
+  });
+});

--- a/packages/parsing/src/dns/index.ts
+++ b/packages/parsing/src/dns/index.ts
@@ -14,6 +14,53 @@ export interface ParsedAnswer {
   priority?: number;
 }
 
+/** Maximum number of CNAME edges trusted by DNS evidence consumers. */
+export const MAX_DNS_CNAME_HOPS = 5;
+
+export interface NormalizedDNSOwner {
+  original: string;
+  normalized: string;
+}
+
+/**
+ * Normalize a DNS owner name without applying domain-only restrictions.
+ * Service owners such as `_mta-sts.example.com` legitimately contain `_`.
+ * DNS responses are expected to expose non-ASCII names in wire-format
+ * punycode; arbitrary escaped/binary labels are rejected here.
+ */
+export function tryNormalizeDNSOwner(name: string): NormalizedDNSOwner | null {
+  if (typeof name !== 'string') return null;
+
+  const trimmed = name.trim();
+  if (!trimmed || trimmed.endsWith('..')) return null;
+
+  const normalized = trimmed.endsWith('.') ? trimmed.slice(0, -1) : trimmed;
+  if (
+    !normalized ||
+    normalized.length > 253 ||
+    normalized.includes('..') ||
+    normalized.includes('*')
+  ) {
+    return null;
+  }
+
+  const labels = normalized.split('.');
+  if (
+    labels.some(
+      (label) =>
+        !label ||
+        label.length > 63 ||
+        label.startsWith('-') ||
+        label.endsWith('-') ||
+        !/^[a-z0-9_-]+$/i.test(label)
+    )
+  ) {
+    return null;
+  }
+
+  return { original: name, normalized: normalized.toLowerCase() };
+}
+
 /**
  * Parse raw DNS answer data into structured format
  */

--- a/packages/parsing/src/dns/recordset.test.ts
+++ b/packages/parsing/src/dns/recordset.test.ts
@@ -334,6 +334,43 @@ describe('observationsToRecordSets', () => {
   });
 });
 
+describe('CNAME owner and target normalization', () => {
+  it('canonicalizes valid CNAME targets while retaining malformed observations', () => {
+    const observation = createObservation({
+      queryName: '_MTA-STS.Example.NET.',
+      queryType: 'CNAME',
+      answerSection: [
+        {
+          name: '_mta-sts.example.net.',
+          type: 'CNAME',
+          ttl: 300,
+          data: '_Policy._MTA-STS.Example.NET.',
+        },
+        {
+          name: '_mta-sts.example.net.',
+          type: 'CNAME',
+          ttl: 300,
+          data: 'not a valid target',
+        },
+        {
+          name: 'unrelated.example.net.',
+          type: 'CNAME',
+          ttl: 300,
+          data: 'ignored.example.net.',
+        },
+      ],
+    });
+
+    expect(observationsToRecordSets([observation])).toMatchObject([
+      {
+        name: '_mta-sts.example.net',
+        type: 'CNAME',
+        values: ['_policy._mta-sts.example.net', 'not a valid target'],
+      },
+    ]);
+  });
+});
+
 describe('groupRecordsByType', () => {
   it('should group records by type in preferred order', () => {
     const records = [

--- a/packages/parsing/src/dns/recordset.ts
+++ b/packages/parsing/src/dns/recordset.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DNSRecord, Observation } from '@dns-ops/db/schema';
+import { tryNormalizeDNSOwner } from './index.js';
 
 export interface NormalizedRecord {
   name: string;
@@ -38,7 +39,9 @@ function groupByNameType(observations: Observation[]): Map<string, Observation[]
   const groups = new Map<string, Observation[]>();
 
   for (const obs of observations) {
-    const key = `${obs.queryName.toLowerCase()}|${obs.queryType}`;
+    const owner = tryNormalizeDNSOwner(obs.queryName)?.normalized;
+    if (!owner) continue;
+    const key = `${owner}|${obs.queryType}`;
     if (!groups.has(key)) {
       groups.set(key, []);
     }
@@ -49,12 +52,20 @@ function groupByNameType(observations: Observation[]): Map<string, Observation[]
 }
 
 /**
- * Extract values from DNS records
+ * Extract values from DNS records. Keep malformed CNAME data unchanged so a
+ * later persisted-evidence authorization check can reject it rather than
+ * silently dropping the observation.
  */
-function extractValues(records: DNSRecord[]): string[] {
+function extractValues(records: DNSRecord[], ownerName: string, recordType: string): string[] {
   const values: string[] = [];
   for (const record of records) {
-    if (record.type === 'MX' && record.priority !== undefined) {
+    if (record.type !== recordType) continue;
+    const recordOwner = tryNormalizeDNSOwner(record.name)?.normalized;
+    if (recordOwner !== ownerName) continue;
+
+    if (record.type === 'CNAME') {
+      values.push(tryNormalizeDNSOwner(record.data)?.normalized ?? record.data);
+    } else if (record.type === 'MX' && record.priority !== undefined) {
       values.push(`${record.priority} ${record.data}`);
     } else {
       values.push(record.data);
@@ -101,7 +112,7 @@ export function observationsToRecordSets(observations: Observation[]): Normalize
       vantages.push(vantageId);
       observationIds.push(obs.id);
 
-      const values = extractValues(obs.answerSection || []);
+      const values = extractValues(obs.answerSection || [], name, type);
       allValues.push(...values);
       vantageValues.set(vantageId, values);
     }
@@ -143,7 +154,14 @@ export function observationsToRecordSets(observations: Observation[]): Normalize
 
     // Calculate average TTL
     const ttls = successfulObs
-      .flatMap((obs) => (obs.answerSection || []).map((r) => r.ttl))
+      .flatMap((obs) =>
+        (obs.answerSection || [])
+          .filter(
+            (record) =>
+              record.type === type && tryNormalizeDNSOwner(record.name)?.normalized === name
+          )
+          .map((r) => r.ttl)
+      )
       .filter((ttl): ttl is number => ttl !== undefined);
 
     const avgTtl = ttls.length > 0 ? Math.round(ttls.reduce((a, b) => a + b, 0) / ttls.length) : 0;

--- a/packages/parsing/src/index.ts
+++ b/packages/parsing/src/index.ts
@@ -11,10 +11,13 @@ export * from './dig/index.js';
 export {
   getWildcardBase,
   isWildcard,
+  MAX_DNS_CNAME_HOPS,
+  type NormalizedDNSOwner,
   normalizeDomain as normalizeDNSDomain,
   type ParsedAnswer,
   parseDNSAnswer,
   parseTXTRecord,
+  tryNormalizeDNSOwner,
 } from './dns/index.js';
 export * from './dns/recordset.js';
 

--- a/verification/receipts/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent--fleet.reports.md
+++ b/verification/receipts/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent--fleet.reports.md
@@ -1,0 +1,64 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-074832Z-4063b7c-pr70-fleet-fresh-independent
+feature_id: fleet.reports
+profile: critical
+surface: web
+sha: 4063b7c14c185be971f274032a3412797c0fe38c
+code_digest: 6eabeb229cbd6284fd634486bdd49d9595208ce4d27f81546751908d4a341433
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "fresh-independent-pr70-exact-staged-tree"
+evidence_dir: verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent
+created_at: 2026-09-01T08:05:19.868Z
+---
+
+# Receipt: fleet.reports — passed
+
+## Observations (expected → seen)
+
+- A fresh verifier drove the real local `/portfolio` Fleet Reports workflow against the staged PR #70 candidate using local web and collector services, a disposable six-domain PostgreSQL fixture, active probes disabled, and local e2e tenant headers. Doctor/readiness checks passed.
+- The submitted Mail Security Baseline report returned HTTP 200 with `backedByPersistedFindings: true`, six domains checked, zero domain errors, `summary.unknownChecks: 22`, and `summary.domainsWithIssues: 2`. SPF stats were pass=1, fail=1, unknown=4.
+- `stale.example`, `partial.example`, `uncorrelated.example`, and `never-evaluated.example` rendered UNKNOWN for all four checks and had no issues. `clean.example` rendered SPF PASS from a correlated persisted finding. `broken.example` rendered SPF FAIL from a correlated persisted finding.
+- CSV import returned 200; unauthenticated report access returned 401; malformed inventory returned 400; a foreign tenant could not read the fixture rows; duplicate report submissions returned deterministic equivalent results.
+
+## Forbidden (must not happen → confirmed absent)
+
+- No check reported PASS without complete, ruleset-backed, correlated persisted evidence. Unknown-only domains did not increment `domainsWithIssues`.
+- No provider, production, credential, active-probe, tracker-write, or external live-service path was used.
+- No CSS selectors, coordinate clicks, fixed sleeps, or test/debug endpoints were used by the real-surface drive.
+
+## Read-back (side effects checked through an independent path)
+
+- `http/fleet-report-run.json` records the live API request/response and status 200 with persisted-findings classification and unknown counts.
+- `http/fleet-report-adversarial.json` records CSV, authentication, malformed-input, tenant-isolation, and duplicate-request checks.
+- `readback/fleet-report-badges.json` records the rendered status/title/class read-back for all domains, and `readback/fleet-fixture-db.json` records the disposable fixture rows.
+- `fleet-report-collapsed.png`, `fleet-report-expanded.png`, and `trace.zip` capture the real UI workflow. The captured local-dev failures are limited to the known `/_build/assets/client.css` 404, blocked external font requests, and one aborted portfolio-search request; they did not affect the report result.
+- Focused collector security/fleet/route tests passed (11 files, 399 tests), and focused web Fleet Reports tests passed (2 files, 6 tests). `lint-map --fresh` passed.
+- UBS completed with findings concentrated in test fixtures and request-body size warnings: hardcoded test-secret literals at `apps/collector/src/jobs/monitoring.test.ts:36,60,75`, `Math.random` fixture IDs at `apps/collector/src/jobs/fleet-report.test.ts:503,795`, and unbounded body parsing warnings at `apps/collector/src/jobs/fleet-report.ts:40,197`. These are recorded as review residuals; no product files were changed during verification.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/console.log | log | aux · unrecognized .log | aa3a45dc162e4963ba8472baf098e07a5c067e9414cee5224abfd4b41e444e98 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/doctor.txt | txt | aux · unrecognized .txt | a912c2353c5e9b993b5c1254fd1c0e609ebd4c159750bebcb0a91801f3924a62 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/env.txt | env | aux | 6dd5c2736ac264515fb557d013d09a74e505b989fb7e5e43404c0447067b5834 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/failed-requests.log | log | aux · unrecognized .log | 9129561e47f5b0e13758910cc1e280895523978dcc0e65e0c05ac5497c9b1ebc |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/fleet-api-summary.json | json | aux · unrecognized .json | ea1ec627015d523dcd7e399da542532622f051607884970ffb86c14d8e4a127f |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/fleet-report-collapsed.png | png | evidence · 1280x4142 | 08181d74de434238f5a285e28cc9471c0a0a7b9b2d8132cbc6e9eac57703b460 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/fleet-report-expanded.png | png | evidence · 1280x4538 | 6005f5698a302e01a9de8f2204f62270d703e34a25a1ec7735abbc5de528d925 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/fleet-surface-summary.json | json | aux · unrecognized .json | 7ebbcdf5dd70cae4dd708b3deb90ec2c556e499e3670f93b5d2514d5f7f918ed |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/focused-collector-security-fleet-route.log | log | aux · unrecognized .log | c5e9cb37b2072b90e0f1501a7c06fa30ca1e8c9c6151d343363a0f5963ac7034 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/focused-web-fleet-route.log | log | aux · unrecognized .log | e954533e6eb397144b22084d53a8729953029233e8f4e2426dbf436539653201 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/http/fleet-report-run.json | http | evidence | c8d075deb5296d91cc2199b61509c12ff151565a5c5d59c6a9c9f30ed7c13f6d |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/lint-map-fresh.log | log | aux · unrecognized .log | 3046d1ffbfbb241819d2e1212cabb075382afdf1c1085091a7dd2055132d380d |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/readback/fleet-fixture-db.json | readback | evidence | 8d0c2ac7f97720ef540c8a1db7477a499304814bc0a7c959eccaf072c74d755d |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/readback/fleet-report-adversarial.json | readback | evidence | 169fb9680d0c2f8a0c31b4f56fb431c519bf679f2c86debecba20aa7c6c5e1d7 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/readback/fleet-report-badges.json | readback | evidence | 3b84d67f9b3405b2218e3c27c364ca345980861bbe789d279fa0614d9576012c |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/trace.zip | trace | evidence · playwright trace | 9b97f690f5110f809259a1bc83aedc6952d35e70af9601468b518aaba6f59a64 |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/ubs-diff.log | log | aux · unrecognized .log | 763c13d42abeaf26ca881a5ae40404dc2c0f74c3520625a9f05360ac7727f1eb |
+| verification/runs/20260901-074832Z-4063b7c-pr70-fleet-fresh-independent/ubs-staged.log | log | aux · unrecognized .log | 519db428871f20afffd35bfbe485d47f90e4e78956a70273ec6df9299c8b2eb4 |

--- a/verification/receipts/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked--domain.overview.md
+++ b/verification/receipts/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked--domain.overview.md
@@ -1,0 +1,49 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 4063b7c14c185be971f274032a3412797c0fe38c
+code_digest: 6eabeb229cbd6284fd634486bdd49d9595208ce4d27f81546751908d4a341433
+dirty: true
+untracked: 0
+status: blocked
+reason: "Changed-profile Domain 360 proof is blocked: the disposable local fixture has no google.com domain row and zero successful identifier-bearing public-recursive observations, so the required persisted recursive TTL evidence is unavailable; no passed receipt is claimable."
+verifier: fresh
+verifier_session: "fresh-independent-pr70-domain-overview-preflight"
+evidence_dir: verification/runs/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked
+created_at: 2026-09-01T08:05:30.837Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+
+- The fresh verifier reached the real Domain 360 route for `google.com` through the local authenticated/e2e-header path and captured the Domain 360 shell, tabs, and heading.
+- The changed-profile proof requires persisted recursive DNS evidence for the documented domain. The disposable fixture contained six fleet domains, no `google.com` domain row, and zero successful identifier-bearing `public-recursive` observations.
+- The DNS Parsed view therefore could not produce the required persisted-evidence TTL rows; the harness stopped when `Remaining TTL` was unavailable. This receipt is honestly blocked, not a pass.
+
+## Forbidden (must not happen → confirmed absent)
+
+- No provider, production, credential, active-probe, tracker-write, or external live-service path was used.
+- No passed Domain Overview receipt was claimed from mocked or absent recursive TTL evidence.
+- No product or test files were edited to bypass the missing fixture precondition.
+
+## Read-back (side effects checked through an independent path)
+
+- `readback/domain-preflight.json` records direct read-back of the disposable database: `matchingDomainRows: 0`, `successfulPublicRecursiveObservations: 0`, and six fixture rows under the public-recursive vantage.
+- `domain-harness.log`, `domain-overview.png`, and `trace.zip` capture the route and the precise TTL-column timeout. The local CSS 404, blocked external fonts, and missing fixture-backed API rows are retained as evidence.
+- Safe focused tests and static checks were run separately; they do not establish the required persisted recursive fixture evidence for this changed-profile surface.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked/console.log | log | aux · unrecognized .log | d584b608feccd44bc73684635535994b5a48dcbdefa6f21dcc5bb3271b538471 |
+| verification/runs/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked/domain-harness.log | log | aux · unrecognized .log | f0deacbdffd285aae4765fd65eee06caf13086217c34fa3348fb780cdb5c331c |
+| verification/runs/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked/domain-overview.png | png | evidence · 1280x720 | 10374606b0f7c63e9cbb64695cedd291c6a01748719452621695e9d04720bb78 |
+| verification/runs/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked/env.txt | env | aux | 84f4778fef670cb22961c5bc3c918ef32897ab74c81b14d7fefc6ca19e1d74f1 |
+| verification/runs/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked/failed-requests.log | log | aux · unrecognized .log | 47ec4c7df6d68ed51977bccb7b1958bd4e5ee9bccee4f09ac7f2168d79860437 |
+| verification/runs/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked/readback/domain-preflight.json | readback | evidence | cfd5dbe7961be4158c254546960630e722cd2d59d5ece475e2a57b9e76d79633 |
+| verification/runs/20260901-075724Z-4063b7c-pr70-domain-overview-fresh-blocked/trace.zip | trace | evidence · playwright trace | 3a30ca4d64896c82b56641b27846595039ee88278fb24bd6d6c58e8bc1c42a7b |

--- a/verification/receipts/20260901-090738Z-8137441-pr70-fresh-exact-staged--fleet.reports.md
+++ b/verification/receipts/20260901-090738Z-8137441-pr70-fresh-exact-staged--fleet.reports.md
@@ -1,0 +1,64 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-090738Z-8137441-pr70-fresh-exact-staged
+feature_id: fleet.reports
+profile: critical
+surface: web
+sha: 8137441799fd5fc9492a774fb4f8293c28038f74
+code_digest: 28f35e8afaf4110f8ff52143a2c8a68a6ca3da62001796a180c6ef5c7abfa003
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "fresh-independent-pr70-exact-staged-tree-fleet"
+evidence_dir: verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged
+created_at: 2026-09-01T09:15:14.142Z
+---
+
+# Receipt: fleet.reports — passed
+
+## Observations (expected → seen)
+
+- A fresh verifier drove the real local `/portfolio` Fleet Reports workflow against the staged PR #70 candidate using local web and collector services, an isolated disposable PostgreSQL container (`dns-ops-pr70-fresh`), a synthetic six-domain fixture, `ENABLE_ACTIVE_PROBES=false`, and local e2e tenant headers. No provider, production, or live DNS system was used. Doctor/readiness passed.
+- The submitted Mail Security Baseline report returned HTTP 200 with `backedByPersistedFindings: true`, six domains checked, zero domain errors, `summary.unknownChecks: 22`, and `summary.domainsWithIssues: 2`. SPF stats were pass=1, fail=1, unknown=4.
+- `stale.example`, `partial.example`, `uncorrelated.example`, and `never-evaluated.example` rendered UNKNOWN for all four checks and had no issues. `clean.example` rendered SPF PASS from a correlated persisted info finding. `broken.example` rendered SPF FAIL from a correlated persisted high finding.
+- CSV import returned 200; unauthenticated report access returned 401; malformed inventory returned 400; a foreign tenant could not read fixture rows; duplicate report submissions returned normalized-equivalent results.
+
+## Forbidden (must not happen → confirmed absent)
+
+- No check reported PASS without complete, ruleset-backed, correlated persisted findings evidence. Unknown-only domains did not increment `domainsWithIssues`.
+- No provider, production, credential, active-probe, tracker-write, or external live-service path was used. Browser requests were restricted to the local web service.
+- No CSS selectors, coordinate clicks, fixed sleeps, or test/debug endpoints were used by the Fleet Reports drive.
+
+## Read-back (side effects checked through an independent path)
+
+- `http/fleet-report-run.json` records the live local API request/response and status 200 with persisted-findings classification and unknown counts.
+- `readback/fleet-report-adversarial.json` records CSV, authentication, malformed-input, tenant-isolation, and duplicate-request checks.
+- `readback/fleet-report-badges.json` records rendered status/title/class read-back for all 24 check badges. `readback/fleet-fixture-db.json` independently records six domains, six snapshots, three findings, and one synthetic resolver-identified public-recursive observation per fixture domain.
+- `fleet-report-collapsed.png`, `fleet-report-expanded.png`, and `trace.zip` capture the real UI workflow. The only captured browser failures were the known dev `/_build/assets/client.css` 404 and blocked external font requests; they did not affect the report result.
+- Focused collector security/fleet/route tests passed (11 files, 399 tests); focused web Fleet Reports tests passed (2 files, 6 tests); collector typecheck passed; `lint-map --fresh`, `ubs --diff .`, and `ubs --staged` completed with exit 0.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/collector-typecheck.log | log | aux · unrecognized .log | a4138f5e5ee88130541d25638a6117c3244ee7cb8a2c7d83d79510f42c5e818f |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/console.log | log | aux · unrecognized .log | aa3a45dc162e4963ba8472baf098e07a5c067e9414cee5224abfd4b41e444e98 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/doctor.txt | txt | aux · unrecognized .txt | a912c2353c5e9b993b5c1254fd1c0e609ebd4c159750bebcb0a91801f3924a62 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/env.txt | env | aux | 63ff57fcbec60fb1733de7180736702ccc241c6a8241de3f1d7c4f9169d78825 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/failed-requests.log | log | aux · unrecognized .log | 9129561e47f5b0e13758910cc1e280895523978dcc0e65e0c05ac5497c9b1ebc |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/fleet-api-summary.json | json | aux · unrecognized .json | ea1ec627015d523dcd7e399da542532622f051607884970ffb86c14d8e4a127f |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/fleet-report-collapsed.png | png | evidence · 1280x4142 | 0883e21d74a5740c49480b0393397198d07bc8c9b9a378683b9db3f2ebb156a5 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/fleet-report-expanded.png | png | evidence · 1280x4538 | 7ce1beb62bf6168525533d4f94986df3b1637d0ccc4c15b90f1c38cad179fdc8 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/fleet-surface-summary.json | json | aux · unrecognized .json | 7ebbcdf5dd70cae4dd708b3deb90ec2c556e499e3670f93b5d2514d5f7f918ed |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/focused-collector-security-fleet-route.log | log | aux · unrecognized .log | 089d60c8e356b8342c3ccf3a94661a345d1f95b6699116cfc1665dc558c14a2d |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/focused-web-fleet-route.log | log | aux · unrecognized .log | dbb6e431aa485a371dbc2f091838e22556ed2cc7f74a2e96aaca730814d70eb1 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/http/fleet-report-run.json | http | evidence | 1cb695d77a53a7a3c5c040def3ac495c7d79a7c33fd4473cea5cc7c4f3558f3d |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/lint-map-fresh.log | log | aux · unrecognized .log | cdb5cf5a44b08b50dd2223c80a3f8a976e791aef827ac857f9c96a3edbf01d32 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/readback/fleet-fixture-db.json | readback | evidence | 5c4db3d26933e2beff67a2f705d4040f488da44c9b56df01ecbbbd04c8a5db77 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/readback/fleet-report-adversarial.json | readback | evidence | d5b3e203c452bd3be83aa2d50ad910c6b1dac73b46a245f390b64ea57406cb12 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/readback/fleet-report-badges.json | readback | evidence | cd2f8d4f5a1eb1ab131091a5872bfaac16ce3e311361c041d89cd7a6902c25d4 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/trace.zip | trace | evidence · playwright trace | afc6a4f3ce65d25f2ca892e1bf1d9733206ac30ed4eb76946b4debd815942e5d |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/ubs-diff.log | log | aux · unrecognized .log | 04fa2a3b98f82ada7c7292dfb785b404f16157672cc74aad71ae418ec92001a6 |
+| verification/runs/20260901-090738Z-8137441-pr70-fresh-exact-staged/ubs-staged.log | log | aux · unrecognized .log | b24073aff0b577278921f9d9a5eb398e89b8d0c2185b31d39d937c40e94d382a |

--- a/verification/receipts/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun--domain.overview.md
+++ b/verification/receipts/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun--domain.overview.md
@@ -1,0 +1,54 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 8137441799fd5fc9492a774fb4f8293c28038f74
+code_digest: 28f35e8afaf4110f8ff52143a2c8a68a6ca3da62001796a180c6ef5c7abfa003
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "fresh-independent-pr70-exact-staged-tree-domain"
+evidence_dir: verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun
+created_at: 2026-09-01T09:15:14.247Z
+---
+
+# Receipt: domain.overview — passed
+
+## Observations (expected → seen)
+
+- A fresh verifier drove the real local home-page Analyze workflow to `/domain/google.com` with local e2e tenant headers, then opened the DNS tab. The isolated disposable PostgreSQL fixture supplied a synthetic `google.com` snapshot and one synthetic A answer (`192.0.2.1`) from reserved local-test resolver identity `192.0.2.53`; no provider, production, live DNS, or active probe was used.
+- The Domain 360 heading contained `google.com`; Overview, DNS, Mail, History, and the currently enabled Delegation tabs were visible.
+- The Parsed DNS table rendered one persisted `google.com` A row with non-empty Remaining TTL and Estimated live at cells. The live countdown and machine-readable `<time datetime>` matched the persisted recursive answer's `queriedAt + TTL` deadline.
+
+## Forbidden (must not happen → confirmed absent)
+
+- No blank TTL cells, averaged-TTL estimate, all-UNKNOWN output, CSS selector, coordinate click, fixed wait for an end state, provider call, or live DNS query was used.
+- Browser navigation was restricted to the local web service; blocked external font requests were not used as evidence.
+
+## Read-back (side effects checked through an independent path)
+
+- `readback/dns-observations.json` records the API observation read-back, including the successful resolver-identified public-recursive observation and synthetic answer.
+- `readback/dns-ttl-audit.json` independently compares persisted record evidence with every rendered row's deadline and countdown; `readback/dns-ttl-cells.json` records both rendered timing cells.
+- `domain-overview.png`, `domain-dns-parsed-ttl.png`, and `trace.zip` capture the real UI route and Parsed view. `doctor.txt` records healthy local web and collector readiness. Captured dev-only failures were limited to `/_build/assets/client.css` 404 and blocked external fonts.
+- The hydration-waited fresh Playwright drive used the feature's ARIA role/label selectors and retained evidence in this run directory.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/console.log | log | aux · unrecognized .log | efaac86334d1d36e050ab4cec089a6f8f2a7a96e93713db5600503ac9c00de6a |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/doctor.txt | txt | aux · unrecognized .txt | a912c2353c5e9b993b5c1254fd1c0e609ebd4c159750bebcb0a91801f3924a62 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/domain-dns-parsed-ttl.png | png | evidence · 1280x755 | 67bca738c91202261a81b4456fd67f06a6e677bf8da7ae9e845078dc522253e5 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/domain-harness.log | log | aux · unrecognized .log | 8a5d327321ad897cf1dafa56f1e1352733c10f8fab88a8136eb871d235c7e5e1 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/domain-overview.png | png | evidence · 1280x1852 | 323da4fbce44eb7a54f0c56caf0ff56cfba2978965d86fa74e6ca0e34105000d |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/domain-surface-summary.json | json | aux · unrecognized .json | d55afc5c3a0bc6a0582abcc2c9009463dd74812f4e6fdd7592f664230ab646e4 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/env.txt | env | aux | 97acae58b95b0b565ffb3cba3c4ac764d35f2b01da66cec12200c8c60c9e4f58 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/failed-requests.log | log | aux · unrecognized .log | 320dd31e56201312413a3a33a81f9e3a352356dcd75a6a02961a2976a68053e5 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/readback/dns-observations.json | readback | evidence | b341957bec64e950dbeb1ce8a33f7a1db4a22b8206cb81d311d1cdb43a091fa1 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/readback/dns-ttl-audit.json | readback | evidence | a03055fb17ba55133cc7d46e73d00b3cce9f00aa635085b0e36d475dc3b1a849 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/readback/dns-ttl-cells.json | readback | evidence | 60e48b6ba3f0d9564f8f624eba20a766ce1233833219549542eb690ef085fee3 |
+| verification/runs/20260901-091236Z-8137441-pr70-domain-exact-staged-custom-rerun/trace.zip | trace | evidence · playwright trace | 40432776ffdc9ac7dc278c0cc14ee176d97138d8fea3f09ad4112e7970b5d025 |

--- a/verification/receipts/20260901-093035Z-f8254dc-final-domain--domain.overview.md
+++ b/verification/receipts/20260901-093035Z-f8254dc-final-domain--domain.overview.md
@@ -1,0 +1,57 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-093035Z-f8254dc-final-domain
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: f8254dc9143c8e12dfa7b2bc8e38f9bf7109715e
+code_digest: ba8b0a0068efbcc82e351a6db480d965fd98f511c5aec310c888b56f74879a6f
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "fresh-independent-final-f8254dc-domain"
+evidence_dir: verification/runs/20260901-093035Z-f8254dc-final-domain
+created_at: 2026-09-01T09:39:39.273Z
+---
+
+# Receipt: domain.overview — passed
+
+## Observations (expected → seen)
+
+- Independent fresh verification used exact product SHA `f8254dc9143c8e12dfa7b2bc8e38f9bf7109715e` from a clean isolated worktree. Local web and collector services ran from that checkout on ports 3320/3321, with a dedicated disposable PostgreSQL 15 fixture on port 55468, `ENABLE_ACTIVE_PROBES=false`, and local development tenant headers.
+- Doctor/readiness passed. The real home-page Analyze flow reached `http://127.0.0.1:3320/domain/google.com?addToPortfolio=false&tab=dns`; the Domain 360 heading contained `google.com`, and Overview, DNS, Mail, History, and enabled Delegation tabs were visible.
+- The persisted `google.com` snapshot was `20000000-0000-4000-8000-000000000007`, carried `dnsQueryTimestampBasis: response-received-v1`, and had one successful public-recursive observation with identifier `192.0.2.53`. The Parsed DNS view rendered exactly one matching `google.com` A row.
+- The rendered row populated both timing cells: Remaining TTL was a non-empty seconds value and Estimated live at was a non-empty machine-readable time. The independent TTL audit matched the rendered deadline to the persisted observation's `queriedAt + TTL` and matched the countdown within the harness tolerance.
+
+## Forbidden (must not happen → confirmed absent)
+
+- No blank TTL cells, averaged-TTL estimate, all-UNKNOWN output, invalid live value, CSS selector, coordinate click, fixed sleep, provider call, live DNS query, or active probe was used.
+- Browser routing allowed only the local web service; blocked external font requests were not used as evidence.
+
+## Read-back (side effects checked through an independent path)
+
+- `readback/dns-observations.json` records the API observation read-back, including the successful resolver-identified public-recursive observation and synthetic A answer `192.0.2.1` with TTL 120.
+- `readback/dns-ttl-audit.json` independently compares persisted record evidence with the rendered row's deadline and countdown; `readback/dns-ttl-cells.json` records both rendered timing cells.
+- `domain-overview.png`, `domain-dns-parsed-ttl.png`, and `trace.zip` capture the real route and Parsed view. The only captured local-dev failures were the known `/_build/assets/client.css` 404 and blocked external font requests.
+- Focused DNS collector tests passed: 5 files, 33 tests, with 6 opt-in live tests skipped because live DNS was disabled. No provider or production system was contacted.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-093035Z-f8254dc-final-domain/console.log | log | aux · unrecognized .log | bbac977684da3594c31d0cc785262f6a26d0d3c15b9fc69e37e10098aba4c8ec |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/doctor.txt | txt | aux · unrecognized .txt | a912c2353c5e9b993b5c1254fd1c0e609ebd4c159750bebcb0a91801f3924a62 |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/domain-dns-parsed-ttl.png | png | evidence · 1280x755 | 2665e9a32fb5607b2303df554ce0e6db656ced41738f4eabaa458bcb60be2a93 |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/domain-harness.log | log | aux · unrecognized .log | 79ce504408eca6230e66740d361d7ff34b9d03174a42bdf646b84d71ee93f143 |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/domain-overview.png | png | evidence · 1280x1852 | a97e13c5aeed85ded1d08c7b7dcd85617bd3051b9c9a07bebc8df7f33dfd6ede |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/domain-surface-summary.json | json | aux · unrecognized .json | 3b6fba6c4037a4abea307fc0787bf35eb8334d0a75197c371402764aaecc9d4f |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/env.txt | env | aux | a2a4bfd7bea9cb84e9ac4f9689db9f14ef3076dcc763802a727d33f3d6df975b |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/failed-requests.log | log | aux · unrecognized .log | 0a6320a840bb683a57aac74725e6c979771d3a59b56179ac4d17a625b7b977a9 |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/focused-dns-collector.log | log | aux · unrecognized .log | 2009f87ef19acbd43784d5966549c90da3675272d8619419f4fa028d06467a8e |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/observations.md | md | aux · unrecognized .md | 6928acc4a357d7c5f06cc966c74ddf009a822c823358e1f0414756bc352bca51 |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/readback/dns-observations.json | readback | evidence | b341957bec64e950dbeb1ce8a33f7a1db4a22b8206cb81d311d1cdb43a091fa1 |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/readback/dns-ttl-audit.json | readback | evidence | 732ab3c59cb9b4a254f46e047ff28f46ff1a8df2d35ccb20d1a6ca08080d0de3 |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/readback/dns-ttl-cells.json | readback | evidence | c044ab8e5480dc206d6d4d296de0b421834cf7c377db4b8665e39e4097b63308 |
+| verification/runs/20260901-093035Z-f8254dc-final-domain/trace.zip | trace | evidence · playwright trace | 26dd743125e555d3f40f39d847a83252d1620647302d2cee769231066ee67ee2 |

--- a/verification/receipts/20260901-093035Z-f8254dc-final-fleet--fleet.reports.md
+++ b/verification/receipts/20260901-093035Z-f8254dc-final-fleet--fleet.reports.md
@@ -1,0 +1,67 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-093035Z-f8254dc-final-fleet
+feature_id: fleet.reports
+profile: critical
+surface: web
+sha: f8254dc9143c8e12dfa7b2bc8e38f9bf7109715e
+code_digest: ba8b0a0068efbcc82e351a6db480d965fd98f511c5aec310c888b56f74879a6f
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "fresh-independent-final-f8254dc-fleet"
+evidence_dir: verification/runs/20260901-093035Z-f8254dc-final-fleet
+created_at: 2026-09-01T09:39:16.892Z
+---
+
+# Receipt: fleet.reports — passed
+
+## Observations (expected → seen)
+
+- Independent fresh verification used exact product SHA `f8254dc9143c8e12dfa7b2bc8e38f9bf7109715e` from a clean isolated worktree. Local web and collector services ran from that checkout on ports 3320/3321, with a dedicated disposable PostgreSQL 15 fixture on port 55468, `ENABLE_ACTIVE_PROBES=false`, and local development tenant headers.
+- Doctor/readiness passed. The real `/portfolio` Fleet Reports flow displayed Fleet Reports, selected Mail Security Baseline, accepted six inventory domains, submitted Run Report, and rendered the report details.
+- The local API response was HTTP 200 with `backedByPersistedFindings: true`, six domains checked, zero domain errors, `summary.unknownChecks: 22`, `summary.domainsWithIssues: 2`, and SPF stats pass=1, fail=1, unknown=4.
+- `stale.example`, `partial.example`, `uncorrelated.example`, and `never-evaluated.example` were UNKNOWN for all four requested checks with no issues. `clean.example` had a correlated info finding and SPF PASS. `broken.example` had a correlated high finding and SPF FAIL. The UI read-back captured 24 badges: four UNKNOWN-only domain cards, one PASS SPF badge, and one FAIL SPF badge.
+
+## Forbidden (must not happen → confirmed absent)
+
+- No check reported PASS without complete, ruleset-backed, correlated persisted evidence. UNKNOWN-only checks did not increment `domainsWithIssues`.
+- No provider, production, credential, active-probe, tracker-write, or external live-service path was used. Browser routing allowed only the local web service; external font requests were aborted.
+- No CSS selector or coordinate click was used for actions, and no fixed sleep was used for an end state.
+
+## Read-back (side effects checked through an independent path)
+
+- `http/fleet-report-run.json` records the real local API request/response and report summary.
+- `http/fleet-report-adversarial.json` records CSV import HTTP 200, unauthenticated run HTTP 401, malformed inventory HTTP 400, foreign-tenant isolation (HTTP 200 with zero results and one error), and duplicate submissions HTTP 200/200 with normalized-equivalent results.
+- `readback/fleet-report-badges.json` records status titles and styling for every rendered badge. `readback/fleet-fixture-db.json` independently records six fixture domains, six snapshots, three findings, and one successful resolver-identified public-recursive observation per domain.
+- `fleet-report-collapsed.png`, `fleet-report-expanded.png`, and `trace.zip` capture the real UI workflow. The only captured local-dev failures were the known `/_build/assets/client.css` 404 and blocked external font requests; neither affected report behavior.
+- Focused collector security/webhook/fleet tests passed: 11 files, 399 tests. Focused web Fleet Reports tests passed: 2 files, 6 tests. DNS collector tests passed: 5 files, 33 tests, with 6 opt-in live tests skipped because live DNS was disabled.
+- Contracts build and collector typecheck passed. `lint-map --fresh`, selector lint, `ubs --diff .`, and `ubs --staged` passed; UBS correctly reported no changed files in the clean product tree.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/collector-typecheck.log | log | aux · unrecognized .log | 5618ab8479c8adda76a6b3a4362b45f35343dfd8ebedea8d45f9059aac57d6c0 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/console.log | log | aux · unrecognized .log | aa3a45dc162e4963ba8472baf098e07a5c067e9414cee5224abfd4b41e444e98 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/contracts-build.log | log | aux · unrecognized .log | 5cb2a0c734ac4447ba5f0dc8d5eccfaaef21c67e3697feb2c5de9d1708c66bfd |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/doctor.txt | txt | aux · unrecognized .txt | a912c2353c5e9b993b5c1254fd1c0e609ebd4c159750bebcb0a91801f3924a62 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/env.txt | env | aux | 69e19c39b615e189e4f66b9adbd8601d2025338f2fbafaceeb8168e1faff7b71 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/failed-requests.log | log | aux · unrecognized .log | ede3947e7b6d3bf4e71f038c675c85a43d48cd5932a58648dc006d4cca4a5190 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/fleet-report-collapsed.png | png | evidence · 1280x4142 | 32ca7a3b007f3129d67d24c316bef1a83965b6dcd424ba644196e527c62dfb04 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/fleet-report-expanded.png | png | evidence · 1280x4538 | 39f0b11493d21409106261a97af1705ae555c49991553f776bdd3a3b70a0156a |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/fleet-surface-summary.json | json | aux · unrecognized .json | 9d22f16d5e9853246fde07d0853cd4fb898c883535163578b116fee8cea82e9f |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/focused-collector-security-fleet-route.log | log | aux · unrecognized .log | f074f63c4f1b19f09b04e792285f0c801fb8eb61e7dcb37fb07d5a3e3f72f972 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/focused-web-fleet-route.log | log | aux · unrecognized .log | 4705dc4c513c38d100bedb922eb574810dae49ca81a1a0d2ccc03171bc78bc45 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/http/fleet-report-run.json | http | evidence | 93ff0c570ea87fb113950b6d43a2683b9875dc6a8f35d32f8db6c0ae576d018c |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/lint-map-fresh.log | log | aux · unrecognized .log | ae3dc7cdc3c9c317427c9da75ac7fcac5d3febdfcb401004fafd13e05981eb53 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/lint-selectors.log | log | aux · unrecognized .log | 46be362b670640d992d85f81f04572005863157997b44896f74020646362e5dc |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/observations.md | md | aux · unrecognized .md | ad0c969bfd7dfd6b87066ee40cc53f67a3c5bf4834b132a6715ab3ef333e983c |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/readback/fleet-fixture-db.json | readback | evidence | 5c4db3d26933e2beff67a2f705d4040f488da44c9b56df01ecbbbd04c8a5db77 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/readback/fleet-report-adversarial.json | readback | evidence | 477ae195b0879942dc8cba403d7e170a6a4b115a7c61aac41667d3eb9a093802 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/readback/fleet-report-badges.json | readback | evidence | 723a0e394e2364b279f9128cb436545640474635755683f536e71b6fbc1a481e |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/trace.zip | trace | evidence · playwright trace | 68924c575489c22b65394279067ab2ea9e6d7bc1e64c1389144d0a9db3bb232e |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/ubs-diff.log | log | aux · unrecognized .log | 4198859668c08229143701811f5380b5ffadeaabdedc7e5354104d06289f4074 |
+| verification/runs/20260901-093035Z-f8254dc-final-fleet/ubs-staged.log | log | aux · unrecognized .log | 4198859668c08229143701811f5380b5ffadeaabdedc7e5354104d06289f4074 |


### PR DESCRIPTION
## Summary
- reject caller-supplied DNS evidence for probe authorization
- derive targets from fresh, persisted, tenant-owned observations
- pin checked SMTP IPs, canonicalize allowlists, and preserve SSRF guards
- document the remaining MTA-STS fetch residual

## Validation
- focused authorization, allowlist, SMTP, and SSRF tests
- collector lint/typecheck
- independent current-HEAD security review: no actionable findings

Resolves #67

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #67: probe routes previously trusted caller-supplied DNS records for authorization; they now derive targets only from fresh, persisted, tenant-owned collector evidence and reject caller-supplied DNS fields with 403. Outbound probe and webhook connections are pinned to SSRF-checked IPs, closing the DNS rebinding gap for active probes.

**Bug Fixes**
- SMTP and MTA-STS probes resolve and SSRF-check the target IP up front, pin the connection to that checked IP, and fail closed on DNS errors.
- Webhook and MTA-STS policy delivery use pinned native HTTPS against the checked IP with delivery deadlines and response size caps instead of `fetch()`.
- The SSRF guard blocks all IPv6 targets and the complete IANA IPv4 special-purpose registry.
- Allowlist entries, record sets, and tenant lookups are canonicalized; stale evidence, untrusted vantage provenance, and cross-tenant domains fail closed.

**Migration**
- Callers must stop sending `txtRecords`, `mxRecords`, or `dnsResults`; send only `domain`, and optionally a `hostname` that exactly matches a persisted MX target, with port fixed to 25.

<sup>Written for commit 4b7573121c1f5c97f4e3dabfb24149f69e4a7d44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

