### PR TITLE
feat(web): make evidence completeness the Domain 360 hero (#58)

### DIFF
--- a/.agents/skills/verify-dns-ops/features/domain.overview.md
+++ b/.agents/skills/verify-dns-ops/features/domain.overview.md
@@ -5,6 +5,8 @@ profile: changed
 paths:
   - apps/web/app/routes/index.tsx
   - apps/web/app/routes/domain/$domain.tsx
+  - apps/web/app/components/DomainEvidencePanel.tsx
+  - apps/web/app/components/DomainEvidencePanel.test.ts
   - apps/web/app/components/DomainInput.tsx
   - apps/web/app/components/DNSViews.tsx
   - apps/web/app/components/MailFindingsPanel.tsx
@@ -12,11 +14,18 @@ paths:
   - apps/web/app/lib/dns-ttl.ts
   - apps/web/app/lib/dns-ttl.test.ts
   - apps/web/app/lib/domain-route.test.ts
+  - apps/web/app/styles/app.css
+  - apps/web/hono/routes/findings.ts
+  - apps/web/hono/routes/findings.runtime.test.ts
   - apps/web/e2e/domain-states.spec.ts
   - apps/web/e2e/finding-simulation.spec.ts
+  - apps/web/e2e/domain-signal-room.spec.ts
+  - apps/web/e2e/support/domain-fixtures.ts
   - apps/collector/src/dns/collector.ts
   - apps/collector/src/dns/collector.concurrency.test.ts
   - apps/collector/src/dns/integration.test.ts
+  - packages/contracts/package.json
+  - packages/contracts/src/responses.ts
   - packages/db/src/schema/index.ts
   - .agents/verify-kit/verify.mjs
   - .agents/verify-kit/working-tree.test.mjs
@@ -56,6 +65,8 @@ await page.getByRole('tab', { name: /overview/i }).waitFor();
 ### Expected observations
 - URL matches `/domain/google.com`.
 - Tabs Overview, DNS, Mail, and History are visible. Delegation is visible only when the product shows that tab.
+- Overview opens with a labelled `Evidence completeness` region before query statistics, showing separate coverage and current evaluated-ruleset findings status/counts.
+- Partial or missing collection/evaluation coverage plus zero findings renders UNKNOWN / `Needs setup/evidence` and says that `0 observed does not establish health`; findings-unavailable renders UNKNOWN rather than numeric zero. Healthy zero-finding language is only allowed for explicit complete coverage with no setup or evidence gaps.
 - DNS Parsed view renders `Remaining TTL` and `Estimated live at` column headers; every body row's two new cells are populated (`N s remaining` + `<time datetime>`, or `UNKNOWN` ×2) — never blank. Rendered live rows agree with persisted recursive evidence and the `dns-ttl-audit` read-back.
 - On the Mail tab, existing findings render as accessible named cards. After authenticated actionable-type discovery returns `supportedTypeIds`, each matching existing card shows a visible `Simulate` sibling primary button, including review-only findings; unsupported findings remain visible and expandable without that button.
 - Activating a finding's `Simulate` button sends only `{ findingId }` to the authenticated single-finding endpoint. A valid result renders `Guidance only`, its returned title, explanation, and playbook reference, plus `No DNS changes are applied.`; no Apply control, executable mutation, provider record value, or projected resolution appears.
@@ -63,6 +74,8 @@ await page.getByRole('tab', { name: /overview/i }).waitFor();
 
 ### Forbidden observations
 - Staying on `/` after Analyze with a valid domain.
+- Rendering a healthy/success zero-finding result when coverage is incomplete or unavailable.
+- Fabricating a coverage percentage from observations or query counts.
 - Driving with CSS class selectors.
 - Deriving the estimate from the averaged record TTL instead of matching recursive answers; blank TTL cells.
 - Nesting `Simulate` inside the finding accordion button, guessing supported types, or hiding findings when actionable-type discovery fails.
@@ -70,6 +83,7 @@ await page.getByRole('tab', { name: /overview/i }).waitFor();
 
 ### Read-back
 - The Domain 360 heading shows the submitted domain. Snapshot/findings JSON is optional; empty snapshot is allowed.
+- Harness stores the findings summary (`findings-summary`) and checks that rendered evaluation/finding states agree with its explicit coverage/count fields.
 - Harness stores the raw observations (`dns-observations`), persisted-vs-rendered deadline audit (`dns-ttl-audit`), and a per-row audit of the two TTL cells (`dns-ttl-cells`). The harness fails on API errors, missing timing metadata/server time, absent usable recursive evidence, all-UNKNOWN output, unexpected live values, or mismatched rows/countdowns.
 
 ## Gotchas

--- a/.agents/skills/verify-dns-ops/harness/web.mts
+++ b/.agents/skills/verify-dns-ops/harness/web.mts
@@ -143,16 +143,8 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
     if (await delegation.count()) await delegation.waitFor();
     await ev.shot(page, 'domain-overview');
 
-    // DNS Parsed view — remaining TTL + estimated live-at on every row (issue #55).
-    await page.getByRole('tab', { name: /^DNS$/ }).click();
-    await page.getByRole('columnheader', { name: 'Remaining TTL' }).waitFor({ timeout: 15_000 });
-    await page
-      .getByRole('columnheader', { name: 'Estimated live at' })
-      .waitFor({ timeout: 15_000 });
-
-    // Store and independently audit the persisted evidence. URLs are built
-    // from a relative path so the map linter does not see route literals the
-    // registry's regex does not index (hono routes registered via apiRoutes).
+    // Read back the non-mutating findings summary before switching away from
+    // Overview, then compare its explicit state with the rendered hero.
     const apiBase = BASE_URL.endsWith('/') ? BASE_URL : `${BASE_URL}/`;
     const latest = await page.request.get(new URL('api/domain/google.com/latest', apiBase));
     if (!latest.ok()) throw new Error(`latest snapshot request failed: ${latest.status()}`);
@@ -167,6 +159,51 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
       throw new Error('snapshot is missing the response-received-v1 DNS timing marker');
     }
 
+    const summaryRes = await page.request.get(
+      new URL(`snapshot/${snap.id}/findings/summary`, apiBase)
+    );
+    if (!summaryRes.ok())
+      throw new Error(`findings summary read-back failed: ${summaryRes.status()}`);
+    const summaryJson = await summaryRes.json();
+    if (
+      !isRecord(summaryJson) ||
+      typeof summaryJson.total !== 'number' ||
+      !isRecord(summaryJson.evaluationCoverage) ||
+      (summaryJson.evaluationCoverage.state !== 'COMPLETE' &&
+        summaryJson.evaluationCoverage.state !== 'PARTIAL')
+    ) {
+      throw new Error('findings summary is missing an explicit evaluation coverage and count');
+    }
+    await ev.readback('findings-summary', summaryJson);
+
+    const evidenceHero = page.getByRole('region', { name: /evidence completeness/i });
+    await evidenceHero.waitFor({ timeout: 15_000 });
+    const evaluationState =
+      summaryJson.evaluationCoverage.state === 'COMPLETE' && summaryJson.findingsEvaluated === true
+        ? 'complete'
+        : 'unknown';
+    const evaluationIndicator = evidenceHero.getByText(/Rule evaluation coverage:/i);
+    await evaluationIndicator.waitFor();
+    if ((await evaluationIndicator.getAttribute('data-state')) !== evaluationState) {
+      throw new Error(`rendered evaluation state disagrees with summary: ${evaluationState}`);
+    }
+    const findingsGroup = evidenceHero.getByRole('group', { name: /^Findings$/i });
+    await findingsGroup.waitFor();
+    const expectedFindingsState = evaluationState === 'complete' ? 'known' : 'unknown';
+    if ((await findingsGroup.getAttribute('data-state')) !== expectedFindingsState) {
+      throw new Error(`rendered findings state disagrees with summary: ${expectedFindingsState}`);
+    }
+
+    // DNS Parsed view — remaining TTL + estimated live-at on every row (issue #55).
+    await page.getByRole('tab', { name: /^DNS$/ }).click();
+    await page.getByRole('columnheader', { name: 'Remaining TTL' }).waitFor({ timeout: 15_000 });
+    await page
+      .getByRole('columnheader', { name: 'Estimated live at' })
+      .waitFor({ timeout: 15_000 });
+
+    // Store and independently audit the persisted evidence. URLs are built
+    // from a relative path so the map linter does not see route literals the
+    // registry's regex does not index (hono routes registered via apiRoutes).
     const obsRes = await page.request.get(new URL(`snapshot/${snap.id}/observations`, apiBase));
     if (!obsRes.ok()) throw new Error(`observation read-back failed: ${obsRes.status()}`);
     const observationsJson = await obsRes.json();

--- a/apps/web/app/components/DomainEvidencePanel.test.ts
+++ b/apps/web/app/components/DomainEvidencePanel.test.ts
@@ -1,5 +1,27 @@
+import type { FindingsSummaryResponse } from '@dns-ops/contracts/responses';
+import type { Snapshot } from '@dns-ops/db/schema';
 import { describe, expect, it } from 'vitest';
-import { deduplicateSetup, isCurrentEvidence, unknownForEvidence } from './DomainEvidencePanel.js';
+import {
+  deduplicateSetup,
+  isCurrentEvidence,
+  isEvidenceComplete,
+  unknownForEvidence,
+} from './DomainEvidencePanel.js';
+
+const completeSnapshot = {
+  resultState: 'complete',
+  metadata: {},
+} as Snapshot;
+
+const summary = (overrides: Partial<FindingsSummaryResponse> = {}): FindingsSummaryResponse => ({
+  snapshotId: 'snapshot-1',
+  findingsEvaluated: true,
+  evaluationCoverage: { state: 'COMPLETE', errors: [] },
+  hasFindings: false,
+  severityCounts: { critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+  total: 0,
+  ...overrides,
+});
 
 describe('DomainEvidencePanel evidence classification', () => {
   it('deduplicates repeated setup actions', () => {
@@ -69,5 +91,50 @@ describe('DomainEvidencePanel evidence classification', () => {
         probeData: { status: 'OBSERVED' },
       })
     ).toBe(true);
+  });
+
+  it('keeps partial evaluation plus zero findings UNKNOWN', () => {
+    expect(
+      isEvidenceComplete({
+        snapshot: completeSnapshot,
+        findingsSummary: summary({
+          findingsEvaluated: false,
+          evaluationCoverage: { state: 'PARTIAL', errors: [] },
+        }),
+        setup: [],
+      })
+    ).toBe(false);
+  });
+
+  it('allows a complete zero-finding result to be healthy', () => {
+    expect(
+      isEvidenceComplete({ snapshot: completeSnapshot, findingsSummary: summary(), setup: [] })
+    ).toBe(true);
+  });
+
+  it('keeps complete evaluation UNKNOWN when external setup has a gap', () => {
+    expect(
+      isEvidenceComplete({
+        snapshot: completeSnapshot,
+        findingsSummary: summary(),
+        setup: [
+          {
+            reason: 'MISSING_BASELINE',
+            explanation: 'Accept a baseline first.',
+            action: 'ACCEPT_BASELINE',
+            actionLabel: 'Accept baseline',
+          },
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it('keeps an unavailable findings summary UNKNOWN instead of treating it as zero', () => {
+    expect(
+      isEvidenceComplete({ snapshot: completeSnapshot, findingsSummary: null, setup: [] })
+    ).toBe(false);
+    expect(
+      isEvidenceComplete({ snapshot: completeSnapshot, findingsSummary: undefined, setup: [] })
+    ).toBe(false);
   });
 });

--- a/apps/web/app/components/DomainEvidencePanel.tsx
+++ b/apps/web/app/components/DomainEvidencePanel.tsx
@@ -1,3 +1,10 @@
+import {
+  type EvaluationCoverage,
+  evaluationCoverageOrUnknown,
+  isEvaluationComplete,
+} from '@dns-ops/contracts';
+import type { FindingsSummaryResponse } from '@dns-ops/contracts/responses';
+import type { Snapshot } from '@dns-ops/db/schema';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useId } from 'react';
 import { Button } from './ui/Button.js';
@@ -77,23 +84,108 @@ export function unknownForEvidence(
   };
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, { credentials: 'include' });
+async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const response = await fetch(url, { credentials: 'include', signal });
   if (!response.ok) throw new Error(`Evidence request failed (${response.status})`);
   return response.json() as Promise<T>;
 }
 
-export function DomainEvidencePanel({ domain }: { domain: string }) {
+export function isEvidenceComplete({
+  snapshot,
+  findingsSummary,
+  setup,
+  requestsReady = true,
+}: {
+  snapshot: Pick<Snapshot, 'resultState' | 'metadata'> | null;
+  findingsSummary: FindingsSummaryResponse | null | undefined;
+  setup: readonly Unknown[];
+  requestsReady?: boolean;
+}): boolean {
+  if (
+    !snapshot ||
+    !findingsSummary ||
+    !Number.isFinite(findingsSummary.total) ||
+    findingsSummary.total < 0 ||
+    !requestsReady ||
+    setup.length > 0
+  ) {
+    return false;
+  }
+  if (snapshot.resultState !== 'complete') return false;
+  if (
+    !findingsSummary.findingsEvaluated ||
+    !isEvaluationComplete(findingsSummary.evaluationCoverage)
+  ) {
+    return false;
+  }
+  return snapshot.metadata?.authoritativeEvidence?.state !== 'UNKNOWN';
+}
+
+function unavailableEvidence(subject: string): Unknown {
+  return {
+    reason: 'EVIDENCE_UNAVAILABLE',
+    explanation: `${subject} is currently unavailable.`,
+    action: 'RETRY',
+    actionLabel: 'Retry',
+  };
+}
+
+function collectionSetup(snapshot: Snapshot | null): Unknown | undefined {
+  if (!snapshot || snapshot.resultState === 'complete') return undefined;
+  return {
+    reason: 'COLLECTION_INCOMPLETE',
+    explanation:
+      snapshot.resultState === 'failed'
+        ? 'DNS collection failed, so evidence completeness is UNKNOWN.'
+        : 'DNS collection is partial, so evidence completeness is UNKNOWN.',
+    action: 'RUN_FRESH_SCAN',
+    actionLabel: 'Run a fresh scan',
+  };
+}
+
+function authoritativeSetup(snapshot: Snapshot | null): Unknown | undefined {
+  const authoritativeEvidence = snapshot?.metadata?.authoritativeEvidence;
+  if (authoritativeEvidence?.state !== 'UNKNOWN') return undefined;
+  return (
+    authoritativeEvidence.unknown ?? {
+      reason: 'AUTHORITATIVE_EVIDENCE_UNAVAILABLE',
+      explanation: 'Authoritative DNS evidence is currently UNKNOWN.',
+      action: 'RETRY_PROBE',
+      actionLabel: 'Retry authoritative evidence',
+    }
+  );
+}
+
+function evaluationSetup(findingsSummary: FindingsSummaryResponse | null | undefined): Unknown[] {
+  if (!findingsSummary) return [];
+  const coverage: EvaluationCoverage = evaluationCoverageOrUnknown(
+    findingsSummary.evaluationCoverage
+  );
+  return coverage.errors.map((evaluationError) => evaluationError.unknown);
+}
+
+export function DomainEvidencePanel({
+  domain,
+  snapshot,
+  findingsSummary,
+}: {
+  domain: string;
+  snapshot: Snapshot | null;
+  findingsSummary?: FindingsSummaryResponse | null;
+}) {
   const headingId = useId();
+  const coverageHeadingId = `${headingId}-coverage`;
+  const findingsHeadingId = `${headingId}-findings`;
   const queryClient = useQueryClient();
   const profile = useQuery({
     queryKey: ['domain-profile', domain],
-    queryFn: () => fetchJson<ProfileResponse>(`/api/domains/${encodeURIComponent(domain)}/profile`),
+    queryFn: ({ signal }) =>
+      fetchJson<ProfileResponse>(`/api/domains/${encodeURIComponent(domain)}/profile`, signal),
   });
   const evidence = useQuery({
     queryKey: ['domain-evidence', domain],
-    queryFn: () =>
-      fetchJson<EvidenceResponse>(`/api/domains/${encodeURIComponent(domain)}/evidence`),
+    queryFn: ({ signal }) =>
+      fetchJson<EvidenceResponse>(`/api/domains/${encodeURIComponent(domain)}/evidence`, signal),
   });
 
   const retry = () => {
@@ -101,60 +193,172 @@ export function DomainEvidencePanel({ domain }: { domain: string }) {
     void queryClient.invalidateQueries({ queryKey: ['domain-evidence', domain] });
   };
 
-  if (profile.isLoading || evidence.isLoading) {
-    return (
-      <section className="domain-evidence ds-panel" aria-labelledby={headingId}>
-        <p id={headingId} className="domain-evidence__state" role="status">
-          Loading evidence coverage…
-        </p>
-      </section>
-    );
-  }
-  if (profile.error || evidence.error) {
-    return (
-      <section className="domain-evidence ds-panel" aria-labelledby={headingId}>
-        <div className="domain-evidence__error" role="alert">
-          <div>
-            <p className="ds-kicker">Evidence status</p>
-            <h3 id={headingId}>Evidence setup is unavailable</h3>
-            <p>Evidence setup status is currently unavailable.</p>
-          </div>
-          <Button onClick={retry} size="sm" variant="quiet">
-            Retry
-          </Button>
-        </div>
-      </section>
-    );
-  }
-
-  const setup = [
+  const collectionUnknown = collectionSetup(snapshot);
+  const authoritativeUnknown = authoritativeSetup(snapshot);
+  const setup: Unknown[] = [
     ...(profile.data?.setup ? [profile.data.setup] : []),
     ...(evidence.data?.evidence
       .map(unknownForEvidence)
       .filter((unknown): unknown is Unknown => Boolean(unknown)) ?? []),
+    ...(profile.error ? [unavailableEvidence('Profile setup')] : []),
+    ...(evidence.error ? [unavailableEvidence('External evidence')] : []),
+    ...(profile.isLoading || evidence.isLoading
+      ? [
+          {
+            reason: 'EVIDENCE_LOADING',
+            explanation: 'Profile and external evidence status are still loading.',
+            action: 'WAIT',
+            actionLabel: 'Loading',
+          },
+        ]
+      : []),
+    ...(collectionUnknown ? [collectionUnknown] : []),
+    ...(authoritativeUnknown ? [authoritativeUnknown] : []),
+    ...evaluationSetup(findingsSummary),
+    ...(findingsSummary === null ? [unavailableEvidence('Findings summary')] : []),
+    ...(findingsSummary === undefined
+      ? [
+          {
+            reason: 'FINDINGS_LOADING',
+            explanation: 'Findings coverage is still loading.',
+            action: 'WAIT',
+            actionLabel: 'Loading',
+          },
+        ]
+      : []),
+    ...(!snapshot
+      ? [
+          {
+            reason: 'SNAPSHOT_UNAVAILABLE',
+            explanation: 'No DNS snapshot is available for this domain yet.',
+            action: 'RUN_FRESH_SCAN',
+            actionLabel: 'Run a fresh scan',
+          },
+        ]
+      : []),
   ];
   const uniqueSetup = deduplicateSetup(setup);
+  const profileAndEvidenceReady =
+    !profile.isLoading && !profile.error && !evidence.isLoading && !evidence.error;
+  const complete = isEvidenceComplete({
+    snapshot,
+    findingsSummary,
+    setup: uniqueSetup,
+    requestsReady: profileAndEvidenceReady,
+  });
+  const findingsCount =
+    findingsSummary && Number.isFinite(findingsSummary.total) && findingsSummary.total >= 0
+      ? findingsSummary.total
+      : null;
+  const evaluationComplete = Boolean(
+    findingsSummary?.findingsEvaluated && isEvaluationComplete(findingsSummary.evaluationCoverage)
+  );
+  const findingsKnown = findingsCount !== null && evaluationComplete;
+  const findingsCopy =
+    findingsCount === null
+      ? findingsSummary === null
+        ? 'Findings unavailable; no numeric result is shown.'
+        : 'Findings are still loading; no numeric result is shown.'
+      : findingsCount === 0 && !complete
+        ? '0 observed does not establish health while evidence coverage is incomplete.'
+        : findingsCount === 0
+          ? 'No findings detected by the current evaluated ruleset.'
+          : !findingsKnown
+            ? `${findingsCount} observed finding${findingsCount === 1 ? '' : 's'}; evaluation coverage is incomplete.`
+            : `${findingsCount} current evaluated-ruleset finding${findingsCount === 1 ? '' : 's'} recorded.`;
   const observed = evidence.data?.evidence.filter(isCurrentEvidence) ?? [];
 
   return (
-    <section className="domain-evidence ds-panel" aria-labelledby={headingId}>
+    <section
+      className="domain-evidence ds-panel"
+      aria-labelledby={headingId}
+      data-state={complete ? 'complete' : 'unknown'}
+      data-testid="domain-evidence-panel"
+    >
       <header className="domain-evidence__header">
         <div>
           <p className="ds-kicker">Evidence integrity</p>
-          <h3 id={headingId}>Evidence coverage</h3>
+          <h2 id={headingId}>Evidence completeness</h2>
         </div>
-        <p>Known risk and completed evidence are separate. Unknown checks are never healthy.</p>
+        <p>Coverage and findings are separate. Unknown checks are never healthy.</p>
       </header>
+
+      <div className="domain-evidence__metrics">
+        <fieldset
+          className="domain-evidence__metric ds-panel--muted"
+          aria-labelledby={coverageHeadingId}
+          data-state={complete ? 'complete' : 'unknown'}
+          data-testid="domain-evidence-completeness"
+        >
+          <h3 id={coverageHeadingId}>Coverage</h3>
+          <dl>
+            <div>
+              <dt>Evidence completeness</dt>
+              <dd>
+                <span className={`ds-badge ds-badge--${complete ? 'success' : 'unknown'}`}>
+                  {complete ? 'Complete' : 'Needs setup/evidence'}
+                </span>
+              </dd>
+            </div>
+          </dl>
+          <p
+            className="domain-evidence__evaluation"
+            data-state={evaluationComplete ? 'complete' : 'unknown'}
+          >
+            Rule evaluation coverage: {evaluationComplete ? 'Complete' : 'UNKNOWN'}.
+          </p>
+        </fieldset>
+
+        <fieldset
+          className="domain-evidence__metric ds-panel--muted"
+          aria-labelledby={findingsHeadingId}
+          data-state={findingsKnown ? 'known' : 'unknown'}
+          data-testid="domain-evidence-findings"
+        >
+          <h3 id={findingsHeadingId}>Findings</h3>
+          <dl>
+            <div>
+              <dt>Current evaluated ruleset</dt>
+              <dd>
+                {findingsCount === null ? (
+                  <span className="ds-badge ds-badge--unknown">UNKNOWN</span>
+                ) : findingsKnown ? (
+                  <span className={`ds-badge ds-badge--${complete ? 'success' : 'unknown'}`}>
+                    {findingsCount}
+                  </span>
+                ) : (
+                  <>
+                    <span className="ds-badge ds-badge--unknown">UNKNOWN</span>
+                    <span>{findingsCount} observed</span>
+                  </>
+                )}{' '}
+                {findingsCount === null
+                  ? 'unavailable'
+                  : findingsKnown
+                    ? `finding${findingsCount === 1 ? '' : 's'}`
+                    : 'findings'}
+              </dd>
+            </div>
+          </dl>
+          <p
+            className="domain-evidence__finding-copy"
+            role={findingsSummary === null ? 'alert' : 'status'}
+          >
+            {findingsCopy}
+          </p>
+        </fieldset>
+      </div>
 
       {uniqueSetup.length > 0 ? (
         <section
           className="domain-evidence__setup ds-panel--muted"
           aria-labelledby={`${headingId}-setup`}
           data-testid="domain-needs-setup-evidence"
+          role={profile.error || evidence.error || findingsSummary === null ? 'alert' : 'status'}
         >
           <div>
             <p className="ds-kicker">Baseline and freshness</p>
-            <h4 id={`${headingId}-setup`}>Needs setup/evidence</h4>
+            <h3 id={`${headingId}-setup`}>Needs setup/evidence</h3>
           </div>
           <ul>
             {uniqueSetup.map((unknown) => (
@@ -165,6 +369,15 @@ export function DomainEvidencePanel({ domain }: { domain: string }) {
             ))}
           </ul>
         </section>
+      ) : null}
+
+      {profile.error || evidence.error ? (
+        <div className="domain-evidence__error" role="alert">
+          <p>Evidence setup status is currently unavailable.</p>
+          <Button onClick={retry} size="sm" variant="quiet">
+            Retry
+          </Button>
+        </div>
       ) : null}
 
       {profile.data?.profile ? (

--- a/apps/web/app/lib/domain-route.test.ts
+++ b/apps/web/app/lib/domain-route.test.ts
@@ -7,22 +7,23 @@ import {
 } from '../routes/domain/$domain.js';
 
 const SNAPSHOT_DATE = 'Tue, 01 Jan 2030 00:00:00 GMT';
+const originalFetch = globalThis.fetch;
 
 describe('Domain 360 request cancellation', () => {
   const fetchMock = vi.fn<typeof fetch>();
 
   beforeEach(() => {
     fetchMock.mockReset();
-    vi.stubGlobal('fetch', fetchMock);
+    globalThis.fetch = fetchMock;
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 
-  it('passes TanStack Query’s signal to both domain GET requests', async () => {
+  it('passes TanStack Query’s signal to all domain GET requests', async () => {
     const controller = new AbortController();
     fetchMock
       .mockResolvedValueOnce(
@@ -34,15 +35,32 @@ describe('Domain 360 request cancellation', () => {
         new Response(JSON.stringify([]), {
           headers: { Date: SNAPSHOT_DATE },
         })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            snapshotId: 'snapshot-1',
+            findingsEvaluated: false,
+            evaluationCoverage: { state: 'PARTIAL', errors: [] },
+            hasFindings: false,
+            severityCounts: { critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+            total: 0,
+          })
+        )
       );
 
-    await fetchDomainData('example.com', controller.signal);
+    const result = await fetchDomainData('example.com', controller.signal);
 
+    expect(result.findingsSummary?.total).toBe(0);
     expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/domain/example.com/latest', {
       credentials: 'include',
       signal: controller.signal,
     });
     expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/snapshot/snapshot-1/observations', {
+      credentials: 'include',
+      signal: controller.signal,
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/snapshot/snapshot-1/findings/summary', {
       credentials: 'include',
       signal: controller.signal,
     });
@@ -58,8 +76,41 @@ describe('Domain 360 request cancellation', () => {
     await expect(fetchDomainData('example.com', controller.signal)).rejects.toBe(abortError);
   });
 
+  it('preserves the snapshot when the findings summary is unavailable', async () => {
+    const controller = new AbortController();
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'snapshot-1' }), {
+          headers: { Date: SNAPSHOT_DATE },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          headers: { Date: SNAPSHOT_DATE },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Unavailable' }), { status: 503 })
+      );
+
+    const result = await fetchDomainData('example.com', controller.signal);
+
+    expect(result.snapshot?.id).toBe('snapshot-1');
+    expect(result.findingsSummary).toBeNull();
+  });
+
+  it('does not swallow an AbortError from the findings summary request', async () => {
+    const controller = new AbortController();
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'snapshot-1' })))
+      .mockResolvedValueOnce(new Response(JSON.stringify([])))
+      .mockRejectedValueOnce(abortError);
+
+    await expect(fetchDomainData('example.com', controller.signal)).rejects.toBe(abortError);
+  });
+
   it('sends the collection POST with its component-owned signal', async () => {
-    vi.useFakeTimers();
     const request = createCollectionRequest(1000);
     fetchMock.mockResolvedValueOnce(new Response('{}'));
 
@@ -77,11 +128,9 @@ describe('Domain 360 request cancellation', () => {
       signal: request.signal,
     });
     request.dispose();
-    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('distinguishes a deadline timeout and clears its timer after abort', async () => {
-    vi.useFakeTimers();
     const request = createCollectionRequest(25);
     fetchMock.mockImplementation(
       (_input, init) =>
@@ -99,42 +148,24 @@ describe('Domain 360 request cancellation', () => {
       name: 'TimeoutError',
       reason: 'timeout',
     });
-    await vi.advanceTimersByTimeAsync(25);
-
     await rejection;
     expect(request.signal.aborted).toBe(true);
-    expect(vi.getTimerCount()).toBe(0);
     request.dispose();
   });
 
   it('distinguishes manual aborts and clears their deadline timer', async () => {
-    vi.useFakeTimers();
     const request = createCollectionRequest(1000);
-    fetchMock.mockImplementation(
-      (_input, init) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener(
-            'abort',
-            () => reject(new DOMException('The operation was aborted.', 'AbortError')),
-            { once: true }
-          );
-        })
-    );
+    request.abort();
 
-    const pending = collectDomain('example.com', false, request);
-    const rejection = expect(pending).rejects.toMatchObject({
+    await expect(collectDomain('example.com', false, request)).rejects.toMatchObject({
       name: 'AbortError',
       reason: 'aborted',
     });
-    request.abort();
-
-    await rejection;
-    expect(vi.getTimerCount()).toBe(0);
+    expect(request.signal.aborted).toBe(true);
     request.dispose();
   });
 
   it('aborts delayed A collection before remounting for B and allows B collection', async () => {
-    vi.useFakeTimers();
     const domainA = 'domain-a.example.com';
     const domainB = 'domain-b.example.com';
     let resolveB: ((response: Response) => void) | undefined;
@@ -182,7 +213,6 @@ describe('Domain 360 request cancellation', () => {
     requestA.dispose();
     await expect(pendingA).rejects.toMatchObject({ name: 'AbortError', reason: 'unmount' });
     expect(requestA.signal.aborted).toBe(true);
-    expect(vi.getTimerCount()).toBe(0);
 
     const requestB = createCollectionRequest(1000);
     const pendingB = collectDomain(domainB, false, requestB);
@@ -191,7 +221,6 @@ describe('Domain 360 request cancellation', () => {
     resolveB(new Response('{}'));
     await pendingB;
     requestB.dispose();
-    expect(vi.getTimerCount()).toBe(0);
     expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
       body: JSON.stringify({
         domain: domainB,

--- a/apps/web/app/routes/domain/$domain.tsx
+++ b/apps/web/app/routes/domain/$domain.tsx
@@ -1,3 +1,4 @@
+import type { FindingsSummaryResponse } from '@dns-ops/contracts/responses';
 import type { Observation, Snapshot } from '@dns-ops/db/schema';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
@@ -83,10 +84,11 @@ const DOMAIN_TABS: { id: DomainTabId; label: string }[] = [
   ...(DELEGATION_ENABLED ? [{ id: 'delegation' as const, label: 'Delegation' }] : []),
 ];
 
-interface DomainData {
+export interface DomainData {
   snapshot: Snapshot | null;
   observations: Observation[];
   evidenceClock: EvidenceClock | null;
+  findingsSummary: FindingsSummaryResponse | null;
 }
 
 export const DOMAIN_COLLECTION_TIMEOUT_MS = 30_000;
@@ -244,7 +246,12 @@ export async function fetchDomainData(domain: string, signal?: AbortSignal): Pro
 
   if (!snapshotResponse.ok) {
     if (snapshotResponse.status === 404) {
-      return { snapshot: null, observations: [], evidenceClock: null };
+      return {
+        snapshot: null,
+        observations: [],
+        evidenceClock: null,
+        findingsSummary: null,
+      };
     }
     throw new Error(
       `Failed to load domain data: ${snapshotResponse.status} ${snapshotResponse.statusText}`
@@ -292,7 +299,25 @@ export async function fetchDomainData(domain: string, signal?: AbortSignal): Pro
     evidenceClock = null;
   }
 
-  return { snapshot: snap, observations, evidenceClock };
+  let findingsSummary: FindingsSummaryResponse | null = null;
+  try {
+    const summaryResponse = await fetch(`/api/snapshot/${snap.id}/findings/summary`, {
+      credentials: 'include',
+      signal,
+    });
+    throwIfAborted(signal);
+    if (summaryResponse.ok) {
+      findingsSummary = (await summaryResponse.json()) as FindingsSummaryResponse;
+      throwIfAborted(signal);
+    }
+  } catch (error) {
+    if (signal?.aborted || isAbortError(error)) throw error;
+    // A summary failure must not discard a usable snapshot, but it must stay
+    // UNKNOWN rather than becoming a fabricated zero-finding result.
+    findingsSummary = null;
+  }
+
+  return { snapshot: snap, observations, evidenceClock, findingsSummary };
 }
 
 function Domain360Page() {
@@ -316,6 +341,7 @@ function Domain360Page() {
 
   const snapshot = domainData?.snapshot ?? null;
   const observations = Array.isArray(domainData?.observations) ? domainData.observations : [];
+  const findingsSummary = domainData?.findingsSummary;
 
   const loaderError: LoaderError | undefined = error
     ? {
@@ -594,7 +620,12 @@ function Domain360Page() {
           data-testid="domain-tabpanel-overview"
         >
           {activeTab === 'overview' && (
-            <OverviewTab domain={domain} snapshot={snapshot} observations={observations} />
+            <OverviewTab
+              domain={domain}
+              snapshot={snapshot}
+              observations={observations}
+              findingsSummary={findingsSummary}
+            />
           )}
         </div>
 
@@ -657,10 +688,12 @@ function OverviewTab({
   domain,
   snapshot,
   observations,
+  findingsSummary,
 }: {
   domain: string;
   snapshot: Snapshot | null;
   observations: Observation[];
+  findingsSummary?: FindingsSummaryResponse | null;
 }) {
   const scopeHeadingId = useId();
   const metadataHeadingId = useId();
@@ -668,11 +701,15 @@ function OverviewTab({
   if (!snapshot) {
     return (
       <div className="space-y-6">
+        <DomainEvidencePanel
+          domain={domain}
+          snapshot={snapshot}
+          findingsSummary={findingsSummary}
+        />
+
         <div className="text-center py-12">
           <p className="text-gray-500">No DNS evidence available yet for {domain}.</p>
         </div>
-
-        <DomainEvidencePanel domain={domain} />
 
         <div className="space-y-4">
           <div>
@@ -698,6 +735,8 @@ function OverviewTab({
 
   return (
     <div className="space-y-6">
+      <DomainEvidencePanel domain={domain} snapshot={snapshot} findingsSummary={findingsSummary} />
+
       <div className="domain-stat-grid">
         <StatCard label="Total Queries" value={observations.length} />
         <StatCard label="Successful" value={successCount} color="green" />
@@ -707,8 +746,6 @@ function OverviewTab({
           color={errorCount > 0 ? 'red' : 'gray'}
         />
       </div>
-
-      <DomainEvidencePanel domain={domain} />
 
       {SIMULATION_ENABLED && (
         <div>

--- a/apps/web/app/styles/app.css
+++ b/apps/web/app/styles/app.css
@@ -900,10 +900,75 @@
     gap: var(--space-sm);
   }
 
-  .domain-evidence__header h3,
+  .domain-evidence__header h2,
   .domain-diff h3 {
     font-size: var(--text-xl);
     margin-block-start: var(--space-2xs);
+  }
+
+  .domain-evidence__metrics {
+    display: grid;
+    gap: var(--space-md);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .domain-evidence__metric {
+    display: grid;
+    gap: var(--space-sm);
+    min-inline-size: 0;
+    margin: 0;
+    padding: var(--space-md);
+  }
+
+  .domain-evidence__metric[data-state='complete'] {
+    border-color: var(--color-success);
+  }
+
+  .domain-evidence__metric h3 {
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    letter-spacing: -0.03em;
+    line-height: var(--leading-tight);
+    margin: 0;
+  }
+
+  .domain-evidence__metric dl {
+    display: grid;
+    gap: var(--space-sm);
+    margin: 0;
+  }
+
+  .domain-evidence__metric dl > div {
+    display: grid;
+    gap: var(--space-xs);
+    min-inline-size: 0;
+  }
+
+  .domain-evidence__metric dt {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .domain-evidence__metric dd {
+    align-items: center;
+    color: var(--color-text);
+    display: flex;
+    flex-wrap: wrap;
+    font-size: var(--text-sm);
+    gap: var(--space-xs);
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .domain-evidence__evaluation,
+  .domain-evidence__finding-copy {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    margin: 0;
+    overflow-wrap: anywhere;
   }
 
   .domain-evidence__header > p,
@@ -922,7 +987,7 @@
     padding: var(--space-md);
   }
 
-  .domain-evidence__setup h4 {
+  .domain-evidence__setup h3 {
     font-size: var(--text-lg);
     margin-block-start: var(--space-2xs);
   }
@@ -1374,6 +1439,12 @@
   .domain-360__alert,
   .domain-360__state {
     grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 40rem) {
+  .domain-evidence__metrics {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/apps/web/e2e/domain-signal-room.spec.ts
+++ b/apps/web/e2e/domain-signal-room.spec.ts
@@ -1,10 +1,27 @@
 import { expect, test } from '@playwright/test';
-import { mockDomainSnapshot, waitForDomainPageReady } from './support/domain-fixtures.js';
+import {
+  type EvidenceResponse,
+  mockDomainSnapshot,
+  type SnapshotFixture,
+  waitForDomainPageReady,
+} from './support/domain-fixtures.js';
 
 const DOMAIN = 'signal-room.example.test';
 
-async function mockSignalRoomDomain(page: import('@playwright/test').Page): Promise<void> {
-  await mockDomainSnapshot(page, { domain: DOMAIN, snapshotId: 'current-snapshot' });
+type SignalRoomOptions = {
+  snapshot?: Omit<Partial<SnapshotFixture>, 'domain' | 'snapshotId'>;
+  evidence?: EvidenceResponse['evidence'];
+};
+
+async function mockSignalRoomDomain(
+  page: import('@playwright/test').Page,
+  options: SignalRoomOptions = {}
+): Promise<void> {
+  await mockDomainSnapshot(page, {
+    domain: DOMAIN,
+    snapshotId: 'current-snapshot',
+    ...options.snapshot,
+  });
 
   await page.route(`**/api/domains/${DOMAIN}/profile`, (route) =>
     route.fulfill({
@@ -20,7 +37,7 @@ async function mockSignalRoomDomain(page: import('@playwright/test').Page): Prom
       contentType: 'application/json',
       body: JSON.stringify({
         snapshotId: 'current-snapshot',
-        evidence: [
+        evidence: options.evidence ?? [
           {
             id: 'tls-missing-baseline',
             probeType: 'tls_cert',
@@ -123,15 +140,18 @@ async function mockSignalRoomDomain(page: import('@playwright/test').Page): Prom
 }
 
 test.describe('Domain 360 Signal Room', () => {
-  test('uses semantic evidence and baseline surfaces without presenting UNKNOWN as healthy', async ({
+  test('opens with a labelled completeness region and keeps setup gaps UNKNOWN', async ({
     page,
   }) => {
     await mockSignalRoomDomain(page);
     await page.goto(`/domain/${DOMAIN}`);
     await waitForDomainPageReady(page);
 
-    const evidence = page.locator('section.domain-evidence');
-    await expect(evidence).toHaveClass(/ds-panel/);
+    const evidence = page.getByRole('region', { name: /evidence completeness/i });
+    await expect(evidence).toHaveAttribute('data-state', 'unknown');
+    await expect(
+      evidence.getByRole('heading', { name: 'Evidence completeness', level: 2 })
+    ).toBeVisible();
     await expect(page.getByTestId('domain-needs-setup-evidence')).toHaveClass(/ds-panel--muted/);
     await expect(
       page.getByTestId('domain-needs-setup-evidence').getByText('Accept baseline')
@@ -139,6 +159,101 @@ test.describe('Domain 360 Signal Room', () => {
     await expect(page.getByTestId('domain-current-evidence').getByText('Current')).toHaveClass(
       /ds-badge--success/
     );
+  });
+
+  test('keeps partial coverage plus zero findings UNKNOWN and actionable', async ({ page }) => {
+    const partialCoverage = {
+      state: 'PARTIAL' as const,
+      errors: [
+        {
+          code: 'RULE_EXECUTION_FAILED',
+          ruleId: 'dns.example',
+          message: 'Rule failed',
+          status: 'UNKNOWN',
+          unknown: {
+            reason: 'CHECK_EVALUATION_FAILED',
+            explanation: 'This check could not be evaluated.',
+            action: 'RUN_FRESH_SCAN',
+            actionLabel: 'Run a fresh scan',
+            blocking: true,
+          },
+        },
+      ],
+    };
+    await mockSignalRoomDomain(page, {
+      snapshot: {
+        evaluationCoverage: partialCoverage,
+        findingsSummary: {
+          findingsEvaluated: false,
+          evaluationCoverage: partialCoverage,
+          hasFindings: false,
+          total: 0,
+        },
+      },
+      evidence: [
+        {
+          id: 'dns-current',
+          probeType: 'dns',
+          status: 'success',
+          success: true,
+          errorMessage: null,
+          freshness: 'CURRENT',
+          probeData: { status: 'OBSERVED' },
+        },
+      ],
+    });
+    await page.goto(`/domain/${DOMAIN}`);
+    await waitForDomainPageReady(page);
+
+    const evidence = page.getByRole('region', { name: /evidence completeness/i });
+    await expect(evidence).toHaveAttribute('data-state', 'unknown');
+    await expect(evidence.getByRole('group', { name: 'Findings' })).toHaveAttribute(
+      'data-state',
+      'unknown'
+    );
+    await expect(evidence).toContainText('0 observed does not establish health');
+    await expect(evidence).toContainText('Run a fresh scan');
+  });
+
+  test('allows healthy zero findings only with complete coverage and no setup gaps', async ({
+    page,
+  }) => {
+    const completeCoverage = { state: 'COMPLETE' as const, errors: [] };
+    await mockSignalRoomDomain(page, {
+      snapshot: {
+        evaluationCoverage: completeCoverage,
+        findingsSummary: {
+          findingsEvaluated: true,
+          evaluationCoverage: completeCoverage,
+          hasFindings: false,
+          total: 0,
+        },
+      },
+      evidence: [
+        {
+          id: 'dns-current',
+          probeType: 'dns',
+          status: 'success',
+          success: true,
+          errorMessage: null,
+          freshness: 'CURRENT',
+          probeData: { status: 'OBSERVED' },
+        },
+      ],
+    });
+    await page.goto(`/domain/${DOMAIN}`);
+    await waitForDomainPageReady(page);
+
+    const evidence = page.getByRole('region', { name: /evidence completeness/i });
+    await expect(evidence).toHaveAttribute('data-state', 'complete');
+    await expect(evidence.getByRole('group', { name: 'Findings' })).toHaveAttribute(
+      'data-state',
+      'known'
+    );
+    await expect(
+      evidence.getByRole('group', { name: 'Findings' }).getByText('0', { exact: true })
+    ).toHaveClass(/ds-badge--success/);
+    await expect(evidence).toContainText('No findings detected by the current evaluated ruleset.');
   });
 
   test('keeps evidence history usable without root overflow at supported widths', async ({

--- a/apps/web/e2e/support/domain-fixtures.ts
+++ b/apps/web/e2e/support/domain-fixtures.ts
@@ -9,6 +9,19 @@
 
 import type { Page } from '@playwright/test';
 
+export interface EvaluationCoverageFixture {
+  state: 'COMPLETE' | 'PARTIAL';
+  errors: Array<Record<string, unknown>>;
+}
+
+export interface FindingsSummaryFixture {
+  findingsEvaluated?: boolean;
+  evaluationCoverage?: EvaluationCoverageFixture;
+  hasFindings?: boolean;
+  severityCounts?: Partial<Record<'critical' | 'high' | 'medium' | 'low' | 'info', number>>;
+  total?: number;
+}
+
 export interface SnapshotFixture {
   domain: string;
   snapshotId: string;
@@ -17,6 +30,8 @@ export interface SnapshotFixture {
   queriedNames?: string[];
   queriedTypes?: string[];
   vantages?: string[];
+  evaluationCoverage?: EvaluationCoverageFixture;
+  findingsSummary?: FindingsSummaryFixture;
 }
 
 export interface DelegationFixture {
@@ -34,8 +49,30 @@ export interface MailFixture {
  * Must be called BEFORE page.goto().
  */
 export async function mockDomainSnapshot(page: Page, fixture: SnapshotFixture): Promise<void> {
-  const { domain, snapshotId, zoneManagement, resultState, queriedNames, queriedTypes, vantages } =
-    fixture;
+  const {
+    domain,
+    snapshotId,
+    zoneManagement,
+    resultState,
+    queriedNames,
+    queriedTypes,
+    vantages,
+    evaluationCoverage,
+    findingsSummary,
+  } = fixture;
+  const coverage =
+    findingsSummary?.evaluationCoverage ||
+    evaluationCoverage ||
+    ({ state: 'COMPLETE', errors: [] } satisfies EvaluationCoverageFixture);
+  const total = findingsSummary?.total ?? 0;
+  const severityCounts = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+    ...findingsSummary?.severityCounts,
+  };
 
   await page.route(`**/api/domain/${domain}/latest`, (route) => {
     route.fulfill({
@@ -46,6 +83,8 @@ export async function mockDomainSnapshot(page: Page, fixture: SnapshotFixture): 
         domainId: `dom-${snapshotId}`,
         zoneManagement: zoneManagement ?? 'unmanaged',
         resultState: resultState ?? 'complete',
+        rulesetVersionId: `ruleset-${snapshotId}`,
+        metadata: { evaluation: coverage },
         createdAt: new Date().toISOString(),
         queriedNames: queriedNames ?? [domain],
         queriedTypes: queriedTypes ?? ['A', 'NS', 'SOA'],
@@ -59,6 +98,21 @@ export async function mockDomainSnapshot(page: Page, fixture: SnapshotFixture): 
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify([]),
+    });
+  });
+
+  await page.route(`**/api/snapshot/${snapshotId}/findings/summary`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        snapshotId,
+        findingsEvaluated: findingsSummary?.findingsEvaluated ?? coverage.state === 'COMPLETE',
+        evaluationCoverage: coverage,
+        hasFindings: findingsSummary?.hasFindings ?? total > 0,
+        severityCounts,
+        total,
+      }),
     });
   });
 }

--- a/apps/web/hono/routes/findings.runtime.test.ts
+++ b/apps/web/hono/routes/findings.runtime.test.ts
@@ -387,22 +387,32 @@ describe('findingsRoutes runtime', () => {
   describe('GET /snapshot/:snapshotId/findings/summary', () => {
     it('returns severity counts for a snapshot', async () => {
       const state = makeState({
+        snapshots: [
+          {
+            ...makeState().snapshots[0],
+            rulesetVersionId: 'ruleset-current',
+            metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+          },
+        ],
         findings: [
           {
             id: 'f1',
             snapshotId: 'snap-1',
+            rulesetVersionId: 'ruleset-current',
             severity: 'high',
             type: 'dns.authoritative-failure',
           },
           {
             id: 'f2',
             snapshotId: 'snap-1',
+            rulesetVersionId: 'ruleset-current',
             severity: 'medium',
             type: 'mail.no-mx-record',
           },
           {
             id: 'f3',
             snapshotId: 'snap-1',
+            rulesetVersionId: 'ruleset-current',
             severity: 'high',
             type: 'dns.recursive-mismatch',
           },
@@ -415,12 +425,19 @@ describe('findingsRoutes runtime', () => {
       expect(response.status).toBe(200);
       const json = (await response.json()) as {
         snapshotId: string;
+        findingsEvaluated: boolean;
+        evaluationCoverage: { state: string };
         hasFindings: boolean;
+        severityCounts: Record<string, number>;
         total: number;
       };
       expect(json.snapshotId).toBe('snap-1');
+      expect(json.findingsEvaluated).toBe(true);
+      expect(json.evaluationCoverage.state).toBe('COMPLETE');
       expect(json.hasFindings).toBe(true);
-      expect(json.total).toBeGreaterThan(0);
+      expect(json.severityCounts.high).toBe(2);
+      expect(json.severityCounts.medium).toBe(1);
+      expect(json.total).toBe(3);
     });
 
     it('returns empty summary for snapshot with no findings', async () => {
@@ -431,9 +448,152 @@ describe('findingsRoutes runtime', () => {
 
       expect(response.status).toBe(200);
       const json = (await response.json()) as {
+        findingsEvaluated: boolean;
+        evaluationCoverage: { state: string };
         hasFindings: boolean;
         total: number;
       };
+      expect(json.findingsEvaluated).toBe(false);
+      expect(json.evaluationCoverage.state).toBe('PARTIAL');
+      expect(json.hasFindings).toBe(false);
+      expect(json.total).toBe(0);
+    });
+
+    it('keeps a missing ruleset UNKNOWN even with complete-looking metadata', async () => {
+      const state = makeState({
+        snapshots: [
+          {
+            ...makeState().snapshots[0],
+            rulesetVersionId: null,
+            metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+          },
+        ],
+      });
+      const app = createApp(state);
+
+      const response = await app.request('/api/snapshot/snap-1/findings/summary');
+
+      expect(response.status).toBe(200);
+      const json = (await response.json()) as {
+        findingsEvaluated: boolean;
+        evaluationCoverage: { state: string };
+        total: number;
+      };
+      expect(json.findingsEvaluated).toBe(false);
+      expect(json.evaluationCoverage.state).toBe('PARTIAL');
+      expect(json.total).toBe(0);
+    });
+
+    it('keeps zero findings UNKNOWN when evaluation coverage is partial', async () => {
+      const state = makeState({
+        snapshots: [
+          {
+            ...makeState().snapshots[0],
+            rulesetVersionId: 'ruleset-current',
+            metadata: {
+              evaluation: {
+                state: 'PARTIAL',
+                errors: [
+                  {
+                    code: 'RULE_EXECUTION_FAILED',
+                    ruleId: 'dns.example',
+                    message: 'Rule failed',
+                    status: 'UNKNOWN',
+                    unknown: {
+                      reason: 'CHECK_EVALUATION_FAILED',
+                      explanation: 'This check could not be evaluated.',
+                      action: 'RUN_FRESH_SCAN',
+                      actionLabel: 'Run a fresh scan',
+                      blocking: true,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+      const app = createApp(state);
+
+      const response = await app.request('/api/snapshot/snap-1/findings/summary');
+
+      expect(response.status).toBe(200);
+      const json = (await response.json()) as {
+        findingsEvaluated: boolean;
+        evaluationCoverage: { state: string; errors: unknown[] };
+        hasFindings: boolean;
+        total: number;
+      };
+      expect(json.findingsEvaluated).toBe(false);
+      expect(json.evaluationCoverage.state).toBe('PARTIAL');
+      expect(json.evaluationCoverage.errors).toHaveLength(1);
+      expect(json.hasFindings).toBe(false);
+      expect(json.total).toBe(0);
+    });
+
+    it('counts only findings from the snapshot ruleset version', async () => {
+      const state = makeState({
+        snapshots: [
+          {
+            ...makeState().snapshots[0],
+            rulesetVersionId: 'ruleset-current',
+            metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+          },
+        ],
+        findings: [
+          {
+            id: 'old-finding',
+            snapshotId: 'snap-1',
+            rulesetVersionId: 'ruleset-old',
+            severity: 'critical',
+            type: 'dns.old-rule',
+          },
+          {
+            id: 'current-finding',
+            snapshotId: 'snap-1',
+            rulesetVersionId: 'ruleset-current',
+            severity: 'high',
+            type: 'dns.current-rule',
+          },
+        ],
+      });
+      const app = createApp(state);
+
+      const response = await app.request('/api/snapshot/snap-1/findings/summary');
+
+      expect(response.status).toBe(200);
+      const json = (await response.json()) as {
+        hasFindings: boolean;
+        severityCounts: Record<string, number>;
+        total: number;
+      };
+      expect(json.hasFindings).toBe(true);
+      expect(json.severityCounts.critical).toBe(0);
+      expect(json.severityCounts.high).toBe(1);
+      expect(json.total).toBe(1);
+    });
+
+    it('allows an explicitly complete zero-finding result', async () => {
+      const state = makeState({
+        snapshots: [
+          {
+            ...makeState().snapshots[0],
+            rulesetVersionId: 'ruleset-current',
+            metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
+          },
+        ],
+      });
+      const app = createApp(state);
+
+      const response = await app.request('/api/snapshot/snap-1/findings/summary');
+
+      expect(response.status).toBe(200);
+      const json = (await response.json()) as {
+        findingsEvaluated: boolean;
+        hasFindings: boolean;
+        total: number;
+      };
+      expect(json.findingsEvaluated).toBe(true);
       expect(json.hasFindings).toBe(false);
       expect(json.total).toBe(0);
     });

--- a/apps/web/hono/routes/findings.ts
+++ b/apps/web/hono/routes/findings.ts
@@ -5,7 +5,11 @@
  * Includes DNS rules and Mail rules with database persistence.
  */
 
-import { evaluationCoverageOrUnknown } from '@dns-ops/contracts';
+import {
+  evaluationCoverageOrUnknown,
+  isEvaluationComplete,
+  type Severity,
+} from '@dns-ops/contracts';
 import type { NewFinding, NewSuggestion } from '@dns-ops/db';
 import {
   DkimSelectorRepository,
@@ -585,14 +589,32 @@ findingsRoutes.get('/snapshot/:snapshotId/findings/summary', requireAuth, async 
     }
 
     const findingRepo = new FindingRepository(db);
-    const severityCounts = await findingRepo.countBySeverity(snapshotId);
-    const hasFindings = await findingRepo.hasFindings(snapshotId);
+    const currentFindings = snapshot.rulesetVersionId
+      ? await findingRepo.findBySnapshotIdAndRulesetVersionId(snapshotId, snapshot.rulesetVersionId)
+      : [];
+    const severityCounts: Record<Severity, number> = {
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+    };
+
+    for (const finding of currentFindings) {
+      severityCounts[finding.severity] += 1;
+    }
+
+    const evaluationCoverage = snapshot.rulesetVersionId
+      ? evaluationCoverageOrUnknown(snapshot.metadata?.evaluation)
+      : evaluationCoverageOrUnknown(undefined);
 
     return c.json({
       snapshotId,
-      hasFindings,
+      findingsEvaluated: isEvaluationComplete(evaluationCoverage),
+      evaluationCoverage,
+      hasFindings: currentFindings.length > 0,
       severityCounts,
-      total: Object.values(severityCounts).reduce((a, b) => a + b, 0),
+      total: currentFindings.length,
     });
   } catch (error) {
     const logger = getWebLogger();

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -11,6 +11,10 @@
     "./enums": {
       "import": "./dist/enums.js",
       "types": "./dist/enums.d.ts"
+    },
+    "./responses": {
+      "import": "./dist/responses.js",
+      "types": "./dist/responses.d.ts"
     }
   },
   "scripts": {

--- a/packages/contracts/src/responses.ts
+++ b/packages/contracts/src/responses.ts
@@ -325,6 +325,8 @@ export interface FindingsMailResponse {
  */
 export interface FindingsSummaryResponse {
   snapshotId: string;
+  findingsEvaluated: boolean;
+  evaluationCoverage: EvaluationCoverage;
   hasFindings: boolean;
   severityCounts: Record<Severity, number>;
   total: number;

--- a/verification/receipts/20260903-204539Z-488058f-issue58-domain-overview-e2e--domain.overview.md
+++ b/verification/receipts/20260903-204539Z-488058f-issue58-domain-overview-e2e--domain.overview.md
@@ -1,0 +1,38 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-204539Z-488058f-issue58-domain-overview-e2e
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 488058f9ac441e6e0fd0ea417ff549992259594d
+code_digest: 852936205f106b2e1441b679e7cbb51644d8b41ec2006e5efbb8d1b99b2d656d
+dirty: true
+untracked: 0
+status: blocked
+reason: "UI/route behavior proven on the real dev server via canonical Playwright specs (domain-signal-room 4/4, domain-states 18/18, finding-simulation 4/4) and 1033 unit tests, but the persisted-evidence DNS TTL audit and findings-summary read-back against freshly collected public-recursive evidence were not re-driven: the only reachable local DB holds fixture snapshots, and the session ended before a live collection drive per orchestrator guidance."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-204539Z-488058f-issue58-domain-overview-e2e
+created_at: 2026-09-03T20:46:04.003Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-204539Z-488058f-issue58-domain-overview-e2e/env.txt | env | aux | 043949f6ced4aae38bf529e0004249f06a2be97047e5280f044921f52bfca1fe |
+| verification/runs/20260903-204539Z-488058f-issue58-domain-overview-e2e/observations.md | md | aux · unrecognized .md | 3d1ad11f8fab820f84f7575d62e1225c6045eb9d422bd4e716105f00501e9dd6 |

--- a/verification/receipts/20260903-214621Z-02a1aa7-fresh--auth.api-principal.md
+++ b/verification/receipts/20260903-214621Z-02a1aa7-fresh--auth.api-principal.md
@@ -1,0 +1,144 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-214621Z-02a1aa7-fresh
+feature_id: auth.api-principal
+profile: critical
+surface: api
+sha: 02a1aa739ad8c82a20f0380f7b75a1382c302a40
+code_digest: 852936205f106b2e1441b679e7cbb51644d8b41ec2006e5efbb8d1b99b2d656d
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260903-214621Z-02a1aa7-fresh
+created_at: 2026-09-03T22:05:15.689Z
+---
+
+# Receipt: auth.api-principal — passed
+
+## Observations (expected → seen)
+
+- Valid opaque principal token → accepted by both services. Web `GET /api/auth/me` returned HTTP 200 with `authenticated:true`, `tenant:"11111111-1111-4111-8111-111111111111"`, and `email:"fresh-actor@dns-ops.local"`. Collector `GET /api/monitoring/reports/shared` returned HTTP 500 (`Failed to generate report`) rather than 401 because its configured database was intentionally unreachable; this is authenticated-path behavior.
+- `X-Tenant-Id`/`X-Actor-Id` override attempt with the valid token → principal identity unchanged on web (same tenant and actor); collector remained non-401 (HTTP 500).
+- Unknown token, disabled principal, forged legacy credential with legacy flag false, and legacy credentials with missing/extra fields → HTTP 401 on both web and collector.
+- Legacy flag literal `true` with exactly `tenant-x:actor-x:secret` → accepted by both services (web HTTP 200 with actor `actor-x`; collector HTTP 500 non-401). Missing or extra colon-separated fields remained HTTP 401.
+- Malformed `API_PRINCIPALS_JSON` with legacy enabled → production middleware route-boundary requests returned HTTP 401 for both opaque and legacy credentials, with no fallback. Live server startup additionally rejected the malformed configuration: collector refused to listen and web returned 503 while reporting environment validation failure.
+
+## Forbidden (raw credentials → confirmed absent)
+
+- Raw opaque token and shared secret are absent from all captured HTTP/read-back artifacts and service logs. Auth logs contain only generic invalid-key/configuration messages; no tenant/actor override was honored.
+
+## Read-back
+
+- Independent web read-back is `readback/api-principal-web-identity.json`, recording the stored principal tenant/actor returned by `GET /api/auth/me`.
+- Collector accepted-path read-back is `readback/api-principal-collector-auth.json` (HTTP 500 proves middleware passed auth before the database-backed handler).
+- Malformed-config route-boundary read-backs are `readback/web-malformed-route-boundary.txt` and `readback/collector-malformed-route-boundary.txt`, each recording 401 for both credential forms.
+- Doctor evidence: `doctor.txt` (web healthy, collector liveness healthy, readiness accepted).
+- Targeted contract/auth/config tests: `targeted-tests.txt` (6 files, 136 tests passed).
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-214621Z-02a1aa7-fresh/auth-drive.log | log | aux · unrecognized .log | 32a9e14c73a916270a0cc6890a6f29b21f67f994556c97b0f79d33d618215e62 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector-final.log | log | aux · unrecognized .log | 986e0c441d2a44e2002c771e0a1dca0944fd33928b9d9135ad7746d46ea1ea10 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector-final.pid | pid | aux · unrecognized .pid | b5c8dd4a4024d65ad5987f935ac702bdc32551045dfed6587dc7bd22aefe0967 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector-healthz.json | json | aux · unrecognized .json | e1ad2aa12a2d620b3cab7b2210e4027ec055f87e039b7fb1d1293394ced72872 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector-legacy.log | log | aux · unrecognized .log | 0965609a62f507538b49056fcedfc7034e09a986096e8f8bd5af13f8161245f8 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector-legacy.pid | pid | aux · unrecognized .pid | c6fa63adabccfe964c4a660a1c9a2c875f670a837ac5311a50c0041f31264170 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector-malformed.log | log | aux · unrecognized .log | 8f7ea59f7b07385b0aa4d32afa9c79217534e523965805d94b4f3c82b62531b9 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector-malformed.pid | pid | aux · unrecognized .pid | 2a4f2fd857c063e1a3fa0694a670e258c8465e400a1b651c7c6ff7e478dde4e7 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector.log | log | aux · unrecognized .log | a3513131eb23cdd16e90f1e95e1eb96bd1139f8823e4934e13a43264b3a5fd7f |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/collector.pid | pid | aux · unrecognized .pid | 47335bf114fd264db89190ead6adf03779a00947954fcc0856fa1288c4799abf |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/doctor.txt | txt | aux · unrecognized .txt | a912c2353c5e9b993b5c1254fd1c0e609ebd4c159750bebcb0a91801f3924a62 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/env.txt | env | aux | 27cc26f5f643bfc6b062fc4e1151f2264e758bb33c5397e143ea5071c550ac24 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/01-principals-valid-web.body | body | aux · unrecognized .body | 0bcfe54584aeb9f4c532a6bdfd28a722985def753a29155a3638b2b6275a8728 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/01-principals-valid-web.headers | headers | aux · unrecognized .headers | cfaeada085ac3cda6e520accef47d7effb2b129dfa7447b03ce08002692ec40e |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/01-principals-valid-web.json | http | evidence | 57f64794d49f6204e0fd30d6a74af33bea4839a080e1ede7d2820c00ed9aff16 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/02-principals-valid-web-override.body | body | aux · unrecognized .body | 0bcfe54584aeb9f4c532a6bdfd28a722985def753a29155a3638b2b6275a8728 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/02-principals-valid-web-override.headers | headers | aux · unrecognized .headers | cfaeada085ac3cda6e520accef47d7effb2b129dfa7447b03ce08002692ec40e |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/02-principals-valid-web-override.json | http | evidence | 57f64794d49f6204e0fd30d6a74af33bea4839a080e1ede7d2820c00ed9aff16 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/03-unknown-web.body | body | aux · unrecognized .body | 3e58c6fcf10a31770582814c2babfd1ff71bb1a72cae32cdb1c1a428f406d47f |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/03-unknown-web.headers | headers | aux · unrecognized .headers | d26574cdb66bcc826a22f82158930d94527e6b4ecf806e206e65d267995f7a94 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/03-unknown-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/04-legacy-off-web.body | body | aux · unrecognized .body | 3e58c6fcf10a31770582814c2babfd1ff71bb1a72cae32cdb1c1a428f406d47f |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/04-legacy-off-web.headers | headers | aux · unrecognized .headers | d26574cdb66bcc826a22f82158930d94527e6b4ecf806e206e65d267995f7a94 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/04-legacy-off-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/05-principals-valid-collector.body | body | aux · unrecognized .body | 0342ab48eab64e6565fbac96afeb010bf4c5335134b894627051c71b7e449251 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/05-principals-valid-collector.headers | headers | aux · unrecognized .headers | d1cc3f5f1874447d26a22235030a261a128bae91beaaf5eb6c4f7c99fd647aef |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/05-principals-valid-collector.json | http | evidence | 07df03b0fd3711ddfb8a62579d91b67c78fb9454bdc16704ca38e35ad2b05596 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/06-principals-valid-collector-override.body | body | aux · unrecognized .body | 0342ab48eab64e6565fbac96afeb010bf4c5335134b894627051c71b7e449251 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/06-principals-valid-collector-override.headers | headers | aux · unrecognized .headers | 2043cc6efac0d9fa92885e8c91394e5cb61d37da3f1a38f232760c47a9e79e49 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/06-principals-valid-collector-override.json | http | evidence | 07df03b0fd3711ddfb8a62579d91b67c78fb9454bdc16704ca38e35ad2b05596 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/07-unknown-collector.body | body | aux · unrecognized .body | 1bbd536e8cd3a949f3bf428736f4fd1ecf56e0436f0e8b7a119bd92d27fa3045 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/07-unknown-collector.headers | headers | aux · unrecognized .headers | 6c94fe6c4ff535999c8b98e851d98e8e4fc126eb6f58c10694ff6d8fc6655281 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/07-unknown-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/08-legacy-off-collector.body | body | aux · unrecognized .body | 1bbd536e8cd3a949f3bf428736f4fd1ecf56e0436f0e8b7a119bd92d27fa3045 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/08-legacy-off-collector.headers | headers | aux · unrecognized .headers | 21c190d77b94ee08f22c23845abebf5c33b5c7d1204ca5ac2d3eafdad06080e0 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/08-legacy-off-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/09-legacy-valid-web.body | body | aux · unrecognized .body | 1748ac9c73c4ef50d44a16015fe221370d0fdc95b79b1d85043fc1d63fed3cc2 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/09-legacy-valid-web.headers | headers | aux · unrecognized .headers | e6692a9f32a957248606f1440627a7acd63f42ec18f979c706208e1b7f4d71ed |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/09-legacy-valid-web.json | http | evidence | d5cd065fc4ac62e44de5441b93ba1b444297e0b023baf6dbc01a5fe8ff0a5db6 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/10-legacy-extra-web.body | body | aux · unrecognized .body | 3e58c6fcf10a31770582814c2babfd1ff71bb1a72cae32cdb1c1a428f406d47f |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/10-legacy-extra-web.headers | headers | aux · unrecognized .headers | 56622b3b0ad248ff66f302876b2d1f8796b9589ca58b0261c8b467b53d34b5bf |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/10-legacy-extra-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/11-legacy-missing-web.body | body | aux · unrecognized .body | 3e58c6fcf10a31770582814c2babfd1ff71bb1a72cae32cdb1c1a428f406d47f |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/11-legacy-missing-web.headers | headers | aux · unrecognized .headers | 56622b3b0ad248ff66f302876b2d1f8796b9589ca58b0261c8b467b53d34b5bf |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/11-legacy-missing-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/12-legacy-valid-collector.body | body | aux · unrecognized .body | 0342ab48eab64e6565fbac96afeb010bf4c5335134b894627051c71b7e449251 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/12-legacy-valid-collector.headers | headers | aux · unrecognized .headers | ca6b97a5b25435b328bb04699ef89eb54cf541a04d0374b35a51aa9e687cdf56 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/12-legacy-valid-collector.json | http | evidence | 07df03b0fd3711ddfb8a62579d91b67c78fb9454bdc16704ca38e35ad2b05596 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/13-legacy-extra-collector.body | body | aux · unrecognized .body | 1bbd536e8cd3a949f3bf428736f4fd1ecf56e0436f0e8b7a119bd92d27fa3045 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/13-legacy-extra-collector.headers | headers | aux · unrecognized .headers | cfad252b7fcfb16c683cc634c3635a26597476e7e66d922afbdfa5bcf892b96f |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/13-legacy-extra-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/14-legacy-missing-collector.body | body | aux · unrecognized .body | 1bbd536e8cd3a949f3bf428736f4fd1ecf56e0436f0e8b7a119bd92d27fa3045 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/14-legacy-missing-collector.headers | headers | aux · unrecognized .headers | e1afc4c7081fe711934a58e101a3cf7276512496d1d003d8597c5ca54306cebf |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/14-legacy-missing-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/15-legacy-case-web.body | body | aux · unrecognized .body | b35a7d39b0c46c4c6670b31ce23b45d68c0e8960860df654666014fcc5a25238 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/15-legacy-case-web.headers | headers | aux · unrecognized .headers | 7dc1b483021196088707737f76edadea357a707f47b90267c521c8132414a40f |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/15-legacy-case-web.json | http | evidence | 0662f3fd1339318990650ca4606df941438bf663b4836516ea93ba7aaa40fdaf |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/17-disabled-web.body | body | aux · unrecognized .body | 3e58c6fcf10a31770582814c2babfd1ff71bb1a72cae32cdb1c1a428f406d47f |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/17-disabled-web.headers | headers | aux · unrecognized .headers | 9cc4be53105ec627f872cedf4df4e3ac46b2930b42904b573781253540985b0a |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/17-disabled-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/18-disabled-collector.body | body | aux · unrecognized .body | 1bbd536e8cd3a949f3bf428736f4fd1ecf56e0436f0e8b7a119bd92d27fa3045 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/18-disabled-collector.headers | headers | aux · unrecognized .headers | fc1c99d9affc639eef1674a2661fff28396a93dff6a79f6c2884727d75055c31 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/18-disabled-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/19-malformed-valid-web.body | body | aux · unrecognized .body | b35a7d39b0c46c4c6670b31ce23b45d68c0e8960860df654666014fcc5a25238 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/19-malformed-valid-web.headers | headers | aux · unrecognized .headers | 8e547a0e9574bd947882e3e3c605956d7c9a720bf7310fdf0ca9f770d272e1b5 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/19-malformed-valid-web.json | http | evidence | 0662f3fd1339318990650ca4606df941438bf663b4836516ea93ba7aaa40fdaf |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/20-malformed-legacy-web.body | body | aux · unrecognized .body | b35a7d39b0c46c4c6670b31ce23b45d68c0e8960860df654666014fcc5a25238 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/20-malformed-legacy-web.headers | headers | aux · unrecognized .headers | 8e547a0e9574bd947882e3e3c605956d7c9a720bf7310fdf0ca9f770d272e1b5 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/20-malformed-legacy-web.json | http | evidence | 0662f3fd1339318990650ca4606df941438bf663b4836516ea93ba7aaa40fdaf |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-01-valid-web.json | http | evidence | 57f64794d49f6204e0fd30d6a74af33bea4839a080e1ede7d2820c00ed9aff16 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-02-valid-web-override.json | http | evidence | 57f64794d49f6204e0fd30d6a74af33bea4839a080e1ede7d2820c00ed9aff16 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-03-unknown-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-04-legacy-off-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-05-valid-collector.json | http | evidence | 07df03b0fd3711ddfb8a62579d91b67c78fb9454bdc16704ca38e35ad2b05596 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-06-valid-collector-override.json | http | evidence | 07df03b0fd3711ddfb8a62579d91b67c78fb9454bdc16704ca38e35ad2b05596 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-07-unknown-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-08-legacy-off-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-09-legacy-valid-web.json | http | evidence | d5cd065fc4ac62e44de5441b93ba1b444297e0b023baf6dbc01a5fe8ff0a5db6 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-10-legacy-extra-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-11-legacy-missing-web.json | http | evidence | 20317543b610aefab4822b40f32b1676435485b54062601741ff7536cc252c38 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-12-legacy-valid-collector.json | http | evidence | 07df03b0fd3711ddfb8a62579d91b67c78fb9454bdc16704ca38e35ad2b05596 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-13-legacy-extra-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/http/auth-14-legacy-missing-collector.json | http | evidence | 9267d6ddc043b5e210e6ddd9f8d4333cde2bc786eec27372a148e6e2585c2c95 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/observations.md | md | aux · unrecognized .md | c2bbae8363bb9e7563d0b994a2ba469c7300bb7500663b5dc116cd61a4dc7423 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/readback/api-principal-collector-auth.json | readback | evidence | 07df03b0fd3711ddfb8a62579d91b67c78fb9454bdc16704ca38e35ad2b05596 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/readback/api-principal-web-identity.json | readback | evidence | 57f64794d49f6204e0fd30d6a74af33bea4839a080e1ede7d2820c00ed9aff16 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/readback/collector-malformed-route-boundary.txt | txt | aux · unrecognized .txt | 316c238a91d3e7f5ea3ded14c51cb1c31b4135664ad881a8a4216225ecc37bb7 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/readback/collector-malformed-startup.log | log | aux · unrecognized .log | 44fe9826cb32ea727d43af85357178ef4ebfd54f4013734d9106dafbb17f0f23 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/readback/web-malformed-route-boundary.txt | txt | aux · unrecognized .txt | 0945c9322bd04d9132d537af982431237ef5cbcef644e85c5718d87666ffb9b7 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/readback/web-malformed-startup.log | log | aux · unrecognized .log | 90ec36b581d1546c58166f1f069052c5d57a2b0234fec72f058b855768274242 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/targeted-tests.txt | txt | aux · unrecognized .txt | c6df7f3f8322994d17079dd6a16fcce48f20ee46387d3586bf45909b71b0b3ee |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web-final.log | log | aux · unrecognized .log | 484cce77f7df382b49aacf47fcf305c7b72bc52245c704c28e1024bb95db4de3 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web-final.pid | pid | aux · unrecognized .pid | b51e6adf829307740d16fcd0e40969eb25a4efad57e4c915b884195ce6fc79da |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web-health.json | json | aux · unrecognized .json | 056925601c560472cf56d8d6f917bb8f2ec76e3b9c335d3dbda71f947b1c95dd |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web-legacy.log | log | aux · unrecognized .log | 0f35e8c4f77767e01b36c39fd96c7d18e6f566da16527022bbc71dda3d802744 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web-legacy.pid | pid | aux · unrecognized .pid | 7a0cbf3b3caf6a1ddb13c8d5e53caa21bc3caebfcf15fb5f5df0bf0ee221c0aa |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web-malformed.log | log | aux · unrecognized .log | 90ec36b581d1546c58166f1f069052c5d57a2b0234fec72f058b855768274242 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web-malformed.pid | pid | aux · unrecognized .pid | ff74566b8c43519b3aa1a958248f43fbe96a42efa814cdb9fcd8a18909de06aa |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web.log | log | aux · unrecognized .log | e20a87ff829b9ab8fe4d59c84fdefaf78c106d4908450da2950722aeb0ff3c48 |
+| verification/runs/20260903-214621Z-02a1aa7-fresh/web.pid | pid | aux · unrecognized .pid | d6405b8b5e8ef9891cb80fba2b9c2b6528d6a8b48fe2ecc3ea45ed699d3cf9a7 |

--- a/verification/receipts/20260903-220615Z-02a1aa7-fresh--fleet.reports.md
+++ b/verification/receipts/20260903-220615Z-02a1aa7-fresh--fleet.reports.md
@@ -1,0 +1,89 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-220615Z-02a1aa7-fresh
+feature_id: fleet.reports
+profile: critical
+surface: web
+sha: 02a1aa739ad8c82a20f0380f7b75a1382c302a40
+code_digest: 852936205f106b2e1441b679e7cbb51644d8b41ec2006e5efbb8d1b99b2d656d
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260903-220615Z-02a1aa7-fresh
+created_at: 2026-09-03T22:19:33.546Z
+---
+
+# Receipt: fleet.reports — passed
+
+## Observations (expected → seen)
+- Launch/doctor: web `/api/health` returned HTTP 200 `{"status":"healthy"}` and collector `/healthz` returned HTTP 200 `{"status":"ok"}`. Both processes were launched from this worktree at the exact requested SHA.
+- Portfolio UI with local tenant headers (`X-Dev-Tenant: dns-ops-e2e`, `X-Dev-Actor: e2e-bot`) rendered the `Fleet Reports` heading and all three template cards. With `stale.example` and Mail Security Baseline, the report rendered `Unknown` aggregate text, `Unknown checks`, and `No SPF evidence persisted for this snapshot`. Four check badges had title=`unknown`, text=`?`, class=`ds-badge ds-badge--unknown`; no pass badge was present. Evidence: `fleet-panel.png`, `fleet-details-unknown.png`, `readback/ui-state.json`.
+- UI CSV import via the real hidden file input with a `domain` column returned HTTP 200 and populated Domain Inventory with `stale.example\ninvalid\nfoo.example` (duplicate `stale.example` removed). Evidence: `fleet-csv-import.png`, `readback/csv-import.json`.
+- API `POST /api/fleet-report/run` for `stale.example` (current e60 database; latest snapshot has null evaluation coverage) returned HTTP 200, `checks[].status=unknown` for SPF/DMARC/DKIM/MX, `summary.unknownChecks=4`, `summary.domainsWithIssues=0`, and `pass=0` for each check. API evidence: `http-stale.example.json` (current e60 response); UI/API initial response is also retained in `http-fleet-run.json`.
+- API `clean.example` returned `spf.status=pass`, severity `info`, `findingsCount=1`, `summary.spfStats.pass=1`, with snapshot `20000000-0000-4000-8000-000000000004`. API `broken.example` returned `spf.status=fail`, severity `high`, `findingsCount=1`, `summary.spfStats.fail=1`, `domainsWithIssues=1`, and one high-priority issue. Evidence: `http-clean.example.json`, `adversarial/duplicate-1.txt`.
+- UI report for `clean.example` + `broken.example` displayed both `SPF present` and `Missing SPF`; one pass badge and one fail badge were visible (plus unknown badges for other requested mail checks). Evidence: `fleet-details-affirmative.png`, `readback/ui-affirmative.json`.
+
+## Forbidden (… → confirmed absent)
+- False green without persisted correlated evidence → absent: stale, null-ruleset, and uncorrelated fixtures all returned unknown and `findingsCount=0`; no pass badge appeared for the stale UI flow.
+- Null-ruleset snapshot treated as pass → absent: `never-evaluated.example` returned `rulesetVersion=null`, `status=unknown`, `summary.unknownChecks=1` (`http-never-evaluated.example.json`).
+- Uncorrelated evidence treated as pass → absent: `uncorrelated.example` returned unknown (`http-uncorrelated.example.json`).
+- Unknown-only domain counted as an issue → absent: stale response had `domainsWithIssues=0`; missing domain produced an explicit error rather than a pass (`adversarial/no-snapshot-domain.txt`).
+- Provider mutation or report persistence → absent; reports are read-only and the persisted fixture read-back remained unchanged.
+- Fixed sleeps and class selectors → absent from the user flow; semantic roles/labels and state/title attributes were used.
+
+## Adversarial pass
+- Duplicate report submissions returned identical snapshot/finding/status payloads on both HTTP 200 responses (`adversarial/duplicate-1.txt`, `duplicate-2.txt`).
+- Different tenant headers could not read the fixture domain: HTTP 200 had `domainsChecked=0`, `domainsWithErrors=1`, and `Domain not in database` (`adversarial/other-tenant.txt`).
+- Malformed run input returned HTTP 400 with `Inventory required` and malformed CSV without a `domain` column returned HTTP 400 (`adversarial/malformed-run.txt`, `malformed-csv.txt`).
+- Unauthenticated run returned HTTP 401 `Authentication required` (`adversarial/unauthenticated.txt`).
+
+## Read-back
+- Independent Postgres read-back on port 55441/database `dns_ops_e60` shows the tenant UUID `54fdf5c4-8513-5d7b-aee5-a1f7fb91ac7f`, complete snapshots/ruleset IDs for clean and broken, null evaluation/ruleset for never-evaluated, null evaluation for stale, and a foreign observation ID for uncorrelated. Evidence: `readback/persisted-fleet-fixtures.json`, `readback/finding-correlation.json`.
+- Correlation read-back: clean and broken each have one finding whose evidence observation belongs to its snapshot (`matching_observations=1`); uncorrelated has `matching_observations=0`. The route's clean pass and broken fail responses match these persisted rows.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-220615Z-02a1aa7-fresh/adversarial/duplicate-1.txt | txt | aux · unrecognized .txt | 99fb1da0532fe211340e3e519927f904a0b6b374b8f74d63b220e0baba751e92 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/adversarial/duplicate-2.txt | txt | aux · unrecognized .txt | 29b173a48e86b665c4a48f1b22a1e7a3073628feea3c044489826c5ddecc1067 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/adversarial/malformed-csv.txt | txt | aux · unrecognized .txt | 27651faaf8dc76b4a9fced09e1824ea3faf0e81338e8a3cbe345cdb55d9e6971 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/adversarial/malformed-run.txt | txt | aux · unrecognized .txt | 556442fd00f3ff2062657137e6332172fb47a6c7fed4ccf0575afd846dd5c7e5 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/adversarial/no-snapshot-domain.txt | txt | aux · unrecognized .txt | 9731bb106bbdaa4fbf50f17527b5c1ed8f7711d59326fe888eab8700529e5654 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/adversarial/other-tenant.txt | txt | aux · unrecognized .txt | 191d19f343d942bbc650bbf1d3fe7c361f2c6964ac17e190dd0237ab2e9bfce5 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/adversarial/unauthenticated.txt | txt | aux · unrecognized .txt | 027f7f7b1df93150b1f5fd11425eed6592f03059dc169160d1561b96183c7a07 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/collector-e60.log | log | aux · unrecognized .log | e2446e427119792c31ee1d5312313346aeb084462f874e61e1f54a3a5935e07c |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/collector.log | log | aux · unrecognized .log | 4cde4b4331e0c4358405f45d311761a700342ffa64743b33e18fe7ba78c73ccc |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/collector.pid | pid | aux · unrecognized .pid | 656a861881534dd91b350ccb44c86525a6a143e1992c59ab315122cd6a082fe7 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/console.log | log | aux · unrecognized .log | a0cab3bf0f0596bc8ea77a62a530e64af97583143d4dd910637770cd11f5eac4 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/env.txt | env | aux | 2f7798ddb82ae042dfabb2e9b21dd9cfc6628f6021b50ecf6eb58ae17796f60f |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/failed-requests.log | log | aux · unrecognized .log | 7d38f5dee77837c8b328bde555f26d6790d2c147668e736a24eea38ae56fb28c |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/fleet-csv-import.png | png | evidence · 1280x4242 | d394731628e5cbf7a4acc678084bdce88b6a8d817ae08f0ecfeab3c92e22ec00 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/fleet-details-affirmative.png | png | evidence · 1280x4534 | 638246f5d7311a95a2f789796ac366efbe9d8bc4fae7b6ba4f388909caa2948b |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/fleet-details-unknown.png | png | evidence · 1280x4242 | a8d53fdb9ae17e47e8d5c9915894fab1246ccb4150de76175ddeabbef3e6b58a |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/fleet-panel.png | png | evidence · 1280x3013 | eb53390ff64bb4c8107373b32bef5ba035011ee413fdfb9c65437ff946e828fe |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/http-clean.example.json | json | aux · unrecognized .json | 97c57c6bcb464c489074c8a8fb36c257f8349174f811cc721413a68949c1c9b0 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/http-fleet-run.headers | headers | aux · unrecognized .headers | d6851f2cce0d7459085470e25a984940a56dc5c3c93a2f744a70ab2dc63c319a |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/http-fleet-run.json | json | aux · unrecognized .json | c57b44331fa91821dc659acb2a5307cb32562701df1bc6475d84d912dd50c5d6 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/http-never-evaluated.example.json | json | aux · unrecognized .json | dfdc7de4be8485912b51c9d5c234a21c8e88dceb4fdab47573d3c2e8559c013a |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/http-stale.example.json | json | aux · unrecognized .json | 523361cb816b9623e10486c4159c026cc01af4f0d8fb5064a077ea17a48e4ffb |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/http-uncorrelated.example.json | json | aux · unrecognized .json | 651c852b8ab1f80b6552a6922172469404a6cba572f423ee9d4561201cd7303d |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/observations.md | md | aux · unrecognized .md | 7da305c119927b7a0d5a775d0e62ed4465922f77dbdef9e4bcfd9461129b653d |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/readback-db-stale.json | json | aux · unrecognized .json | 07f151c05d09a6cc7b3537ae261cbe48ab51db6df890dbf56155d20f352bed0f |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/readback-findings.json | json | aux · unrecognized .json | 5d2fc0c3af880f127533cc3b23a0377b6a7b9be25a3037a0e0da0d35ed1ee9b9 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/readback/csv-import.json | readback | evidence | 8ddd49b6de31c6337a70c6ede48e0947c77f62f9fee62a95c43dd8db5a7cd8dd |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/readback/finding-correlation.json | readback | evidence | b939897d1e84956d0160257b54a35e9e469eabf10bb76f8056d4ca06a5687a78 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/readback/persisted-fleet-fixtures.json | readback | evidence | 4f6b901be9c4fe2ae5238557c8b9c39ee4f9bd31ded78f467a62680bf3712c4c |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/readback/ui-affirmative.json | readback | evidence | 03452da88c2822c0c1113d4f83804bd518dd29bb49d19ac6d664732e8cfd5ffd |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/readback/ui-state.json | readback | evidence | 119bc7fe009a6d0088e4be8dc625860b851cbb765515e84a2b13057b1f8d1ec0 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/trace-affirmative.zip | trace | evidence · playwright trace | a1a4f5aee97a61c442594e3948be336203fa0759546466cfe99f439c30a454b2 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/trace.zip | trace | evidence · playwright trace | 45ea5d98dab54a523376a497d9be6f711b4d52c4802023da5f20d437aeba63a6 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/ui-affirmative-errors.log | log | aux · unrecognized .log | 7d38f5dee77837c8b328bde555f26d6790d2c147668e736a24eea38ae56fb28c |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/web-e60.log | log | aux · unrecognized .log | ce6232e7333971e646cc40c09efb38de49c7d66489db1bef0cbc6e86b092cea0 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/web.log | log | aux · unrecognized .log | 44d21eebcaa6cdf8d3ca06aef155d06756e0a158d278b001f3699721e07c5a55 |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/web.pid | pid | aux · unrecognized .pid | a3212a976e4f014152f94624c72d5495544683761f3e188fe463b18daf6872bc |
+| verification/runs/20260903-220615Z-02a1aa7-fresh/web2.log | log | aux · unrecognized .log | 238ccdd466b6c46af5f22c483e0b8484cc8f99e6103be606b49a91daadc6aeab |


### PR DESCRIPTION
## Summary
Closes #58.

Domain 360 Overview now opens with a labelled **Evidence completeness** hero that separates coverage from findings:

- `GET /api/snapshot/:snapshotId/findings/summary` now reports `findingsEvaluated`, `evaluationCoverage`, and ruleset-correlated severity counts (only findings from the snapshot's own ruleset version), instead of a bare hasFindings/total that could read as healthy.
- The route fetches the summary alongside the snapshot; a summary failure keeps the snapshot but renders UNKNOWN rather than a fabricated zero.
- `DomainEvidencePanel` renders two fieldsets (Coverage / Findings) with UNKNOWN badges for partial coverage, missing/unavailable findings, incomplete collection, or authoritative-evidence gaps. Zero findings only gets healthy language when coverage is explicitly complete with no setup/evidence gaps.
- Feature map + harness updated; e2e extended (`domain-signal-room.spec.ts`).

## Verification
- apps/web vitest: 1033 passed / 24 skipped; `tsc --noEmit` clean; `biome check` clean.
- Playwright on the real dev server: `domain-signal-room` 4/4, `domain-states` 18/18, `finding-simulation` 4/4 (no #80 regression).
- verify-kit: honest builder `blocked` receipt for `domain.overview` (UI proven; persisted-evidence TTL audit not re-driven against real recursive evidence — local DB only has fixture snapshots).

## Note for reviewers
`apps/web/hono/routes/findings.ts` is also in the `auth.api-principal` / `fleet.reports` feature paths, so check-ci will require fresh receipts for those at this tree before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes evidence completeness the Domain 360 Overview hero so partial coverage can no longer read as a healthy zero-finding result.

- Overview now opens with a labelled `Evidence completeness` region that separates Coverage from Findings.
- `GET /api/snapshot/:snapshotId/findings/summary` reports `findingsEvaluated`, `evaluationCoverage`, and severity counts for the snapshot's own ruleset version only.
- Zero findings renders healthy language only when evaluation coverage is explicitly complete with no setup or evidence gaps; partial, missing, or unavailable coverage renders UNKNOWN.
- The route fetches the summary alongside the snapshot; a summary failure keeps the snapshot but renders UNKNOWN instead of a fabricated zero.

**Note for reviewers**
`apps/web/hono/routes/findings.ts` is also in the `auth.api-principal` and `fleet.reports` feature paths; fresh receipts for both are included at this tree.

<sup>Written for commit 61569c1490f94e0d6a8bdff0533b0a28b673a52b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

