### PR TITLE
qa(verify): attest merged Wave 1 master

### DIFF
--- a/verification/receipts/20260901-103611Z-aad22b9-wave1-qa-auth-api-principal--auth.api-principal.md
+++ b/verification/receipts/20260901-103611Z-aad22b9-wave1-qa-auth-api-principal--auth.api-principal.md
@@ -1,0 +1,42 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-103611Z-aad22b9-wave1-qa-auth-api-principal
+feature_id: auth.api-principal
+profile: critical
+surface: api
+sha: aad22b9ce0acb4a5cbbe8b95e06651466a73f8ed
+code_digest: ba8b0a0068efbcc82e351a6db480d965fd98f511c5aec310c888b56f74879a6f
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "fresh-local-loopback-web-collector-disposable-postgres"
+evidence_dir: verification/runs/20260901-103611Z-aad22b9-wave1-qa-auth-api-principal
+created_at: 2026-09-01T10:38:48.982Z
+---
+
+# Receipt: auth.api-principal — passed
+
+## Observations (expected → seen)
+
+- A clean isolated worktree at exact product SHA `aad22b9ce0acb4a5cbbe8b95e06651466a73f8ed` recorded `dirty: false` and `untracked: 0` before driving. The web and collector ran on loopback only against one disposable local PostgreSQL database.
+- A valid bare opaque API principal authenticated web `GET /api/auth/me` with HTTP 200 and the configured stored tenant/actor identity. The same valid principal plus forged `X-Tenant-Id` and `X-Actor-Id` headers returned the same stored identity.
+- The valid bare opaque principal authenticated collector `GET /api/probe/health` with HTTP 200. The same forged identity headers still returned the authenticated probe-health response. Unknown principal tokens returned HTTP 401 on both services.
+
+## Forbidden (must not happen → confirmed absent)
+
+- Request-supplied tenant/actor headers did not override the matched stored principal identity.
+- Unknown API principals were not accepted. No provider, production, live-DNS, OAuth, or real credential access occurred; `ENABLE_ACTIVE_PROBES=false`.
+- Raw credentials were not printed in the captured transcript or receipt notes; only redacted/sanitized observations are recorded.
+
+## Read-back (side effects checked through an independent path)
+
+- The web `/api/auth/me` response independently read back authenticated status, canonical tenant, and stored actor-derived email for both the normal and forged-header requests. Collector probe-health status independently read back successful authentication, and unauthenticated responses independently read back HTTP 401.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-103611Z-aad22b9-wave1-qa-auth-api-principal/cli-auth-principal.txt | transcript | evidence | b26832e42902e34f6686cbbfa80e3b274b496681d7d33d5d46941b3c71c023de |
+| verification/runs/20260901-103611Z-aad22b9-wave1-qa-auth-api-principal/env.txt | env | aux | fb85e94dc96419d319e2b53e4318d6fe08fd0fa5ba6edb516880bfa38a857fbe |

--- a/verification/receipts/20260901-103612Z-aad22b9-wave1-qa-auth-login--auth.login.md
+++ b/verification/receipts/20260901-103612Z-aad22b9-wave1-qa-auth-login--auth.login.md
@@ -1,0 +1,46 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-103612Z-aad22b9-wave1-qa-auth-login
+feature_id: auth.login
+profile: critical
+surface: web
+sha: aad22b9ce0acb4a5cbbe8b95e06651466a73f8ed
+code_digest: ba8b0a0068efbcc82e351a6db480d965fd98f511c5aec310c888b56f74879a6f
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "fresh-local-loopback-web-disposable-postgres"
+evidence_dir: verification/runs/20260901-103612Z-aad22b9-wave1-qa-auth-login
+created_at: 2026-09-01T10:38:58.484Z
+---
+
+# Receipt: auth.login — passed
+
+## Observations (expected → seen)
+
+- A clean isolated worktree at exact product SHA `aad22b9ce0acb4a5cbbe8b95e06651466a73f8ed` recorded `dirty: false` and `untracked: 0` before driving. The production web artifact was served locally on loopback against a disposable local PostgreSQL database; no development-auth headers were supplied.
+- The real `/login` form was opened. Accessible labels `Email address` and `Password` were filled, the role-labeled `Sign in` button was clicked, and the browser landed at `/` with the `DNS Ops Workbench` heading.
+
+## Forbidden (must not happen → confirmed absent)
+
+- No production service, provider, OAuth flow, or real credential was contacted. The login credential was throwaway and is not present in this receipt or captured text evidence.
+- No raw password or session cookie was printed. The pre-login unauthenticated `/api/auth/me` check was the expected 401 while the form was open; it did not prevent login.
+- Signup remains disabled and invalid-login rejection is covered by the exact-tree auth e2e tests run in this verification session.
+
+## Read-back (side effects checked through an independent path)
+
+- After the successful form submission, an independent browser-context `GET /api/auth/me` returned HTTP 200 with `authenticated: true`, the throwaway verifier email, and the expected tenant. The signed-in screenshot and Playwright trace retain the resulting home state.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-auth-login/console.log | log | aux · unrecognized .log | 74f442c997f3ca0140869dff653f33eb591de0f0a0c24067d9a7c329b8ee5172 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-auth-login/env.txt | env | aux | 211fc9790d6797409daca2e24566c66a6353a11d44bf93a5ece340070ff0b041 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-auth-login/failed-requests.log | log | aux · unrecognized .log | 79533e8cad58811984ffd3cc00ffcfeac862b5f47860641728a8661b98e7f5c2 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-auth-login/readback/me.json | readback | evidence | 809555ef03f647f109d9e876872a2e33c7ba89f419dde5478ed45f6bee02410e |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-auth-login/signed-in-home.png | png | evidence · 1280x1207 | c26dcb21dd428283d1c59ddf1d294f5dbfa4036bad04dde5486efc979056ce6c |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-auth-login/trace.zip | trace | evidence · playwright trace | 07d4f33ce9fb7ca59986b851c3639dc420452d15053e955709a307bc533ec170 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-auth-login/video/7c7496ed38926fcafdb76178350b4222.webm | video | evidence | 5cf89d026e189ab33eca944700a4bc9b4bbb5654bf09661793faf3e02993f1e4 |

--- a/verification/receipts/20260901-103612Z-aad22b9-wave1-qa-health-public--health.public.md
+++ b/verification/receipts/20260901-103612Z-aad22b9-wave1-qa-health-public--health.public.md
@@ -1,0 +1,45 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260901-103612Z-aad22b9-wave1-qa-health-public
+feature_id: health.public
+profile: changed
+surface: api
+sha: aad22b9ce0acb4a5cbbe8b95e06651466a73f8ed
+code_digest: ba8b0a0068efbcc82e351a6db480d965fd98f511c5aec310c888b56f74879a6f
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "fresh-local-loopback-web-collector-disposable-postgres"
+evidence_dir: verification/runs/20260901-103612Z-aad22b9-wave1-qa-health-public
+created_at: 2026-09-01T10:39:07.585Z
+---
+
+# Receipt: health.public — passed
+
+## Observations (expected → seen)
+
+- A clean isolated worktree at exact product SHA `aad22b9ce0acb4a5cbbe8b95e06651466a73f8ed` recorded `dirty: false` and `untracked: 0` before driving. Web and collector ran on loopback only against a disposable local PostgreSQL database with `ENABLE_ACTIVE_PROBES=false`.
+- Unauthenticated web `GET /api/health` returned HTTP 200 JSON with `status: healthy`, `service: dns-ops-web`, and the exact product revision. Collector `/healthz` returned HTTP 200 with `status: ok` and the exact revision; `/readyz` returned HTTP 200 with `status: ready` and a database check of `ok`.
+
+## Forbidden (must not happen → confirmed absent)
+
+- Public responses contained no database connection details, secrets, provider output, or live-DNS activity. `/healthz` was treated as liveness only; `/readyz` was checked separately for dependency readiness.
+- Both services were local-only; no production service, provider, OAuth, or real credential was contacted.
+
+## Read-back (side effects checked through an independent path)
+
+- A second unauthenticated web health request independently returned the same healthy status class. The captured collector health and readiness requests independently read back liveness, revision, and database readiness from the running collector.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-health-public/doctor.txt | txt | aux · unrecognized .txt | a912c2353c5e9b993b5c1254fd1c0e609ebd4c159750bebcb0a91801f3924a62 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-health-public/env.txt | env | aux | ce197565ede674bd7ab6127cf3fc2e1224c47ee8c6a70dbe71878f241aa8641b |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-health-public/http/01-web-health.json | http | evidence | f4c9628df7fdb957e8dcdefec626bc44422e34d0239462be757d7b9854830718 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-health-public/http/02-readback-web-health.json | http | evidence | 9fa4ed03bbe007b062b4d173fc1f2f20f97fa10d49c171f09467f684799ad1f5 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-health-public/http/03-collector-healthz.json | http | evidence | 862df51007973e976a9a2072592fa12c791fe090e322da8745671b0efd5ae6f3 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-health-public/http/04-collector-readyz.json | http | evidence | 88189f7e3a1d19a9f2f77b41928b201325c293031df46468817b7813802639b9 |
+| verification/runs/20260901-103612Z-aad22b9-wave1-qa-health-public/readback/web-health.json | readback | evidence | b6b196c223c1195dc83421e3a3eee84aa2fb6493d38d003dd3fdc5506a289596 |


### PR DESCRIPTION
## Summary
- add fresh exact-tree receipts for auth.api-principal, auth.login, and health.public on merged Wave 1 master
- preserve existing exact-tree fleet/domain evidence
- keep active probes default-off

## Validation
- source QA: 3021 tests, build, typecheck, lint, migrations, harness, clean-start
- focused QA: 515 tests
- strict verify-kit check-ci passed
- independent receipt review passed with zero findings

Evidence only: no product, production, provider, or LIVE changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fresh exact-tree verification receipts for `auth.api-principal`, `auth.login`, and `health.public` on the merged Wave 1 master SHA, alongside the existing fleet/domain evidence.

**Validation**
- Ran 3,536 tests, build, typecheck, lint, migrations, harness, and clean-start checks.
- Passed the strict verify-kit check-ci and independent receipt review with zero findings.
- Evidence only: no product, production, provider, or LIVE changes; active probes stay default-off.

<sup>Written for commit c20d503bf082d1ff497bb526a61d84f455a6ac25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

