### PR TITLE
fix(jobs): propagate BullMQ processor failures into retries and failed jobs (#68)

### DIFF
--- a/apps/collector/src/jobs/beads-18-19-20.integration.test.ts
+++ b/apps/collector/src/jobs/beads-18-19-20.integration.test.ts
@@ -41,20 +41,21 @@ describe('Beads 18-19-20 Integration Tests', () => {
         // Verify the function exists and is callable
         expect(typeof processFleetReport).toBe('function');
 
-        const result = await processFleetReport(job);
-        expect(result).toBeDefined();
+        // Failures now propagate to BullMQ instead of resolving success:false.
+        await expect(processFleetReport(job)).rejects.toThrow();
       });
 
       it('should handle missing domains gracefully', async () => {
         const job = createMockJob<FleetReportJobData>('job-1', {
           inventory: ['nonexistent.com'],
           checks: ['spf'],
+          format: 'summary',
           triggeredBy: 'user',
           tenantId: 'tenant-123',
         });
 
-        const result = await processFleetReport(job);
-        expect(result).toBeDefined();
+        // Unreachable DB surfaces as a retryable thrown failure.
+        await expect(processFleetReport(job)).rejects.toThrow();
       });
     });
   });
@@ -154,10 +155,8 @@ describe('Beads 18-19-20 Integration Tests', () => {
         triggeredBy: 'user',
       });
 
-      const result = await processCollectDomain(job);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
+      // Retryable: thrown so BullMQ's three-attempt policy runs.
+      await expect(processCollectDomain(job)).rejects.toThrow('DATABASE_URL');
 
       process.env.DATABASE_URL = originalEnv;
     });

--- a/apps/collector/src/jobs/worker.failure-propagation.test.ts
+++ b/apps/collector/src/jobs/worker.failure-propagation.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Issue #68 — Propagate BullMQ processor failures into retries and failed jobs.
+ *
+ * Proves:
+ * - Unexpected (retryable) processor failures throw, so BullMQ's retry policy runs.
+ * - A later successful attempt completes normally.
+ * - Explicit terminal validation outcomes throw UnrecoverableError (no retry).
+ * - Worker failure classification/metrics distinguish retrying vs failed.
+ */
+
+import { UnrecoverableError } from 'bullmq';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+process.env.DATABASE_URL = 'postgres://test:test@localhost:5432/test';
+
+vi.mock('@dns-ops/db', () => ({
+  createPostgresAdapter: vi.fn().mockReturnValue({}),
+  DomainRepository: vi.fn(),
+  FindingRepository: vi.fn(),
+  FleetReportRepository: vi.fn(),
+  MonitoredDomainRepository: vi.fn(),
+  SnapshotRepository: vi.fn(),
+}));
+
+vi.mock('../dns/collector.js', () => ({
+  DNSCollector: vi.fn(),
+}));
+
+vi.mock('../middleware/error-tracking.js', () => ({
+  getCollectorLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  }),
+  trackJobStart: vi.fn(),
+  trackJobComplete: vi.fn(),
+  trackJobError: vi.fn(),
+}));
+
+vi.mock('./alert-from-findings.js', () => ({
+  generateAndSendFindingAlerts: vi.fn().mockResolvedValue({ alerts: [], webhookSent: false }),
+}));
+
+vi.mock('./operational-condition-finalizer.js', () => ({
+  finalizePersistedCanonicalConditions: vi.fn().mockResolvedValue({ outcomes: [] }),
+}));
+
+vi.mock('./queue.js', () => ({
+  getRedisConnection: vi.fn().mockReturnValue({}),
+  getCollectionQueue: vi.fn().mockReturnValue({
+    add: vi.fn().mockResolvedValue({ id: 'queued-job-123' }),
+  }),
+  QUEUE_NAMES: {
+    COLLECTION: 'dns-ops-collection',
+    MONITORING: 'dns-ops-monitoring',
+    REPORTS: 'dns-ops-reports',
+  },
+}));
+
+import { DomainRepository } from '@dns-ops/db';
+import type { Job } from 'bullmq';
+import { DNSCollector } from '../dns/collector.js';
+import type { CollectDomainJobData, MonitoringRefreshJobData } from './queue.js';
+import {
+  classifyWorkerFailure,
+  processCollectDomain,
+  processMonitoringRefresh,
+  recordWorkerFailure,
+} from './worker.js';
+
+const mockedCollector = vi.mocked(DNSCollector);
+const mockedDomainRepo = vi.mocked(DomainRepository);
+
+function createMockJob<T>(id: string, data: T, attempts = 3): Job<T> {
+  return {
+    id,
+    data,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    attemptsMade: 0,
+    opts: { attempts },
+    processedOn: Date.now(),
+    finishedOn: null,
+  } as unknown as Job<T>;
+}
+
+function validCollectData(): CollectDomainJobData {
+  return { tenantId: 't1', domain: 'example.com', triggeredBy: 'user' };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Issue #68: retryable failures reach BullMQ retries', () => {
+  it('throws unexpected processor failures instead of returning success:false', async () => {
+    // DomainRepository instances return no domain so only collector.collect runs.
+    // biome-ignore lint/complexity/useArrowFunction: must stay constructible for `new DomainRepository()`
+    mockedDomainRepo.mockImplementation(function () {
+      return { findByNameForTenant: async () => undefined };
+    } as never);
+    const collect = vi.fn().mockRejectedValue(new Error('resolver ECONNREFUSED'));
+    // biome-ignore lint/complexity/useArrowFunction: must stay constructible for `new DNSCollector()`
+    mockedCollector.mockImplementation(function () {
+      return { collect };
+    } as never);
+
+    const job = createMockJob<CollectDomainJobData>('job-retry-1', validCollectData());
+
+    // Before the fix this resolved to { success: false } and BullMQ marked it completed.
+    await expect(processCollectDomain(job)).rejects.toThrow('resolver ECONNREFUSED');
+    expect(collect).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes normally when a later attempt succeeds', async () => {
+    // biome-ignore lint/complexity/useArrowFunction: must stay constructible for `new DomainRepository()`
+    mockedDomainRepo.mockImplementation(function () {
+      return { findByNameForTenant: async () => undefined };
+    } as never);
+    // First attempt fails, second attempt (BullMQ retry) succeeds.
+    const collect = vi
+      .fn<() => Promise<{ snapshotId: string }>>()
+      .mockRejectedValueOnce(new Error('transient failure'))
+      .mockResolvedValue({ snapshotId: 'snap-42' });
+    // biome-ignore lint/complexity/useArrowFunction: must stay constructible for `new DNSCollector()`
+    mockedCollector.mockImplementation(function () {
+      return { collect };
+    } as never);
+
+    const job = createMockJob<CollectDomainJobData>('job-retry-2', validCollectData());
+
+    await expect(processCollectDomain(job)).rejects.toThrow('transient failure');
+
+    const retryJob = createMockJob<CollectDomainJobData>('job-retry-2', validCollectData());
+    const result = await processCollectDomain(retryJob);
+
+    expect(result.success).toBe(true);
+    expect(result.snapshotId).toBe('snap-42');
+    expect(collect).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Issue #68: terminal validation outcomes do not retry', () => {
+  it('throws UnrecoverableError for invalid collect-domain job data', async () => {
+    const job = createMockJob<CollectDomainJobData>('job-terminal-1', {
+      tenantId: 't1',
+      domain: 'not a domain',
+      triggeredBy: 'user',
+    });
+
+    const error = await processCollectDomain(job).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    );
+
+    expect(error).toBeInstanceOf(UnrecoverableError);
+    expect(error?.name).toBe('UnrecoverableError');
+  });
+
+  it('classifies UnrecoverableError as failed even before attempts are exhausted', () => {
+    const job = createMockJob<CollectDomainJobData>('job-terminal-2', validCollectData());
+    (job as { attemptsMade: number }).attemptsMade = 1;
+
+    expect(classifyWorkerFailure(job, new UnrecoverableError('nope'))).toBe('failed');
+  });
+
+  it('keeps the scheduled monitoring placeholder valid (batch fan-out path)', async () => {
+    const { MonitoredDomainRepository } = await import('@dns-ops/db');
+    // biome-ignore lint/complexity/useArrowFunction: must stay constructible for `new MonitoredDomainRepository()`
+    vi.mocked(MonitoredDomainRepository).mockImplementation(function () {
+      return { findActiveBySchedule: async () => [] };
+    } as never);
+
+    const job = createMockJob<MonitoringRefreshJobData>('job-scheduled', {
+      monitoredDomainId: 'scheduled',
+      domainId: 'scheduled',
+      domainName: 'scheduled',
+      schedule: 'daily',
+      tenantId: 'system',
+    });
+
+    const result = await processMonitoringRefresh(job);
+    expect(result.success).toBe(true);
+    expect(result.queued).toBe(0);
+  });
+});
+
+describe('Issue #68: worker metrics distinguish retrying, failed, completed', () => {
+  it('classifies a retryable failure with attempts left as retrying', () => {
+    const job = createMockJob<CollectDomainJobData>('job-metrics-1', validCollectData());
+    (job as { attemptsMade: number }).attemptsMade = 1; // first failure of attempts=3
+
+    expect(classifyWorkerFailure(job, new Error('transient'))).toBe('retrying');
+  });
+
+  it('classifies an exhausted retryable failure as failed', () => {
+    const job = createMockJob<CollectDomainJobData>('job-metrics-2', validCollectData());
+    (job as { attemptsMade: number }).attemptsMade = 3; // final failed attempt
+
+    expect(classifyWorkerFailure(job, new Error('still failing'))).toBe('failed');
+  });
+
+  it('emits retried metric (not failed) while attempts remain', () => {
+    const job = createMockJob<CollectDomainJobData>('job-metrics-3', validCollectData());
+    (job as { attemptsMade: number }).attemptsMade = 1;
+    const jobMetrics = { failed: vi.fn(), retried: vi.fn() };
+
+    const outcome = recordWorkerFailure({
+      label: 'Collection',
+      jobType: 'collect-domain',
+      queue: 'dns-ops-collection',
+      job,
+      error: new Error('transient'),
+      jobMetrics,
+    });
+
+    expect(outcome).toBe('retrying');
+    expect(jobMetrics.retried).toHaveBeenCalledTimes(1);
+    expect(jobMetrics.retried).toHaveBeenCalledWith(
+      expect.objectContaining({ jobType: 'collect-domain', attempt: 1 })
+    );
+    expect(jobMetrics.failed).not.toHaveBeenCalled();
+  });
+
+  it('emits failed metric (not retried) when retries are exhausted or terminal', () => {
+    const job = createMockJob<CollectDomainJobData>('job-metrics-4', validCollectData());
+    (job as { attemptsMade: number }).attemptsMade = 3;
+    const jobMetrics = { failed: vi.fn(), retried: vi.fn() };
+
+    const outcome = recordWorkerFailure({
+      label: 'Collection',
+      jobType: 'collect-domain',
+      queue: 'dns-ops-collection',
+      job,
+      error: new Error('exhausted'),
+      jobMetrics,
+    });
+
+    expect(outcome).toBe('failed');
+    expect(jobMetrics.failed).toHaveBeenCalledTimes(1);
+    expect(jobMetrics.failed).toHaveBeenCalledWith(
+      expect.objectContaining({ jobType: 'collect-domain', attempt: 3, error: 'exhausted' })
+    );
+    expect(jobMetrics.retried).not.toHaveBeenCalled();
+  });
+});

--- a/apps/collector/src/jobs/worker.processors.test.ts
+++ b/apps/collector/src/jobs/worker.processors.test.ts
@@ -90,7 +90,7 @@ describe('Job Worker Processors - Bead 19', () => {
       expect(typeof processCollectDomain).toBe('function');
     });
 
-    it('should return error when DATABASE_URL not set', async () => {
+    it('should throw when DATABASE_URL not set so BullMQ retries', async () => {
       const originalEnv = process.env.DATABASE_URL;
       delete process.env.DATABASE_URL;
 
@@ -100,10 +100,7 @@ describe('Job Worker Processors - Bead 19', () => {
         triggeredBy: 'user',
       });
 
-      const result = await processCollectDomain(job);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('DATABASE_URL');
+      await expect(processCollectDomain(job)).rejects.toThrow('DATABASE_URL');
 
       process.env.DATABASE_URL = originalEnv;
     });
@@ -114,7 +111,7 @@ describe('Job Worker Processors - Bead 19', () => {
       expect(typeof processMonitoringRefresh).toBe('function');
     });
 
-    it('should return error when DATABASE_URL not set', async () => {
+    it('should throw when DATABASE_URL not set so BullMQ retries', async () => {
       const originalEnv = process.env.DATABASE_URL;
       delete process.env.DATABASE_URL;
 
@@ -126,10 +123,7 @@ describe('Job Worker Processors - Bead 19', () => {
         tenantId: 't1',
       });
 
-      const result = await processMonitoringRefresh(job);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('DATABASE_URL');
+      await expect(processMonitoringRefresh(job)).rejects.toThrow('DATABASE_URL');
 
       process.env.DATABASE_URL = originalEnv;
     });
@@ -140,7 +134,7 @@ describe('Job Worker Processors - Bead 19', () => {
       expect(typeof processFleetReport).toBe('function');
     });
 
-    it('should return error when DATABASE_URL not set', async () => {
+    it('should throw when DATABASE_URL not set so BullMQ retries', async () => {
       const originalEnv = process.env.DATABASE_URL;
       delete process.env.DATABASE_URL;
 
@@ -152,10 +146,7 @@ describe('Job Worker Processors - Bead 19', () => {
         tenantId: 't1',
       });
 
-      const result = await processFleetReport(job);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('DATABASE_URL');
+      await expect(processFleetReport(job)).rejects.toThrow('DATABASE_URL');
 
       process.env.DATABASE_URL = originalEnv;
     });

--- a/apps/collector/src/jobs/worker.ts
+++ b/apps/collector/src/jobs/worker.ts
@@ -17,7 +17,9 @@ import {
   MonitoredDomainRepository,
   SnapshotRepository,
 } from '@dns-ops/db';
-import { type ConnectionOptions, type Job, Worker } from 'bullmq';
+import type { JobMetrics } from '@dns-ops/logging';
+import { isValidDomain } from '@dns-ops/parsing';
+import { type ConnectionOptions, type Job, UnrecoverableError, Worker } from 'bullmq';
 import { DNSCollector } from '../dns/collector.js';
 import type { CollectionConfig } from '../dns/types.js';
 import {
@@ -39,6 +41,110 @@ import {
 } from './queue.js';
 
 const logger = getCollectorLogger();
+
+type WorkerFailureOutcome = 'retrying' | 'failed';
+
+type JobMetricsRecorder = Pick<JobMetrics, 'failed' | 'retried'>;
+
+function validationError(message: string): never {
+  throw new UnrecoverableError(`Job validation failed: ${message}`);
+}
+
+function validateCollectDomainJobData(data: CollectDomainJobData): void {
+  if (!data.tenantId || !isValidDomain(data.domain) || !data.triggeredBy) {
+    validationError('tenantId, domain, and triggeredBy are required');
+  }
+}
+
+function validateMonitoringRefreshJobData(data: MonitoringRefreshJobData): void {
+  if (!data.tenantId || !['hourly', 'daily', 'weekly'].includes(data.schedule)) {
+    validationError('monitoring refresh job data is invalid');
+  }
+  // The scheduled placeholder (domainName 'scheduled', tenantId 'system') only
+  // fans out batch refreshes; it has no per-domain fields to validate.
+  if (data.monitoredDomainId === 'scheduled') return;
+  if (!data.monitoredDomainId || !data.domainId || !isValidDomain(data.domainName)) {
+    validationError('monitoring refresh job data is invalid');
+  }
+}
+
+function validateFleetReportJobData(data: FleetReportJobData): void {
+  if (
+    !Array.isArray(data.inventory) ||
+    !data.inventory.every((domain) => typeof domain === 'string') ||
+    !Array.isArray(data.checks) ||
+    !data.checks.every((check) => typeof check === 'string') ||
+    !['summary', 'detailed'].includes(data.format) ||
+    !data.triggeredBy ||
+    !data.tenantId
+  ) {
+    validationError('fleet report job data is invalid');
+  }
+}
+
+function isUnrecoverableError(error: Error): boolean {
+  return error instanceof UnrecoverableError || error.name === 'UnrecoverableError';
+}
+
+export function classifyWorkerFailure(job: Job | undefined, error: Error): WorkerFailureOutcome {
+  const attempt = job?.attemptsMade ?? 0;
+  const maxAttempts = Math.max(job?.opts.attempts ?? 1, 1);
+  return !isUnrecoverableError(error) && attempt < maxAttempts ? 'retrying' : 'failed';
+}
+
+export function recordWorkerFailure({
+  label,
+  jobType,
+  queue,
+  job,
+  error,
+  jobMetrics,
+}: {
+  label: string;
+  jobType: string;
+  queue: string;
+  job: Job | undefined;
+  error: Error;
+  jobMetrics: JobMetricsRecorder;
+}): WorkerFailureOutcome {
+  const outcome = classifyWorkerFailure(job, error);
+  const attempt = job?.attemptsMade ?? 0;
+  const maxAttempts = Math.max(job?.opts.attempts ?? 1, 1);
+
+  if (outcome === 'retrying') {
+    logger.warn(`${label} job retrying`, {
+      jobId: job?.id,
+      eventType: 'job_retry',
+      attempt,
+      maxAttempts,
+      error: error.message,
+    });
+    jobMetrics.retried({
+      jobType,
+      queue,
+      jobId: job?.id || 'unknown',
+      attempt,
+    });
+  } else {
+    logger.error(`${label} job failed`, error, {
+      jobId: job?.id,
+      eventType: 'job_failed',
+      outcome: isUnrecoverableError(error) ? 'terminal_validation' : 'exhausted_retries',
+      attempt,
+      maxAttempts,
+    });
+    jobMetrics.failed({
+      jobType,
+      queue,
+      jobId: job?.id || 'unknown',
+      durationMs: job?.processedOn ? Date.now() - job.processedOn : 0,
+      error: error.message,
+      attempt,
+    });
+  }
+
+  return outcome;
+}
 
 // =============================================================================
 // Database Helper
@@ -77,6 +183,7 @@ export async function processCollectDomain(job: Job<CollectDomainJobData>): Prom
   });
 
   try {
+    validateCollectDomainJobData(job.data);
     const db = getDbAdapter();
 
     const config: CollectionConfig = {
@@ -188,10 +295,7 @@ export async function processCollectDomain(job: Job<CollectDomainJobData>): Prom
       domain,
       durationMs: Date.now() - startTime,
     });
-    return {
-      success: false,
-      error: err.message,
-    };
+    throw err;
   }
 }
 
@@ -214,6 +318,7 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
     logger.info('Processing scheduled monitoring refresh', { schedule, jobId: job.id });
 
     try {
+      validateMonitoringRefreshJobData(job.data);
       const db = getDbAdapter();
       const monitoredRepo = new MonitoredDomainRepository(db);
       const domainRepo = new DomainRepository(db);
@@ -221,10 +326,7 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
       const queue = getCollectionQueue();
 
       if (!queue) {
-        return {
-          success: false,
-          error: 'Queue not available for scheduling',
-        };
+        throw new Error('Queue not available for scheduling');
       }
 
       // Find all monitored domains due for refresh across ALL tenants
@@ -306,10 +408,7 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
         tenantId,
         jobId: job.id,
       });
-      return {
-        success: false,
-        error: err.message,
-      };
+      throw err;
     }
   }
 
@@ -321,16 +420,19 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
   });
 
   try {
+    validateMonitoringRefreshJobData(job.data);
     const db = getDbAdapter();
     const domainRepo = new DomainRepository(db);
 
     // Get domain to check zone management
     const domain = await domainRepo.findById(domainId);
     if (!domain || domain.tenantId !== tenantId) {
-      throw new Error(`Domain ${domainId} is outside the monitoring tenant`);
+      throw new UnrecoverableError(`Domain ${domainId} is outside the monitoring tenant`);
     }
     if (domain.normalizedName !== domainName.toLowerCase()) {
-      throw new Error('Monitoring job domain name does not match the registered domain');
+      throw new UnrecoverableError(
+        'Monitoring job domain name does not match the registered domain'
+      );
     }
 
     const config: CollectionConfig = {
@@ -399,10 +501,7 @@ export async function processMonitoringRefresh(job: Job<MonitoringRefreshJobData
       domain: domainName,
       durationMs: Date.now() - startTime,
     });
-    return {
-      success: false,
-      error: err.message,
-    };
+    throw err;
   }
 }
 
@@ -427,6 +526,7 @@ export async function processFleetReport(job: Job<FleetReportJobData>): Promise<
   });
 
   try {
+    validateFleetReportJobData(job.data);
     const db = getDbAdapter();
     const domainRepo = new DomainRepository(db);
     const snapshotRepo = new SnapshotRepository(db);
@@ -512,10 +612,7 @@ export async function processFleetReport(job: Job<FleetReportJobData>): Promise<
       jobType: 'fleet-report',
       durationMs: Date.now() - startTime,
     });
-    return {
-      success: false,
-      error: err.message,
-    };
+    throw err;
   }
 }
 
@@ -555,39 +652,25 @@ export async function startWorkers(): Promise<void> {
   );
 
   collectionWorker.on('completed', (job) => {
-    const result = job.returnvalue as { success?: boolean; error?: string } | undefined;
     const durationMs = job.finishedOn && job.processedOn ? job.finishedOn - job.processedOn : 0;
-    if (result?.success === false) {
-      logger.debug('Collection job completed with failure', { jobId: job.id });
-      jobMetrics.failed({
-        jobType: 'collect-domain',
-        queue: QUEUE_NAMES.COLLECTION,
-        jobId: job.id || 'unknown',
-        durationMs,
-        error: result.error || 'Unknown error',
-        attempt: job.attemptsMade || 0,
-      });
-    } else {
-      logger.debug('Collection job completed', { jobId: job.id });
-      jobMetrics.completed({
-        jobType: 'collect-domain',
-        queue: QUEUE_NAMES.COLLECTION,
-        jobId: job.id || 'unknown',
-        durationMs,
-      });
-    }
-  });
-
-  // Fires only on uncaught processor crashes (processors catch known errors)
-  collectionWorker.on('failed', (job, error) => {
-    logger.error('Collection job crashed', error, { jobId: job?.id });
-    jobMetrics.failed({
+    logger.debug('Collection job completed', { jobId: job.id });
+    jobMetrics.completed({
       jobType: 'collect-domain',
       queue: QUEUE_NAMES.COLLECTION,
-      jobId: job?.id || 'unknown',
-      durationMs: job?.processedOn ? Date.now() - job.processedOn : 0,
-      error: error.message,
-      attempt: job?.attemptsMade || 0,
+      jobId: job.id || 'unknown',
+      durationMs,
+    });
+  });
+
+  // Processors throw for retryable and terminal outcomes; BullMQ retries here.
+  collectionWorker.on('failed', (job, error) => {
+    recordWorkerFailure({
+      label: 'Collection',
+      jobType: 'collect-domain',
+      queue: QUEUE_NAMES.COLLECTION,
+      job,
+      error,
+      jobMetrics,
     });
   });
 
@@ -604,38 +687,24 @@ export async function startWorkers(): Promise<void> {
   );
 
   monitoringWorker.on('completed', (job) => {
-    const result = job.returnvalue as { success?: boolean; error?: string } | undefined;
     const durationMs = job.finishedOn && job.processedOn ? job.finishedOn - job.processedOn : 0;
-    if (result?.success === false) {
-      logger.debug('Monitoring job completed with failure', { jobId: job.id });
-      jobMetrics.failed({
-        jobType: 'monitoring-refresh',
-        queue: QUEUE_NAMES.MONITORING,
-        jobId: job.id || 'unknown',
-        durationMs,
-        error: result.error || 'Unknown error',
-        attempt: job.attemptsMade || 0,
-      });
-    } else {
-      logger.debug('Monitoring job completed', { jobId: job.id });
-      jobMetrics.completed({
-        jobType: 'monitoring-refresh',
-        queue: QUEUE_NAMES.MONITORING,
-        jobId: job.id || 'unknown',
-        durationMs,
-      });
-    }
+    logger.debug('Monitoring job completed', { jobId: job.id });
+    jobMetrics.completed({
+      jobType: 'monitoring-refresh',
+      queue: QUEUE_NAMES.MONITORING,
+      jobId: job.id || 'unknown',
+      durationMs,
+    });
   });
 
   monitoringWorker.on('failed', (job, error) => {
-    logger.error('Monitoring job crashed', error, { jobId: job?.id });
-    jobMetrics.failed({
+    recordWorkerFailure({
+      label: 'Monitoring',
       jobType: 'monitoring-refresh',
       queue: QUEUE_NAMES.MONITORING,
-      jobId: job?.id || 'unknown',
-      durationMs: job?.processedOn ? Date.now() - job.processedOn : 0,
-      error: error.message,
-      attempt: job?.attemptsMade || 0,
+      job,
+      error,
+      jobMetrics,
     });
   });
 
@@ -652,38 +721,24 @@ export async function startWorkers(): Promise<void> {
   );
 
   reportsWorker.on('completed', (job) => {
-    const result = job.returnvalue as { success?: boolean; error?: string } | undefined;
     const durationMs = job.finishedOn && job.processedOn ? job.finishedOn - job.processedOn : 0;
-    if (result?.success === false) {
-      logger.debug('Reports job completed with failure', { jobId: job.id });
-      jobMetrics.failed({
-        jobType: 'fleet-report',
-        queue: QUEUE_NAMES.REPORTS,
-        jobId: job.id || 'unknown',
-        durationMs,
-        error: result.error || 'Unknown error',
-        attempt: job.attemptsMade || 0,
-      });
-    } else {
-      logger.debug('Reports job completed', { jobId: job.id });
-      jobMetrics.completed({
-        jobType: 'fleet-report',
-        queue: QUEUE_NAMES.REPORTS,
-        jobId: job.id || 'unknown',
-        durationMs,
-      });
-    }
+    logger.debug('Reports job completed', { jobId: job.id });
+    jobMetrics.completed({
+      jobType: 'fleet-report',
+      queue: QUEUE_NAMES.REPORTS,
+      jobId: job.id || 'unknown',
+      durationMs,
+    });
   });
 
   reportsWorker.on('failed', (job, error) => {
-    logger.error('Reports job crashed', error, { jobId: job?.id });
-    jobMetrics.failed({
+    recordWorkerFailure({
+      label: 'Reports',
       jobType: 'fleet-report',
       queue: QUEUE_NAMES.REPORTS,
-      jobId: job?.id || 'unknown',
-      durationMs: job?.processedOn ? Date.now() - job.processedOn : 0,
-      error: error.message,
-      attempt: job?.attemptsMade || 0,
+      job,
+      error,
+      jobMetrics,
     });
   });
 


### PR DESCRIPTION
## Problem
A read-only audit found that unexpected BullMQ processor failures were returned as `{ success: false }`, so BullMQ marked failed work **completed** instead of retrying.

## Changes
- **Retryable failures throw.** All three processors (`processCollectDomain`, `processMonitoringRefresh`, `processFleetReport`) now rethrow unexpected errors after `trackJobError`, so the existing three-attempt policy runs and exhausted retries stay visibly failed.
- **Terminal validation is non-retryable and observable.** Job-shape validation throws BullMQ `UnrecoverableError`. The scheduled monitoring placeholder (`monitoredDomainId: 'scheduled'`) remains valid so batch fan-out keeps working.
- **Metrics/logging distinguish outcomes.** `recordWorkerFailure` classifies `retrying` (attempts remain, non-terminal error) vs `failed` (exhausted or terminal) and emits `job_retried_total` / `job_failed_total` plus structured `job_retry` / `job_failed` log events with `outcome: terminal_validation | exhausted_retries`.
- Removed the now-dead `success:false` branch from the worker `completed` handlers — completed now always means success.

## Tests
- New `worker.failure-propagation.test.ts`: retryable throw (not swallowed `success:false`), later-attempt success, terminal `UnrecoverableError` (invalid domain), scheduled-placeholder validity, and retried-vs-failed metric classification.
- Updated `worker.processors.test.ts` and `beads-18-19-20.integration.test.ts` to the throwing contract.

Closes #68

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BullMQ processor failure handling so failed work is retried and stays failed instead of being marked completed.

**Changes**
- Unexpected processor failures now throw instead of returning `{ success: false }`, so the three-attempt retry policy runs.
- Terminal job-shape validation throws BullMQ `UnrecoverableError`; the `scheduled` monitoring placeholder stays valid.
- Worker failure handling now emits `job_retried_total` / `job_failed_total` metrics and `job_retry` / `job_failed` log events.
- Removed the dead `success: false` branch from completed handlers; completed now always means success.

<sup>Written for commit 9719ee6e6a967be0dd1c8d29774f62eec75e2d67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

