### PR TITLE
feat(web): open portfolio on three built-in saved-filter views (#63)

### DIFF
--- a/.agents/skills/verify-dns-ops/features/portfolio.search.md
+++ b/.agents/skills/verify-dns-ops/features/portfolio.search.md
@@ -5,7 +5,12 @@ profile: critical
 paths:
   - apps/web/app/routes/portfolio.tsx
   - apps/web/app/components/PortfolioSearchPanel.tsx
+  - apps/web/app/components/BuiltInViewsPanel.tsx
+  - apps/web/app/lib/built-in-views.ts
+  - apps/web/app/lib/built-in-views.test.ts
   - apps/web/hono/routes/portfolio.ts
+  - apps/web/hono/routes/portfolio.test.ts
+  - .agents/skills/verify-dns-ops/harness/web.mts
 always_with: []
 ---
 # Search the portfolio
@@ -16,6 +21,7 @@ An operator opens Portfolio workflows and searches tenant domains by query/tag.
 
 - Route `/portfolio` shows heading **Portfolio workflows** and **Portfolio Search**.
 - Query field labeled **Query**.
+- The **Built-in views** panel opens the workspace with three one-click views: **Mail broken**, **Expiring evidence**, and **Incomplete coverage** (issue #63). Selecting a view drives `POST /api/portfolio/search` with the view criteria (`findingTypePrefix: "mail."` plus high/critical severities, `snapshotOlderThanDays: 30`, `coverage: "incomplete"`); selecting the active view again clears it.
 - Saved filters, monitored domains, alerts, and related panels are present on the same page (chrome only unless the feature file is expanded).
 
 ## How to get to it (user POV)
@@ -23,6 +29,7 @@ An operator opens Portfolio workflows and searches tenant domains by query/tag.
 1. Open `/portfolio` while signed in (or local e2e headers).
 2. Confirm **Portfolio Search** and the **Query** field.
 3. Type a domain fragment in **Query** and observe results or an empty valid set.
+4. Activate each built-in view button and observe the filtered result set; activate the active view again to clear it.
 
 ## Driving it with harness/web.mts
 
@@ -38,6 +45,8 @@ await page.getByLabel('Query').fill('example.com');
 ### Expected observations
 - Headings **Portfolio workflows** and **Portfolio Search** are visible.
 - **Query** accepts input.
+- The **Built-in views** panel shows the three view buttons; each click issues `POST /api/portfolio/search` whose request body carries that view's criteria, the button becomes `aria-pressed="true"`, and re-clicking removes the criteria.
+- View result sets respect the criteria server-side: `findingTypePrefix` returns only domains with matching-type findings (unevaluated domains are kept), `snapshotOlderThanDays` returns only domains whose latest snapshot is older, `coverage: "incomplete"` returns only domains whose evidence is not fully evaluated (a domain without a snapshot counts as incomplete).
 
 ### Forbidden observations
 - Treating the sign-in warning (“Operator sign-in is required to search tenant domains”) as a successful search.
@@ -45,6 +54,7 @@ await page.getByLabel('Query').fill('example.com');
 
 ### Read-back
 - `POST /api/portfolio/search` with the same session/headers returns 200 JSON `{ domains: [...] }` (empty array is valid).
+- The same POST issued directly with each built-in view's criteria returns a subset consistent with the button-driven result set (server-side enforcement, not client-only filtering).
 
 ## Gotchas
 

--- a/.agents/skills/verify-dns-ops/harness/web.mts
+++ b/.agents/skills/verify-dns-ops/harness/web.mts
@@ -274,18 +274,70 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
     await page.goto(`${BASE_URL}/portfolio`);
     await page.getByRole('heading', { name: /portfolio workflows/i }).waitFor({ timeout: 15_000 });
     await page.getByRole('heading', { name: /portfolio search/i }).waitFor();
-    const pending = page.waitForResponse(
-      (r) => r.url().includes('/api/portfolio/search') && r.request().method() === 'POST',
-      { timeout: 15_000 }
-    );
-    await page.getByLabel('Query').fill('example.com');
-    const res = await pending;
-    if (res.status() !== 200)
-      throw new Error(`POST /api/portfolio/search expected 200, got ${res.status()}`);
-    const json = await res.json();
-    if (!json || !Array.isArray(json.domains))
+    await page.getByRole('heading', { name: /built-in views/i }).waitFor();
+
+    async function searchRoundtrip(action: () => Promise<void>): Promise<{
+      request: Record<string, unknown>;
+      json: { domains?: unknown };
+    }> {
+      const pending = page.waitForResponse(
+        (r) => r.url().includes('/api/portfolio/search') && r.request().method() === 'POST',
+        { timeout: 15_000 }
+      );
+      await action();
+      const res = await pending;
+      if (res.status() !== 200)
+        throw new Error(`POST /api/portfolio/search expected 200, got ${res.status()}`);
+      return {
+        request: (res.request().postDataJSON() ?? {}) as Record<string, unknown>,
+        json: (await res.json()) as { domains?: unknown },
+      };
+    }
+
+    const query = await searchRoundtrip(() => page.getByLabel('Query').fill('example.com'));
+    if (!query.json || !Array.isArray(query.json.domains))
       throw new Error('portfolio search JSON missing domains[]');
-    await ev.readback('portfolio-search', json);
+
+    // Built-in views (issue #63): each button must drive the real search
+    // endpoint with the view's criteria, and toggling it off removes them.
+    const mailBroken = await searchRoundtrip(() =>
+      page.getByRole('button', { name: /mail broken/i }).click()
+    );
+    if (mailBroken.request.findingTypePrefix !== 'mail.')
+      throw new Error(
+        `mail-broken view lost findingTypePrefix: ${JSON.stringify(mailBroken.request)}`
+      );
+    if (JSON.stringify(mailBroken.request.severities) !== JSON.stringify(['high', 'critical']))
+      throw new Error(`mail-broken view lost severities: ${JSON.stringify(mailBroken.request)}`);
+
+    const expiring = await searchRoundtrip(() =>
+      page.getByRole('button', { name: /expiring evidence/i }).click()
+    );
+    if (expiring.request.snapshotOlderThanDays !== 30)
+      throw new Error(
+        `expiring view lost snapshotOlderThanDays: ${JSON.stringify(expiring.request)}`
+      );
+
+    const incomplete = await searchRoundtrip(() =>
+      page.getByRole('button', { name: /incomplete coverage/i }).click()
+    );
+    if (incomplete.request.coverage !== 'incomplete')
+      throw new Error(`incomplete view lost coverage: ${JSON.stringify(incomplete.request)}`);
+    const activeButton = page.getByRole('button', { name: /incomplete coverage/i });
+    if ((await activeButton.getAttribute('aria-pressed')) !== 'true')
+      throw new Error('incomplete coverage button did not become aria-pressed=true');
+
+    const cleared = await searchRoundtrip(() => activeButton.click());
+    if (cleared.request.coverage !== undefined)
+      throw new Error(`clearing the view kept view criteria: ${JSON.stringify(cleared.request)}`);
+
+    await ev.readback('portfolio-search', query.json);
+    await ev.readback('built-in-view-requests', {
+      mailBroken: mailBroken.request,
+      expiring: expiring.request,
+      incomplete: incomplete.request,
+      cleared: cleared.request,
+    });
     await ev.shot(page, 'portfolio-search');
   },
 };

--- a/apps/web/app/components/BuiltInViewsPanel.tsx
+++ b/apps/web/app/components/BuiltInViewsPanel.tsx
@@ -1,0 +1,57 @@
+/**
+ * Built-in Views Panel (issue #63).
+ *
+ * The Portfolio start screen: three operational views (mail-broken, expiring
+ * evidence, incomplete coverage) that load instantly and can be refined with
+ * the regular search controls. Selecting the active view again clears it.
+ */
+
+import { BUILT_IN_VIEWS, type BuiltInView, type BuiltInViewId } from '../lib/built-in-views.js';
+
+interface BuiltInViewsPanelProps {
+  activeView: BuiltInViewId | null;
+  onSelectView: (view: BuiltInView) => void;
+  onClearView: () => void;
+}
+
+export function BuiltInViewsPanel({
+  activeView,
+  onSelectView,
+  onClearView,
+}: BuiltInViewsPanelProps) {
+  return (
+    <div className="ds-panel portfolio-panel">
+      <div className="border-b border-line px-4 py-3">
+        <h3 className="text-lg font-medium text-ink">Built-in views</h3>
+        <p className="text-sm text-muted">
+          Start from an operational view of the portfolio, then refine it with the search controls.
+        </p>
+      </div>
+
+      <div className="grid gap-3 p-4 sm:grid-cols-3">
+        {BUILT_IN_VIEWS.map((view) => {
+          const isActive = view.id === activeView;
+          return (
+            <button
+              key={view.id}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => (isActive ? onClearView() : onSelectView(view))}
+              className={`rounded-lg border p-3 text-left ${
+                isActive ? 'border-brand bg-info-surface' : 'border-line bg-surface-muted'
+              }`}
+            >
+              <span className="block font-medium text-ink">{view.name}</span>
+              <span className="mt-1 block text-sm text-text">{view.description}</span>
+              <span className="mt-2 inline-block">
+                <span className={`ds-badge ${isActive ? 'ds-badge--info' : 'ds-badge--unknown'}`}>
+                  {isActive ? 'Active' : 'View'}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/PortfolioSearchPanel.tsx
+++ b/apps/web/app/components/PortfolioSearchPanel.tsx
@@ -1,9 +1,9 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { useId, useMemo, useState } from 'react';
+import { type BuiltInView, searchBodyForView } from '../lib/built-in-views.js';
 import {
   type CurrentFilters,
-  currentFiltersToSearchBody,
   EMPTY_CURRENT_FILTERS,
   normalizeCurrentFilters,
   type Severity,
@@ -13,6 +13,9 @@ import {
 interface PortfolioSearchPanelProps {
   currentFilters: CurrentFilters;
   onFiltersChange: (next: CurrentFilters) => void;
+  /** Built-in portfolio view active on top of the visible filters (issue #63). */
+  activeView?: BuiltInView | null;
+  onClearView?: () => void;
 }
 
 interface SearchResult {
@@ -40,6 +43,8 @@ const ZONE_MANAGEMENT: ZoneManagement[] = ['managed', 'unmanaged', 'unknown'];
 export function PortfolioSearchPanel({
   currentFilters,
   onFiltersChange,
+  activeView = null,
+  onClearView,
 }: PortfolioSearchPanelProps) {
   const queryClient = useQueryClient();
   const idPrefix = useId();
@@ -65,19 +70,19 @@ export function PortfolioSearchPanel({
 
   const tagSuggestions = tagSuggestionsData?.tags ?? [];
 
-  // Portfolio search — reactive to filters
+  // Portfolio search — reactive to filters and the active built-in view
   const {
     data: searchData,
     isLoading,
     error,
     isError,
   } = useQuery({
-    queryKey: ['portfolio-search', normalizedFilters],
+    queryKey: ['portfolio-search', normalizedFilters, activeView?.id ?? null],
     queryFn: async ({ signal }) => {
       const response = await fetch('/api/portfolio/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(currentFiltersToSearchBody(normalizedFilters)),
+        body: JSON.stringify(searchBodyForView(normalizedFilters, activeView)),
         signal,
         credentials: 'include',
       });
@@ -157,6 +162,25 @@ export function PortfolioSearchPanel({
       </div>
 
       <div className="space-y-4 p-4">
+        {activeView && (
+          <div className="flex items-start justify-between gap-2 rounded-lg border border-brand bg-info-surface p-3 text-sm text-text">
+            <span>
+              <strong className="text-ink">{activeView.name}</strong> view active —{' '}
+              {activeView.description}
+            </span>
+            {onClearView && (
+              <button
+                type="button"
+                onClick={onClearView}
+                disabled={authRequired}
+                className="shrink-0 font-medium text-brand hover:text-brand disabled:text-faint"
+              >
+                Clear view
+              </button>
+            )}
+          </div>
+        )}
+
         {authRequired && (
           <div className="rounded-lg border border-warning bg-warning-surface p-4 text-sm text-warning">
             Operator sign-in is required to search tenant domains and load saved filters.

--- a/apps/web/app/lib/built-in-views.test.ts
+++ b/apps/web/app/lib/built-in-views.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { BUILT_IN_VIEWS, getBuiltInView, searchBodyForView } from './built-in-views.js';
+import { type CurrentFilters, EMPTY_CURRENT_FILTERS } from './portfolio-filters.js';
+
+describe('built-in portfolio views (issue #63)', () => {
+  it('exposes exactly the three operational views with unique ids', () => {
+    expect(BUILT_IN_VIEWS.map((view) => view.id)).toEqual([
+      'mail-broken',
+      'expiring',
+      'incomplete-coverage',
+    ]);
+    expect(new Set(BUILT_IN_VIEWS.map((view) => view.id)).size).toBe(BUILT_IN_VIEWS.length);
+    for (const view of BUILT_IN_VIEWS) {
+      expect(view.name.trim().length).toBeGreaterThan(0);
+      expect(view.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('mail-broken searches high/critical mail findings', () => {
+    const view = getBuiltInView('mail-broken');
+    const body = searchBodyForView(view.currentFilters, view);
+
+    expect(body.findingTypePrefix).toBe('mail.');
+    expect(body.severities).toEqual(['high', 'critical']);
+  });
+
+  it('expiring searches evidence older than 30 days', () => {
+    const view = getBuiltInView('expiring');
+    const body = searchBodyForView(view.currentFilters, view);
+
+    expect(body.snapshotOlderThanDays).toBe(30);
+  });
+
+  it('incomplete-coverage searches unevaluated evidence', () => {
+    const view = getBuiltInView('incomplete-coverage');
+    const body = searchBodyForView(view.currentFilters, view);
+
+    expect(body.coverage).toBe('incomplete');
+  });
+
+  it('keeps operator refinements alongside the active view', () => {
+    const refined: CurrentFilters = {
+      query: 'acme',
+      tags: ['production'],
+      severities: ['high'],
+      zoneManagement: [],
+    };
+    const body = searchBodyForView(refined, getBuiltInView('expiring'));
+
+    expect(body.query).toBe('acme');
+    expect(body.tags).toEqual(['production']);
+    expect(body.severities).toEqual(['high']);
+    expect(body.snapshotOlderThanDays).toBe(30);
+  });
+
+  it('without a view the body is the plain filter body', () => {
+    const body = searchBodyForView(EMPTY_CURRENT_FILTERS, null);
+
+    expect(body).not.toHaveProperty('findingTypePrefix');
+    expect(body).not.toHaveProperty('snapshotOlderThanDays');
+    expect(body).not.toHaveProperty('coverage');
+  });
+
+  it('getBuiltInView rejects unknown ids', () => {
+    expect(() => getBuiltInView('nope' as 'mail-broken')).toThrow(/Unknown built-in view/);
+  });
+});

--- a/apps/web/app/lib/built-in-views.ts
+++ b/apps/web/app/lib/built-in-views.ts
@@ -1,0 +1,68 @@
+/**
+ * Built-in portfolio views (issue #63).
+ *
+ * Three operational views that open the Portfolio workspace: mail-broken,
+ * expiring evidence, and incomplete coverage. Each view reuses the saved-filter
+ * machinery — the visible search controls are set from `currentFilters`, and the
+ * criteria the controls cannot express travel as extra `/api/portfolio/search`
+ * parameters alongside them.
+ */
+
+import { type CurrentFilters, currentFiltersToSearchBody } from './portfolio-filters.js';
+
+export type BuiltInViewId = 'mail-broken' | 'expiring' | 'incomplete-coverage';
+
+export interface BuiltInView {
+  id: BuiltInViewId;
+  name: string;
+  description: string;
+  /** Filters reflected in the visible search controls while the view is active. */
+  currentFilters: CurrentFilters;
+  /** Extra search criteria the visible controls cannot express. */
+  searchParams: Record<string, unknown>;
+}
+
+export const BUILT_IN_VIEWS: BuiltInView[] = [
+  {
+    id: 'mail-broken',
+    name: 'Mail broken',
+    description: 'Domains with high or critical mail findings (SPF, DMARC, DKIM, MX).',
+    currentFilters: { query: '', tags: [], severities: ['high', 'critical'], zoneManagement: [] },
+    searchParams: { findingTypePrefix: 'mail.' },
+  },
+  {
+    id: 'expiring',
+    name: 'Expiring evidence',
+    description: 'No snapshot in the last 30 days — collected evidence is going stale.',
+    currentFilters: { query: '', tags: [], severities: [], zoneManagement: [] },
+    searchParams: { snapshotOlderThanDays: 30 },
+  },
+  {
+    id: 'incomplete-coverage',
+    name: 'Incomplete coverage',
+    description: 'Latest evidence has not been fully evaluated by the ruleset.',
+    currentFilters: { query: '', tags: [], severities: [], zoneManagement: [] },
+    searchParams: { coverage: 'incomplete' },
+  },
+];
+
+export function getBuiltInView(id: BuiltInViewId): BuiltInView {
+  const view = BUILT_IN_VIEWS.find((candidate) => candidate.id === id);
+  if (!view) {
+    throw new Error(`Unknown built-in view: ${id}`);
+  }
+  return view;
+}
+
+/**
+ * Search request body for the current filters plus, when a built-in view is
+ * active, the view's extra criteria. Operator refinements win on collision
+ * because the view params only carry keys the controls never emit.
+ */
+export function searchBodyForView(
+  filters: CurrentFilters,
+  view: BuiltInView | null
+): Record<string, unknown> {
+  const base = currentFiltersToSearchBody(filters);
+  return view ? { ...base, ...view.searchParams } : base;
+}

--- a/apps/web/app/routes/portfolio.tsx
+++ b/apps/web/app/routes/portfolio.tsx
@@ -3,6 +3,7 @@ import { useId, useState } from 'react';
 import { AlertsPanel } from '../components/AlertsPanel.js';
 import { AuditLogPanel } from '../components/AuditLogPanel.js';
 import { AuthPending } from '../components/AuthPending.js';
+import { BuiltInViewsPanel } from '../components/BuiltInViewsPanel.js';
 import { FleetReportsPanel } from '../components/FleetReportsPanel.js';
 import { MonitoredDomainsPanel } from '../components/MonitoredDomainsPanel.js';
 import { PortfolioSearchPanel } from '../components/PortfolioSearchPanel.js';
@@ -10,6 +11,7 @@ import { SavedFiltersPanel } from '../components/SavedFiltersPanel.js';
 import { SharedReportsPanel } from '../components/SharedReportsPanel.js';
 import { TemplateOverridesPanel } from '../components/TemplateOverridesPanel.js';
 import { requireAuthGuard } from '../lib/auth-guard.js';
+import { type BuiltInView, type BuiltInViewId, getBuiltInView } from '../lib/built-in-views.js';
 import { type CurrentFilters, EMPTY_CURRENT_FILTERS } from '../lib/portfolio-filters.js';
 
 export const Route = createFileRoute('/portfolio')({
@@ -23,6 +25,18 @@ export const Route = createFileRoute('/portfolio')({
 function PortfolioWorkspace() {
   const workspaceTitleId = useId();
   const [currentFilters, setCurrentFilters] = useState<CurrentFilters>(EMPTY_CURRENT_FILTERS);
+  const [activeViewId, setActiveViewId] = useState<BuiltInViewId | null>(null);
+  const activeView = activeViewId ? getBuiltInView(activeViewId) : null;
+
+  const handleSelectView = (view: BuiltInView) => {
+    setActiveViewId(view.id);
+    setCurrentFilters(view.currentFilters);
+  };
+
+  const handleClearView = () => {
+    setActiveViewId(null);
+    setCurrentFilters(EMPTY_CURRENT_FILTERS);
+  };
 
   return (
     <section className="portfolio-workspace" aria-labelledby={workspaceTitleId}>
@@ -40,8 +54,19 @@ function PortfolioWorkspace() {
         </Link>
       </header>
 
+      <BuiltInViewsPanel
+        activeView={activeViewId}
+        onSelectView={handleSelectView}
+        onClearView={handleClearView}
+      />
+
       <div className="portfolio-workspace__search-grid">
-        <PortfolioSearchPanel currentFilters={currentFilters} onFiltersChange={setCurrentFilters} />
+        <PortfolioSearchPanel
+          currentFilters={currentFilters}
+          onFiltersChange={setCurrentFilters}
+          activeView={activeView}
+          onClearView={handleClearView}
+        />
         <SavedFiltersPanel currentFilters={currentFilters} onLoadFilter={setCurrentFilters} />
       </div>
 

--- a/apps/web/e2e/portfolio-signal-room.spec.ts
+++ b/apps/web/e2e/portfolio-signal-room.spec.ts
@@ -84,7 +84,7 @@ test.describe('Portfolio Signal Room', () => {
 
     const workspace = page.locator('.portfolio-workspace');
     await expect(workspace).toBeVisible();
-    await expect(workspace.locator('.portfolio-panel')).toHaveCount(8);
+    await expect(workspace.locator('.portfolio-panel')).toHaveCount(9);
     await expect(page.getByRole('heading', { name: 'Portfolio workflows' })).toBeVisible();
     await expect(
       page.getByRole('heading', { name: 'Portfolio Search' }).locator('xpath=../..')
@@ -114,7 +114,7 @@ test.describe('Portfolio Signal Room', () => {
   test('keeps the complete workspace within the viewport at supported widths', async ({ page }) => {
     await mockPortfolioWorkspace(page);
     await page.goto('/portfolio');
-    await expect(page.locator('.portfolio-panel')).toHaveCount(8);
+    await expect(page.locator('.portfolio-panel')).toHaveCount(9);
 
     for (const width of [320, 375, 414, 768]) {
       await page.setViewportSize({ width, height: 900 });

--- a/apps/web/hono/routes/portfolio.test.ts
+++ b/apps/web/hono/routes/portfolio.test.ts
@@ -44,6 +44,7 @@ interface MockData {
     createdAt: Date;
     resultState: string;
     rulesetVersionId: string | null;
+    metadata?: Record<string, unknown> | null;
   }>;
   findings: Array<{
     id: string;
@@ -51,6 +52,7 @@ interface MockData {
     ruleId: string;
     severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
     summary: string;
+    type: string;
   }>;
   domainNotes: Array<{
     id: string;
@@ -143,6 +145,7 @@ function createMockData(): MockData {
         createdAt: now,
         resultState: 'complete',
         rulesetVersionId: 'ruleset-v1',
+        metadata: { evaluation: { state: 'COMPLETE', errors: [] } },
       },
       {
         id: 'snap-2',
@@ -159,6 +162,7 @@ function createMockData(): MockData {
         ruleId: 'rule-1',
         severity: 'high',
         summary: 'Missing DMARC record',
+        type: 'mail.no-dmarc-record',
       },
       {
         id: 'finding-2',
@@ -166,6 +170,15 @@ function createMockData(): MockData {
         ruleId: 'rule-2',
         severity: 'medium',
         summary: 'SPF too permissive',
+        type: 'mail.spf-permissive',
+      },
+      {
+        id: 'finding-3',
+        snapshotId: 'snap-1',
+        ruleId: 'rule-3',
+        severity: 'high',
+        summary: 'Authoritative servers disagree',
+        type: 'dns.authoritative-mismatch',
       },
     ],
     domainNotes: [],
@@ -1311,6 +1324,7 @@ describe('Portfolio Routes', () => {
         ruleId: 'mail.spf-analysis.v1',
         severity: 'critical',
         summary: 'Critical SPF issue',
+        type: 'mail.spf-permissive',
       });
 
       // Create filter with tag criteria
@@ -1937,6 +1951,120 @@ describe('Portfolio Routes', () => {
 
       expect(res.status).toBe(200);
       // Test passes if no error - actual filtering logic is tested at unit level
+    });
+  });
+
+  // ===========================================================================
+  // BUILT-IN VIEW FILTERS (issue #63)
+  // ===========================================================================
+
+  describe('Built-in view filters (issue #63)', () => {
+    async function searchWith(body: JsonBody): Promise<{ status: number; json: JsonBody }> {
+      const res = await app.request('/api/portfolio/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { status: res.status, json: (await res.json()) as JsonBody };
+    }
+
+    function resultNames(json: JsonBody): string[] {
+      return (
+        (json.domains as Array<{ name: string }>)
+          .map((domain) => domain.name)
+          // The mock drizzle ignores the tenant where clause; the real route
+          // enforces tenant scoping in SQL, so drop the known tenant-2 row here.
+          .filter((name) => name !== 'other-tenant.com')
+      );
+    }
+
+    it('findingTypePrefix keeps evaluated domains with matching findings and narrows returned findings', async () => {
+      // domain-1: COMPLETE evaluation with mail.* and dns.* findings on snap-1
+      const { status, json } = await searchWith({ findingTypePrefix: 'mail.' });
+
+      expect(status).toBe(200);
+      expect(resultNames(json)).toContain('example.com');
+      const example = (json.domains as JsonBody[]).find((d) => d.name === 'example.com');
+      const findings = example?.findings as Array<{ type: string }>;
+      expect(findings.length).toBeGreaterThan(0);
+      expect(findings.every((finding) => finding.type.startsWith('mail.'))).toBe(true);
+    });
+
+    it('findingTypePrefix drops fully evaluated domains without matching findings', async () => {
+      // Re-point every finding away from mail.*: domain-1 is fully evaluated
+      // with no mail findings, so it must be dropped. domain-2 is unevaluated
+      // (unknown coverage) and is kept — it might match once evaluated.
+      for (const finding of mockData.findings) {
+        finding.type = 'dns.recursive-authoritative-mismatch';
+      }
+
+      const { status, json } = await searchWith({ findingTypePrefix: 'mail.' });
+
+      expect(status).toBe(200);
+      expect(resultNames(json)).not.toContain('example.com');
+      expect(resultNames(json)).toContain('test.com');
+    });
+
+    it('snapshotOlderThanDays keeps only domains whose latest snapshot is stale', async () => {
+      const now = Date.now();
+      const day = 24 * 60 * 60 * 1000;
+      const snapOne = mockData.snapshots.find((snapshot) => snapshot.id === 'snap-1');
+      const snapTwo = mockData.snapshots.find((snapshot) => snapshot.id === 'snap-2');
+      if (snapOne) snapOne.createdAt = new Date(now);
+      if (snapTwo) snapTwo.createdAt = new Date(now - 40 * day);
+
+      const { status, json } = await searchWith({ snapshotOlderThanDays: 30 });
+
+      expect(status).toBe(200);
+      expect(resultNames(json)).toEqual(['test.com']);
+    });
+
+    it('snapshotOlderThanDays excludes domains without a snapshot', async () => {
+      const day = 24 * 60 * 60 * 1000;
+      mockData.snapshots = mockData.snapshots.filter((snapshot) => snapshot.id !== 'snap-1');
+      mockData.snapshots[0].createdAt = new Date(Date.now() - 40 * day);
+
+      const { status, json } = await searchWith({ snapshotOlderThanDays: 30 });
+
+      expect(status).toBe(200);
+      // domain-1 has no snapshot at all: nothing is expiring, so it is excluded
+      expect(resultNames(json)).toEqual(['test.com']);
+    });
+
+    it('coverage=incomplete keeps only domains whose evidence is not fully evaluated', async () => {
+      // snap-1 carries explicit COMPLETE evaluation; snap-2 has none
+      const { status, json } = await searchWith({ coverage: 'incomplete' });
+
+      expect(status).toBe(200);
+      expect(resultNames(json)).toEqual(['test.com']);
+    });
+
+    it('rejects unsupported coverage values', async () => {
+      const { status, json } = await searchWith({ coverage: 'complete' });
+
+      expect(status).toBe(400);
+      expect(json.error).toBeDefined();
+    });
+
+    it('rejects out-of-range snapshotOlderThanDays', async () => {
+      const { status } = await searchWith({ snapshotOlderThanDays: 0 });
+
+      expect(status).toBe(400);
+    });
+
+    it('combines built-in view criteria with operator filters', async () => {
+      const day = 24 * 60 * 60 * 1000;
+      const snapOne = mockData.snapshots.find((snapshot) => snapshot.id === 'snap-1');
+      if (snapOne) snapOne.createdAt = new Date(Date.now() - 40 * day);
+
+      const { status, json } = await searchWith({
+        findingTypePrefix: 'mail.',
+        severities: ['high'],
+        zoneManagement: ['managed'],
+      });
+
+      expect(status).toBe(200);
+      expect(resultNames(json)).toContain('example.com');
     });
   });
 });

--- a/apps/web/hono/routes/portfolio.ts
+++ b/apps/web/hono/routes/portfolio.ts
@@ -56,6 +56,13 @@ portfolioRoutes.post('/search', async (c) => {
     tags: optionalArray<string>('tags'),
     severities: optionalArray<string>('severities'),
     zoneManagement: optionalArray<string>('zoneManagement'),
+    findingTypePrefix: optionalString('findingTypePrefix', { maxLength: 100 }),
+    snapshotOlderThanDays: integer('snapshotOlderThanDays', {
+      min: 1,
+      max: 3650,
+      required: false,
+    }),
+    coverage: optionalString('coverage', { maxLength: 20 }),
     limit: integer('limit', { min: 1, max: 100, required: false }),
     offset: integer('offset', { min: 0, required: false }),
   });
@@ -64,7 +71,24 @@ portfolioRoutes.post('/search', async (c) => {
     return validationErrorResponse(c, validation.error);
   }
 
-  const { query, tags, severities, zoneManagement, limit = 20, offset = 0 } = validation.data;
+  const {
+    query,
+    tags,
+    severities,
+    zoneManagement,
+    findingTypePrefix,
+    snapshotOlderThanDays,
+    coverage,
+    limit = 20,
+    offset = 0,
+  } = validation.data;
+
+  // Built-in view criteria (issue #63): only the incomplete-coverage view
+  // exists today, so any other value is a client error rather than a silent
+  // no-op filter.
+  if (coverage !== undefined && coverage !== 'incomplete') {
+    return c.json({ error: 'coverage must be "incomplete"' }, 400);
+  }
 
   try {
     const tagRepo = new DomainTagRepository(db);
@@ -168,28 +192,56 @@ portfolioRoutes.post('/search', async (c) => {
     }
 
     // Process results using the batched data
+    const hasFindingCriteria = hasSeverityFilter || findingTypePrefix !== undefined;
+    const stalenessCutoffMs =
+      snapshotOlderThanDays !== undefined
+        ? startTime - snapshotOlderThanDays * 24 * 60 * 60 * 1000
+        : null;
+
     const filteredDomains = portfolioResults.map((domain) => {
       const latestSnapshot = latestSnapshotByDomain.get(domain.id);
+      const evaluationCoverage = evaluationCoverageOrUnknown(latestSnapshot?.metadata?.evaluation);
+      const findingsEvaluated = isEvaluationComplete(evaluationCoverage);
+
+      // Built-in "incomplete coverage" view: keep only domains whose latest
+      // evidence was not fully evaluated. A domain without a snapshot counts
+      // as incomplete.
+      if (coverage === 'incomplete' && findingsEvaluated) {
+        return null;
+      }
+
+      // Built-in "expiring evidence" view: keep only domains whose latest
+      // snapshot is older than the requested window. Domains without a
+      // snapshot have no evidence to expire and are excluded.
+      if (
+        stalenessCutoffMs !== null &&
+        (!latestSnapshot || new Date(latestSnapshot.createdAt).getTime() > stalenessCutoffMs)
+      ) {
+        return null;
+      }
 
       if (!latestSnapshot) {
         return {
           ...domain,
           findings: [],
-          findingsEvaluated: false,
-          evaluationCoverage: evaluationCoverageOrUnknown(undefined),
+          findingsEvaluated,
+          evaluationCoverage,
           latestSnapshot: null,
         };
       }
 
-      // Only explicit complete coverage permits a zero-finding result to filter
-      // the domain out. A ruleset ID alone does not prove every check completed.
-      const evaluationCoverage = evaluationCoverageOrUnknown(latestSnapshot.metadata?.evaluation);
-      const findingsEvaluated = isEvaluationComplete(evaluationCoverage);
-      const domainFindings = findingsBySnapshot.get(latestSnapshot.id) || [];
+      // Built-in "mail broken" view narrows the snapshot's findings to the
+      // requested type prefix (e.g. `mail.`) before the evaluated-empty rule
+      // applies, so only domains with matching findings survive.
+      const domainFindings = findingTypePrefix
+        ? (findingsBySnapshot.get(latestSnapshot.id) || []).filter((finding) =>
+            finding.type.startsWith(findingTypePrefix)
+          )
+        : findingsBySnapshot.get(latestSnapshot.id) || [];
 
-      // Filter out if severity filter doesn't match AND findings were evaluated
+      // Filter out if finding criteria doesn't match AND findings were evaluated
       // Don't filter out if findings weren't evaluated (might have matching findings once evaluated)
-      if (hasSeverityFilter && domainFindings.length === 0 && findingsEvaluated) {
+      if (hasFindingCriteria && domainFindings.length === 0 && findingsEvaluated) {
         return null;
       }
 
@@ -213,7 +265,14 @@ portfolioRoutes.post('/search', async (c) => {
     trackSearch({
       tenantId,
       query,
-      filters: { tags, severities, zoneManagement },
+      filters: {
+        tags,
+        severities,
+        zoneManagement,
+        findingTypePrefix,
+        snapshotOlderThanDays,
+        coverage,
+      },
       resultCount: domainResults.length,
       durationMs: Date.now() - startTime,
     });

--- a/verification/receipts/20260903-204709Z-488058f-issue63-portfolio-search-unit-only--domain.overview.md
+++ b/verification/receipts/20260903-204709Z-488058f-issue63-portfolio-search-unit-only--domain.overview.md
@@ -1,0 +1,33 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-204709Z-488058f-issue63-portfolio-search-unit-only
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 488058f9ac441e6e0fd0ea417ff549992259594d
+code_digest: bd89fd98569139bfa605c47ca195156cfc4217ad7c843099438483d465bf3fc6
+dirty: true
+untracked: 4
+status: blocked
+reason: "This change only extends the shared verify-dns-ops harness web.mts used by the portfolio.search drive; no Domain 360 behavior changed. The Domain 360 browser drive was not run (mid-run steering stopped server attempts), so no evidence exists for this code tree."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-204709Z-488058f-issue63-portfolio-search-unit-only
+created_at: 2026-09-03T20:47:29.187Z
+---
+
+# Receipt: domain.overview — blocked
+
+# Run notes — issue #63 portfolio.search (unit-level only)
+
+- Environment was prepared for a live browser drive (disposable Postgres 15 on 127.0.0.1:55591, migrations 0000–0021 applied, seeded tenant `dns-ops-e2e` with one complete-eval domain carrying a `mail.no-dmarc-record` high finding, one 40-day-stale snapshot, one unevaluated snapshot; web dev server reached `/api/health` healthy).
+- Mid-run parent steering ordered all long-running server attempts stopped and unit tests only. The server and database were torn down before any browser drive or request/response evidence was captured.
+- Executed after steering: `bun x vitest run hono/routes/portfolio.test.ts app/lib/built-in-views.test.ts` (87 passed), `bun run typecheck` (clean), `biome check` on all changed files (clean).
+- The feature map and harness web.mts drive for the built-in views were updated; they remain unexecuted in this run.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-204709Z-488058f-issue63-portfolio-search-unit-only/env.txt | env | aux | 9d063b730bbac4e6e513ced7854a65ede8908ca2de5ffe7cd4f926273f58218e |
+| verification/runs/20260903-204709Z-488058f-issue63-portfolio-search-unit-only/observations.md | md | aux · unrecognized .md | 3dce9f64709eabdf18fde7c38932d90942c6086e853c133ab0f21f1235374372 |

--- a/verification/receipts/20260903-204709Z-488058f-issue63-portfolio-search-unit-only--portfolio.search.md
+++ b/verification/receipts/20260903-204709Z-488058f-issue63-portfolio-search-unit-only--portfolio.search.md
@@ -1,0 +1,33 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-204709Z-488058f-issue63-portfolio-search-unit-only
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 488058f9ac441e6e0fd0ea417ff549992259594d
+code_digest: bd89fd98569139bfa605c47ca195156cfc4217ad7c843099438483d465bf3fc6
+dirty: true
+untracked: 3
+status: blocked
+reason: "Behavioral verification was not executed: mid-run steering stopped all long-running server attempts before the browser drive ran, so no real-surface evidence exists for this code tree. Unit suite (87 tests), typecheck, and lint are green; live verification against the updated web.mts drive is still required."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-204709Z-488058f-issue63-portfolio-search-unit-only
+created_at: 2026-09-03T20:47:29.032Z
+---
+
+# Receipt: portfolio.search — blocked
+
+# Run notes — issue #63 portfolio.search (unit-level only)
+
+- Environment was prepared for a live browser drive (disposable Postgres 15 on 127.0.0.1:55591, migrations 0000–0021 applied, seeded tenant `dns-ops-e2e` with one complete-eval domain carrying a `mail.no-dmarc-record` high finding, one 40-day-stale snapshot, one unevaluated snapshot; web dev server reached `/api/health` healthy).
+- Mid-run parent steering ordered all long-running server attempts stopped and unit tests only. The server and database were torn down before any browser drive or request/response evidence was captured.
+- Executed after steering: `bun x vitest run hono/routes/portfolio.test.ts app/lib/built-in-views.test.ts` (87 passed), `bun run typecheck` (clean), `biome check` on all changed files (clean).
+- The feature map and harness web.mts drive for the built-in views were updated; they remain unexecuted in this run.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-204709Z-488058f-issue63-portfolio-search-unit-only/env.txt | env | aux | 9d063b730bbac4e6e513ced7854a65ede8908ca2de5ffe7cd4f926273f58218e |
+| verification/runs/20260903-204709Z-488058f-issue63-portfolio-search-unit-only/observations.md | md | aux · unrecognized .md | 3dce9f64709eabdf18fde7c38932d90942c6086e853c133ab0f21f1235374372 |

--- a/verification/receipts/20260903-205226Z-d5355e4-portfolio-search-fresh--portfolio.search.md
+++ b/verification/receipts/20260903-205226Z-d5355e4-portfolio-search-fresh--portfolio.search.md
@@ -1,0 +1,54 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-205226Z-d5355e4-portfolio-search-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: d5355e457d0567d477cb739032f6cd04e60527bc
+code_digest: bd89fd98569139bfa605c47ca195156cfc4217ad7c843099438483d465bf3fc6
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: ""
+evidence_dir: verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh
+created_at: 2026-09-03T20:55:25.730Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` showed **Portfolio workflows**, **Portfolio Search**, **Built-in views**, and the labeled **Query** field.
+- Filling Query with `example.com` completed a real `POST /api/portfolio/search` and returned HTTP 200 JSON with `domains` (3 seeded domains; empty is also valid).
+- Clicking **Mail broken** issued a real POST with `findingTypePrefix: "mail."` and `severities: ["high", "critical"]`; response contained `mailbroken.example` and `unevaluated.example` (unevaluated domain retained).
+- Clicking **Expiring evidence** issued a real POST with `snapshotOlderThanDays: 30`; response contained only `stale.example`, whose latest snapshot is older than 30 days.
+- Clicking **Incomplete coverage** issued a real POST with `coverage: "incomplete"`; response contained only `unevaluated.example`, whose coverage is PARTIAL.
+- The active Incomplete coverage button exposed `aria-pressed="true"`; clicking it again issued a real POST without `coverage` and returned all 3 domains.
+
+## Forbidden (… → confirmed absent)
+- Sign-in warning was not used as success; local e2e tenant/actor headers produced authenticated seeded results.
+- No class selectors were used by the harness.
+
+## Read-back
+- `readback/portfolio-search.json` records the Query response: HTTP-200 JSON `{ domains: [...], total: 3, limit: 20, offset: 0 }`.
+- `readback/built-in-view-requests.json` records the exact button-driven request bodies, including the cleared request without view criteria.
+- Playwright trace response bodies independently show the server-filtered sets: mail view 2 domains, expiring view 1 domain, incomplete view 1 domain, cleared query 3 domains.
+- `doctor.txt` reports web health HTTP 200 healthy.
+
+Ancillary dev-server evidence: the run logged a missing `/_build/assets/client.css`, blocked external font CORS requests, and expected aborted superseded search requests; these did not affect the verified page, endpoint responses, or feature assertions. The E2E harness completed successfully on the final drive.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/console.log | log | aux · unrecognized .log | 5ca1a50a649db81b351b7ca95451293a160e9b463db35f4bb79530039dc0a279 |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/env.txt | env | aux | 6fb7eeeebed0f9fef853c6f17b8f21ac0e789a6831598cb66f70655661d1ab84 |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/failed-requests.log | log | aux · unrecognized .log | febfe11d41c63a8dd1062ce5f6b3ae1cba3de0e48b4b63b7ab2be30d8df3ed0a |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/observations.md | md | aux · unrecognized .md | bdc3fe7e3b0ebff012dad973619d8d746b91b49494da81b55fb0d23f01ecec85 |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/portfolio-search.png | png | evidence · 1280x3748 | d5a71ca73a3a756df2f84d19da116aa14fad690e2d0aca8b68f8c56174af616c |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/trace.zip | trace | evidence · playwright trace | 0e80d340ebca278f3ff4f30fd1c131636e9140367dbd97957a08a35d76d5aacc |
+| verification/runs/20260903-205226Z-d5355e4-portfolio-search-fresh/video/1cce1919aae9cae370f0f7f01bfb38c6.webm | video | evidence | c59e824e8ee613da399e725a96f3d0829cd61a455e8f533269ed216fa98177a2 |

--- a/verification/receipts/20260903-212612Z-dc7e834-fresh--portfolio.search.md
+++ b/verification/receipts/20260903-212612Z-dc7e834-fresh--portfolio.search.md
@@ -1,0 +1,56 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-212612Z-dc7e834-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: dc7e83453085f1fbcb4e6ed5d05219a66bfbb775
+code_digest: 9f92ceebc10bea2a602083e6a16da59e26678af02bf3c93fe638b5ecb213b8ea
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260903-212612Z-dc7e834-fresh
+created_at: 2026-09-03T21:35:14.899Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` rendered headings `Portfolio workflows`, `Portfolio Search`, and `Built-in views`; labeled `Query` accepted `example.com`.
+- Built-in view clicks issued POST `/api/portfolio/search` with bodies: Mail broken `{severities:["high","critical"],limit:20,offset:0,findingTypePrefix:"mail."}`; Expiring evidence `{limit:20,offset:0,snapshotOlderThanDays:30}`; Incomplete coverage `{limit:20,offset:0,coverage:"incomplete"}`. Incomplete button reported `aria-pressed="true"`; re-click issued `{limit:20,offset:0}` and cleared criteria.
+- Direct same-header read-back returned HTTP 200 for every body: base domains `[mailbroken.example, stale.example, unevaluated.example]`; mail-broken `[mailbroken.example, unevaluated.example]`; expiring `[stale.example]`; incomplete `[unevaluated.example]`. Each filtered set was a subset of base and matched the requested server-side criterion.
+
+## Forbidden (… → confirmed absent)
+- No sign-in warning was used as a successful search; local e2e tenant/actor headers yielded real result JSON.
+- No cross-tenant leak: `X-Dev-Tenant: other-tenant` returned HTTP 200 with `domains: []`.
+- Duplicate identical incomplete-coverage POSTs returned identical HTTP 200 JSON.
+- Malformed severity input returned a JSON `{error:"Search failed"}` response without stack data (HTTP 500; see residual note below).
+- No class selectors were used by the drive.
+
+## Read-back
+- Evidence files: `readback/portfolio-search.json`, `readback/built-in-view-requests.json`, `readback/direct-server-readback.json`, and `readback/adversarial.json`.
+- Doctor passed against this checkout's web process: Bun present, Node present, `/api/health` HTTP 200 healthy.
+
+## Residual note
+- Invalid enum-like `severities:["bogus"]` produced clean JSON HTTP 500 rather than a client-error HTTP 400/422. No write occurs on this read-only endpoint, and no stack was exposed, but status-code validation could be tightened separately.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-212612Z-dc7e834-fresh/console.log | log | aux · unrecognized .log | a0cab3bf0f0596bc8ea77a62a530e64af97583143d4dd910637770cd11f5eac4 |
+| verification/runs/20260903-212612Z-dc7e834-fresh/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260903-212612Z-dc7e834-fresh/env.txt | env | aux | 9d43895a60ff47fbbeef2b4e538ed6fa60800166e5a58f42505ee0af32b2d92b |
+| verification/runs/20260903-212612Z-dc7e834-fresh/failed-requests.log | log | aux · unrecognized .log | ab8f547fb490fa005c9f1858de97011a35675e186f0a5874eda1b645fbc6db7b |
+| verification/runs/20260903-212612Z-dc7e834-fresh/observations.md | md | aux · unrecognized .md | 42895468fe6c1c162827ca9f713dcb24534b7c82790c266681d9254116829493 |
+| verification/runs/20260903-212612Z-dc7e834-fresh/portfolio-search.png | png | evidence · 1280x3748 | d5a71ca73a3a756df2f84d19da116aa14fad690e2d0aca8b68f8c56174af616c |
+| verification/runs/20260903-212612Z-dc7e834-fresh/readback/adversarial.json | readback | evidence | 637d13bc4bebf720156f1fee16c81aa389390a7667e4da19bd9f1e16b60c6c11 |
+| verification/runs/20260903-212612Z-dc7e834-fresh/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-212612Z-dc7e834-fresh/readback/direct-server-readback.json | readback | evidence | 8e8f9441486c19e203b195d2f107af4a48f46f0f48acac298343411a9f34f9e0 |
+| verification/runs/20260903-212612Z-dc7e834-fresh/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260903-212612Z-dc7e834-fresh/trace.zip | trace | evidence · playwright trace | ad6699599c69330a1374d1c5d3ba39da30cd1583b9a23b89149d828489fa69ca |
+| verification/runs/20260903-212612Z-dc7e834-fresh/video/c29110525c9461cb361b7543b6a8ee35.webm | video | evidence | 531ee850856905140182fe6e60cbd2254f48861aca16db0e2cf3c8d90b60d4bb |
+| verification/runs/20260903-212612Z-dc7e834-fresh/video/ea9025db8737023e94c7f79608f6ed35.webm | video | evidence | c11bd5416c5cd57f938a7fc52b5b327dcc1e6ce47256c65492bf5ed2f8fed57f |

--- a/verification/receipts/20260903-214115Z-8bce92d-fresh--domain.overview.md
+++ b/verification/receipts/20260903-214115Z-8bce92d-fresh--domain.overview.md
@@ -1,0 +1,39 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-214115Z-8bce92d-fresh
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 8bce92d0147be8667aa84b5e8ed16752631cee11
+code_digest: 9f92ceebc10bea2a602083e6a16da59e26678af02bf3c93fe638b5ecb213b8ea
+dirty: false
+untracked: 0
+status: blocked
+reason: "Required doctor precondition failed: web /api/health returned HTTP 503 status=degraded because the configured local PostgreSQL database connection was unavailable (postgres password authentication failed). Per verify-dns-ops, do not drive authenticated features after a failing doctor."
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260903-214115Z-8bce92d-fresh
+created_at: 2026-09-03T21:45:20.514Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+- App launch completed on this checkout at http://localhost:3000, but doctor could not establish the required healthy web surface.
+- Expected `GET /api/health` HTTP 200 with `status: healthy`; seen HTTP 503 with `{"status":"degraded","service":"dns-ops-web","warning":"Database connection not available - API functionality limited"}`.
+- `.agents/skills/verify-dns-ops/harness/doctor.sh` result: `ok bun present`, `ok node present`, `FAIL web /api/health 200 healthy`.
+
+## Forbidden (… → confirmed absent)
+- No authenticated Domain 360 flow was driven because the required doctor precondition failed; therefore no claims are made about URL, tabs, DNS TTL cells, or read-back.
+
+## Read-back
+- Direct `curl http://localhost:3000/api/health` reproduced the same 503 degraded response. Local PostgreSQL TCP port accepted connections, but the configured `postgresql://postgres:postgres@localhost:5432/dns_ops` credentials were rejected (`password authentication failed for user "postgres"`), so the database-backed verification surface was unavailable.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-214115Z-8bce92d-fresh/doctor-final.txt | txt | aux · unrecognized .txt | c0dff7a8c402d89e102015f624cf3c2613e55171da042f15ff3a9916e97fd298 |
+| verification/runs/20260903-214115Z-8bce92d-fresh/doctor.txt | txt | aux · unrecognized .txt | c0dff7a8c402d89e102015f624cf3c2613e55171da042f15ff3a9916e97fd298 |
+| verification/runs/20260903-214115Z-8bce92d-fresh/env.txt | env | aux | 03778ac7c906bce37122580d95030f3b1b9143d412e31f150c4165bb7bad2019 |
+| verification/runs/20260903-214115Z-8bce92d-fresh/observations.md | md | aux · unrecognized .md | 871dc6fb9e4b907c70b749dd0b38ddd4c27fde7b00e34c149402046757b2062a |


### PR DESCRIPTION
Closes #63

## What

Portfolio now opens on a **Built-in views** panel with three one-click operational views, built on the existing saved-filter machinery:

- **Mail broken** — domains with high/critical `mail.*` findings (`findingTypePrefix: "mail."` + severities `[high, critical]`).
- **Expiring evidence** — no snapshot in the last 30 days (`snapshotOlderThanDays: 30`).
- **Incomplete coverage** — latest evidence not fully evaluated (`coverage: "incomplete"`; no snapshot counts as incomplete).

Selecting a view sets the visible search controls from the view's `CurrentFilters` and sends the extra criteria alongside them to `POST /api/portfolio/search`; the active card is `aria-pressed` and re-clicking clears it. The search panel shows the active view with a **Clear view** control, and operator refinements (query/tags/severity/zone) compose with the active view.

## Backend

`/api/portfolio/search` gains three criteria, enforced server-side with the existing semantics: the evaluated-empty rule (unevaluated domains are kept under finding criteria), pagination over the domain page, and tenant scoping. Unsupported `coverage` values and out-of-range `snapshotOlderThanDays` return 400.

## Tests

- 8 focused route tests in `portfolio.test.ts` (keep/drop semantics for each criterion, unevaluated-domain retention, validation rejections, combined criteria).
- 7 view-module tests (`built-in-views.test.ts`) covering view bodies, refinement composition, and clear behavior.
- Full web unit suite: 1038 passed. Typecheck and Biome clean.

## Verification state (honest)

- Feature map (`portfolio.search.md`) and the `web.mts` harness drive were extended to click each view and assert the request criteria end-to-end.
- Mid-run steering stopped all long-running server verification before the browser drive ran, so the critical-profile receipt for `portfolio.search` is recorded as **blocked** (see commit and receipts). CI verify-kit will fail until a fresh `passed` receipt is produced at this exact tree — run the updated web.mts drive against a seeded tenant and add the receipt before merging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The portfolio page now opens on a Built-in views panel with three one-click operational views — Mail broken, Expiring evidence, and Incomplete coverage — built on the existing saved-filter machinery. Selecting a view sets the visible search controls and sends the view's extra criteria to `POST /api/portfolio/search`; re-clicking the active view clears it, and operator refinements compose with the active view. The critical `portfolio.search` profile is verified with a fresh passed receipt; the changed `domain.overview` profile is blocked — its doctor check failed on a local Postgres auth error — and needs a re-run before merge.

**Backend**
- `/api/portfolio/search` now accepts `findingTypePrefix`, `snapshotOlderThanDays`, and `coverage=incomplete`, enforced server-side with the existing evaluated-empty rule, pagination, and tenant scoping.
- Unsupported `coverage` values and out-of-range `snapshotOlderThanDays` return 400.

**Tests**
- E2E portfolio specs now expect the new Built-in views panel (9 total panels).

<sup>Written for commit fcb9381968f50d704c3d787732c90cfa5a24f93d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

