### PR TITLE
feat(web): add portfolio expiry radar from RDAP evidence (#60)

### DIFF
--- a/.agents/skills/verify-dns-ops/features/portfolio.search.md
+++ b/.agents/skills/verify-dns-ops/features/portfolio.search.md
@@ -8,8 +8,11 @@ paths:
   - apps/web/app/components/BuiltInViewsPanel.tsx
   - apps/web/app/lib/built-in-views.ts
   - apps/web/app/lib/built-in-views.test.ts
+  - apps/web/app/components/SavedFiltersPanel.tsx
+  - apps/web/app/lib/portfolio-filters.ts
   - apps/web/hono/routes/portfolio.ts
   - apps/web/hono/routes/portfolio.test.ts
+  - apps/web/e2e/portfolio-expiry.spec.ts
   - .agents/skills/verify-dns-ops/harness/web.mts
 always_with: []
 ---
@@ -22,6 +25,9 @@ An operator opens Portfolio workflows and searches tenant domains by query/tag.
 - Route `/portfolio` shows heading **Portfolio workflows** and **Portfolio Search**.
 - Query field labeled **Query**.
 - The **Built-in views** panel opens the workspace with three one-click views: **Mail broken**, **Expiring evidence**, and **Incomplete coverage** (issue #63). Selecting a view drives `POST /api/portfolio/search` with the view criteria (`findingTypePrefix: "mail."` plus high/critical severities, `snapshotOlderThanDays: 30`, `coverage: "incomplete"`); selecting the active view again clears it.
+- **Expiry window** select (Any / Within 7 days / Within 30 days / Within 90 days) feeds `expirationWithinDays` into the search request body.
+- Results render as a semantic table with an **Expiry** column: localized date plus bucket for OBSERVED rows, literal `UNKNOWN` otherwise.
+- Saved filters round-trip `expirationWithinDays` via Save Current / Load.
 - Saved filters, monitored domains, alerts, and related panels are present on the same page (chrome only unless the feature file is expanded).
 
 ## How to get to it (user POV)
@@ -47,6 +53,8 @@ await page.getByLabel('Query').fill('example.com');
 - **Query** accepts input.
 - The **Built-in views** panel shows the three view buttons; each click issues `POST /api/portfolio/search` whose request body carries that view's criteria, the button becomes `aria-pressed="true"`, and re-clicking removes the criteria.
 - View result sets respect the criteria server-side: `findingTypePrefix` returns only domains with matching-type findings (unevaluated domains are kept), `snapshotOlderThanDays` returns only domains whose latest snapshot is older, `coverage: "incomplete"` returns only domains whose evidence is not fully evaluated (a domain without a snapshot counts as incomplete).
+- **Expiry window** select is present and offers Any/7/30/90; choosing a window sends `expirationWithinDays` in the `POST /api/portfolio/search` body.
+- The results table has an **Expiry** column; rows without usable RDAP evidence show literal `UNKNOWN`.
 
 ### Forbidden observations
 - Treating the sign-in warning (“Operator sign-in is required to search tenant domains”) as a successful search.

--- a/.agents/skills/verify-dns-ops/harness/web.mts
+++ b/.agents/skills/verify-dns-ops/harness/web.mts
@@ -392,9 +392,42 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
       };
     }
 
-    const query = await searchRoundtrip(() => page.getByLabel('Query').fill('example.com'));
+    const query = await searchRoundtrip(() => page.getByLabel('Query').fill('verify-expiry'));
     if (!query.json || !Array.isArray(query.json.domains))
       throw new Error('portfolio search JSON missing domains[]');
+    // Built-in views (issue #63): each button must drive the real search
+    // endpoint with the view's criteria, and toggling it off removes them.
+    const mailBroken = await searchRoundtrip(() =>
+      page.getByRole('button', { name: /mail broken/i }).click()
+    );
+    if (mailBroken.request.findingTypePrefix !== 'mail.')
+      throw new Error(
+        `mail-broken view lost findingTypePrefix: ${JSON.stringify(mailBroken.request)}`
+      );
+    if (JSON.stringify(mailBroken.request.severities) !== JSON.stringify(['high', 'critical']))
+      throw new Error(`mail-broken view lost severities: ${JSON.stringify(mailBroken.request)}`);
+
+    const expiring = await searchRoundtrip(() =>
+      page.getByRole('button', { name: /expiring evidence/i }).click()
+    );
+    if (expiring.request.snapshotOlderThanDays !== 30)
+      throw new Error(
+        `expiring view lost snapshotOlderThanDays: ${JSON.stringify(expiring.request)}`
+      );
+
+    const incomplete = await searchRoundtrip(() =>
+      page.getByRole('button', { name: /incomplete coverage/i }).click()
+    );
+    if (incomplete.request.coverage !== 'incomplete')
+      throw new Error(`incomplete view lost coverage: ${JSON.stringify(incomplete.request)}`);
+    const activeButton = page.getByRole('button', { name: /incomplete coverage/i });
+    if ((await activeButton.getAttribute('aria-pressed')) !== 'true')
+      throw new Error('incomplete coverage button did not become aria-pressed=true');
+
+    const cleared = await searchRoundtrip(() => activeButton.click());
+    if (cleared.request.coverage !== undefined)
+      throw new Error(`clearing the view kept view criteria: ${JSON.stringify(cleared.request)}`);
+
     const queryNames = query.json.domains.map((d: { name: string }) => d.name);
     if (!queryNames.includes(fixture.observed) || !queryNames.includes(fixture.unknown))
       throw new Error(`expiry fixture domains missing from search results: ${JSON.stringify(queryNames)}`);
@@ -432,39 +465,6 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
       query: query.json,
       expiryWithin90Days: expiryJson,
     });
-
-    // Built-in views (issue #63): each button must drive the real search
-    // endpoint with the view's criteria, and toggling it off removes them.
-    const mailBroken = await searchRoundtrip(() =>
-      page.getByRole('button', { name: /mail broken/i }).click()
-    );
-    if (mailBroken.request.findingTypePrefix !== 'mail.')
-      throw new Error(
-        `mail-broken view lost findingTypePrefix: ${JSON.stringify(mailBroken.request)}`
-      );
-    if (JSON.stringify(mailBroken.request.severities) !== JSON.stringify(['high', 'critical']))
-      throw new Error(`mail-broken view lost severities: ${JSON.stringify(mailBroken.request)}`);
-
-    const expiring = await searchRoundtrip(() =>
-      page.getByRole('button', { name: /expiring evidence/i }).click()
-    );
-    if (expiring.request.snapshotOlderThanDays !== 30)
-      throw new Error(
-        `expiring view lost snapshotOlderThanDays: ${JSON.stringify(expiring.request)}`
-      );
-
-    const incomplete = await searchRoundtrip(() =>
-      page.getByRole('button', { name: /incomplete coverage/i }).click()
-    );
-    if (incomplete.request.coverage !== 'incomplete')
-      throw new Error(`incomplete view lost coverage: ${JSON.stringify(incomplete.request)}`);
-    const activeButton = page.getByRole('button', { name: /incomplete coverage/i });
-    if ((await activeButton.getAttribute('aria-pressed')) !== 'true')
-      throw new Error('incomplete coverage button did not become aria-pressed=true');
-
-    const cleared = await searchRoundtrip(() => activeButton.click());
-    if (cleared.request.coverage !== undefined)
-      throw new Error(`clearing the view kept view criteria: ${JSON.stringify(cleared.request)}`);
 
     await ev.readback('portfolio-search', query.json);
     await ev.readback('built-in-view-requests', {

--- a/.agents/skills/verify-dns-ops/harness/web.mts
+++ b/.agents/skills/verify-dns-ops/harness/web.mts
@@ -2,6 +2,8 @@
 // Run:  VERIFY_RUN_DIR=verification/runs/<id> bun .agents/skills/verify-dns-ops/harness/web.mts <feature-id>
 import fs from 'node:fs';
 import path from 'node:path';
+import { Pool } from 'pg';
+import { getTenantUUID } from '../../../../packages/contracts/src/tenant.ts';
 import type { Observation } from '@dns-ops/db/schema';
 import { type APIResponse, type BrowserContext, chromium, type Page } from '@playwright/test';
 import {
@@ -85,6 +87,64 @@ export async function login(page: Page) {
   await page.getByLabel('Password').fill(pass);
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByRole('heading', { name: /dns ops workbench/i }).waitFor({ timeout: 15_000 });
+}
+
+/** Seed isolated RDAP expiry rows for the portfolio proof and remove them after the drive. */
+async function seedPortfolioExpiryFixture(): Promise<{
+  observed: string;
+  unknown: string;
+  expirationDate: string;
+  cleanup: () => Promise<void>;
+}> {
+  const tenantId = await getTenantUUID(process.env.E2E_DEV_TENANT ?? 'dns-ops-e2e');
+  const observed = 'verify-expiry-observed.example.test';
+  const unknown = 'verify-expiry-unknown.example.test';
+  const expirationDate = new Date(Date.now() + 45 * 24 * 60 * 60 * 1000).toISOString();
+  const connectionString =
+    process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5432/dns_ops';
+  const remove = async () => {
+    const pool = new Pool({ connectionString });
+    try {
+      await pool.query('DELETE FROM domains WHERE tenant_id = $1 AND normalized_name = ANY($2)', [
+        tenantId,
+        [observed, unknown],
+      ]);
+    } finally {
+      await pool.end();
+    }
+  };
+  await remove();
+  const pool = new Pool({ connectionString });
+  try {
+    const insertDomain = async (name: string) =>
+      (await pool.query(
+        `INSERT INTO domains (name, normalized_name, zone_management, tenant_id, metadata)
+         VALUES ($1, $1, 'managed', $2, '{"portfolio": true}'::jsonb) RETURNING id`,
+        [name, tenantId]
+      )).rows[0].id as string;
+    const insertSnapshot = async (domainId: string, name: string) =>
+      (await pool.query(
+        `INSERT INTO snapshots (domain_id, domain_name, result_state, queried_names,
+         queried_types, vantages, zone_management, triggered_by, metadata)
+         VALUES ($1, $2, 'complete', $3::jsonb, '[]'::jsonb, '[]'::jsonb, 'managed',
+         'verify-harness', '{"evaluation":{"state":"COMPLETE"}}'::jsonb) RETURNING id`,
+        [domainId, name, JSON.stringify([name])]
+      )).rows[0].id as string;
+    const observedDomainId = await insertDomain(observed);
+    await insertSnapshot(await insertDomain(unknown), unknown);
+    const observedSnapshotId = await insertSnapshot(observedDomainId, observed);
+    await pool.query(
+      `INSERT INTO probe_observations (snapshot_id, probe_type, status, hostname, port,
+       success, probe_data) VALUES ($1, 'rdap', 'success', $2, 443, true, $3::jsonb)`,
+      [observedSnapshotId, observed, JSON.stringify({
+        check: 'RDAP_EXPIRATION', status: 'OBSERVED',
+        evidence: { kind: 'RDAP_EXPIRATION', domain: observed, expirationDate },
+      })]
+    );
+  } finally {
+    await pool.end();
+  }
+  return { observed, unknown, expirationDate, cleanup: remove };
 }
 
 function responseServerDate(response: APIResponse, label: string): number {
@@ -308,6 +368,7 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
     await ev.shot(page, 'domain-dns-parsed-ttl');
   },
   'portfolio.search': async (page, ev) => {
+    const fixture = await seedPortfolioExpiryFixture();
     await page.goto(`${BASE_URL}/portfolio`);
     await page.getByRole('heading', { name: /portfolio workflows/i }).waitFor({ timeout: 15_000 });
     await page.getByRole('heading', { name: /portfolio search/i }).waitFor();
@@ -334,6 +395,43 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
     const query = await searchRoundtrip(() => page.getByLabel('Query').fill('example.com'));
     if (!query.json || !Array.isArray(query.json.domains))
       throw new Error('portfolio search JSON missing domains[]');
+    const queryNames = query.json.domains.map((d: { name: string }) => d.name);
+    if (!queryNames.includes(fixture.observed) || !queryNames.includes(fixture.unknown))
+      throw new Error(`expiry fixture domains missing from search results: ${JSON.stringify(queryNames)}`);
+    const observedRow = query.json.domains.find(
+      (d: { name: string }) => d.name === fixture.observed
+    );
+    if (observedRow?.expiration?.status !== 'OBSERVED')
+      throw new Error(`expected OBSERVED expiration for ${fixture.observed}`);
+    const table = page.getByRole('table');
+    await table.getByRole('columnheader', { name: 'Expiry' }).waitFor({ timeout: 15_000 });
+    await table
+      .getByRole('row', { name: new RegExp(fixture.observed.replace(/\\./g, '\\\\.')) })
+      .getByText('WITHIN_90')
+      .waitFor({ timeout: 15_000 });
+    await table
+      .getByRole('row', { name: new RegExp(fixture.unknown.replace(/\\./g, '\\\\.')) })
+      .getByRole('cell', { name: 'UNKNOWN', exact: true })
+      .waitFor({ timeout: 15_000 });
+    const expiryPending = page.waitForResponse(
+      (r) => {
+        if (!r.url().includes('/api/portfolio/search') || r.request().method() !== 'POST') return false;
+        return r.request().postDataJSON()?.expirationWithinDays === 90;
+      },
+      { timeout: 15_000 }
+    );
+    await page.getByLabel('Expiry window').selectOption('90');
+    const expiryRes = await expiryPending;
+    if (expiryRes.status() !== 200) throw new Error(`expiry search expected 200, got ${expiryRes.status()}`);
+    const expiryJson = await expiryRes.json();
+    const expiryNames = expiryJson.domains.map((d: { name: string }) => d.name);
+    if (!expiryNames.includes(fixture.observed) || expiryNames.includes(fixture.unknown))
+      throw new Error(`expiry filter returned unexpected domains: ${JSON.stringify(expiryNames)}`);
+    await ev.readback('portfolio-expiry', {
+      fixture: { observed: fixture.observed, unknown: fixture.unknown, seededExpirationDate: fixture.expirationDate },
+      query: query.json,
+      expiryWithin90Days: expiryJson,
+    });
 
     // Built-in views (issue #63): each button must drive the real search
     // endpoint with the view's criteria, and toggling it off removes them.
@@ -376,6 +474,7 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
       cleared: cleared.request,
     });
     await ev.shot(page, 'portfolio-search');
+    await fixture.cleanup();
   },
 };
 

--- a/.agents/skills/verify-dns-ops/harness/web.mts
+++ b/.agents/skills/verify-dns-ops/harness/web.mts
@@ -2,10 +2,9 @@
 // Run:  VERIFY_RUN_DIR=verification/runs/<id> bun .agents/skills/verify-dns-ops/harness/web.mts <feature-id>
 import fs from 'node:fs';
 import path from 'node:path';
-import { Pool } from 'pg';
-import { getTenantUUID } from '../../../../packages/contracts/src/tenant.ts';
 import type { Observation } from '@dns-ops/db/schema';
 import { type APIResponse, type BrowserContext, chromium, type Page } from '@playwright/test';
+import { Pool } from 'pg';
 import {
   estimateLiveAt,
   indexObservationsById,
@@ -13,6 +12,7 @@ import {
   parseServerDate,
   toDateTimeAttribute,
 } from '../../../../apps/web/app/lib/dns-ttl.js';
+import { getTenantUUID } from '../../../../packages/contracts/src/tenant.ts';
 import { observationsToRecordSets } from '../../../../packages/parsing/src/dns/recordset.js';
 
 export const BASE_URL = process.env.APP_URL ?? 'http://localhost:3000';
@@ -117,29 +117,38 @@ async function seedPortfolioExpiryFixture(): Promise<{
   const pool = new Pool({ connectionString });
   try {
     const insertDomain = async (name: string) =>
-      (await pool.query(
-        `INSERT INTO domains (name, normalized_name, zone_management, tenant_id, metadata)
+      (
+        await pool.query(
+          `INSERT INTO domains (name, normalized_name, zone_management, tenant_id, metadata)
          VALUES ($1, $1, 'managed', $2, '{"portfolio": true}'::jsonb) RETURNING id`,
-        [name, tenantId]
-      )).rows[0].id as string;
+          [name, tenantId]
+        )
+      ).rows[0].id as string;
     const insertSnapshot = async (domainId: string, name: string) =>
-      (await pool.query(
-        `INSERT INTO snapshots (domain_id, domain_name, result_state, queried_names,
+      (
+        await pool.query(
+          `INSERT INTO snapshots (domain_id, domain_name, result_state, queried_names,
          queried_types, vantages, zone_management, triggered_by, metadata)
          VALUES ($1, $2, 'complete', $3::jsonb, '[]'::jsonb, '[]'::jsonb, 'managed',
          'verify-harness', '{"evaluation":{"state":"COMPLETE"}}'::jsonb) RETURNING id`,
-        [domainId, name, JSON.stringify([name])]
-      )).rows[0].id as string;
+          [domainId, name, JSON.stringify([name])]
+        )
+      ).rows[0].id as string;
     const observedDomainId = await insertDomain(observed);
     await insertSnapshot(await insertDomain(unknown), unknown);
     const observedSnapshotId = await insertSnapshot(observedDomainId, observed);
     await pool.query(
       `INSERT INTO probe_observations (snapshot_id, probe_type, status, hostname, port,
        success, probe_data) VALUES ($1, 'rdap', 'success', $2, 443, true, $3::jsonb)`,
-      [observedSnapshotId, observed, JSON.stringify({
-        check: 'RDAP_EXPIRATION', status: 'OBSERVED',
-        evidence: { kind: 'RDAP_EXPIRATION', domain: observed, expirationDate },
-      })]
+      [
+        observedSnapshotId,
+        observed,
+        JSON.stringify({
+          check: 'RDAP_EXPIRATION',
+          status: 'OBSERVED',
+          evidence: { kind: 'RDAP_EXPIRATION', domain: observed, expirationDate },
+        }),
+      ]
     );
   } finally {
     await pool.end();
@@ -430,7 +439,9 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
 
     const queryNames = query.json.domains.map((d: { name: string }) => d.name);
     if (!queryNames.includes(fixture.observed) || !queryNames.includes(fixture.unknown))
-      throw new Error(`expiry fixture domains missing from search results: ${JSON.stringify(queryNames)}`);
+      throw new Error(
+        `expiry fixture domains missing from search results: ${JSON.stringify(queryNames)}`
+      );
     const observedRow = query.json.domains.find(
       (d: { name: string }) => d.name === fixture.observed
     );
@@ -448,20 +459,26 @@ const drives: Record<string, (page: Page, ev: Evidence) => Promise<void>> = {
       .waitFor({ timeout: 15_000 });
     const expiryPending = page.waitForResponse(
       (r) => {
-        if (!r.url().includes('/api/portfolio/search') || r.request().method() !== 'POST') return false;
+        if (!r.url().includes('/api/portfolio/search') || r.request().method() !== 'POST')
+          return false;
         return r.request().postDataJSON()?.expirationWithinDays === 90;
       },
       { timeout: 15_000 }
     );
     await page.getByLabel('Expiry window').selectOption('90');
     const expiryRes = await expiryPending;
-    if (expiryRes.status() !== 200) throw new Error(`expiry search expected 200, got ${expiryRes.status()}`);
+    if (expiryRes.status() !== 200)
+      throw new Error(`expiry search expected 200, got ${expiryRes.status()}`);
     const expiryJson = await expiryRes.json();
     const expiryNames = expiryJson.domains.map((d: { name: string }) => d.name);
     if (!expiryNames.includes(fixture.observed) || expiryNames.includes(fixture.unknown))
       throw new Error(`expiry filter returned unexpected domains: ${JSON.stringify(expiryNames)}`);
     await ev.readback('portfolio-expiry', {
-      fixture: { observed: fixture.observed, unknown: fixture.unknown, seededExpirationDate: fixture.expirationDate },
+      fixture: {
+        observed: fixture.observed,
+        unknown: fixture.unknown,
+        seededExpirationDate: fixture.expirationDate,
+      },
       query: query.json,
       expiryWithin90Days: expiryJson,
     });

--- a/apps/web/app/components/PortfolioSearchPanel.tsx
+++ b/apps/web/app/components/PortfolioSearchPanel.tsx
@@ -5,6 +5,7 @@ import { type BuiltInView, searchBodyForView } from '../lib/built-in-views.js';
 import {
   type CurrentFilters,
   EMPTY_CURRENT_FILTERS,
+  type ExpirationWindow,
   normalizeCurrentFilters,
   type Severity,
   type ZoneManagement,
@@ -35,10 +36,24 @@ interface SearchResult {
     resultState: string;
     rulesetVersionId: string | null;
   } | null;
+  expiration:
+    | {
+        status: 'OBSERVED';
+        expirationDate: string;
+        observedAt: string;
+        bucket: 'EXPIRED' | 'WITHIN_7' | 'WITHIN_30' | 'WITHIN_90' | 'LATER';
+      }
+    | { status: 'UNKNOWN' };
 }
 
 const SEVERITIES: Severity[] = ['critical', 'high', 'medium', 'low', 'info'];
 const ZONE_MANAGEMENT: ZoneManagement[] = ['managed', 'unmanaged', 'unknown'];
+const EXPIRY_WINDOW_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '', label: 'Any' },
+  { value: '7', label: 'Within 7 days' },
+  { value: '30', label: 'Within 30 days' },
+  { value: '90', label: 'Within 90 days' },
+];
 
 export function PortfolioSearchPanel({
   currentFilters,
@@ -50,6 +65,7 @@ export function PortfolioSearchPanel({
   const idPrefix = useId();
   const queryId = `${idPrefix}-portfolio-search-query`;
   const tagsId = `${idPrefix}-portfolio-search-tags`;
+  const expiryWindowId = `${idPrefix}-portfolio-search-expiry-window`;
   const [tagDraft, setTagDraft] = useState('');
 
   const normalizedFilters = useMemo(
@@ -310,6 +326,30 @@ export function PortfolioSearchPanel({
           </div>
         </fieldset>
 
+        <div>
+          <label className="mb-1 block text-sm font-medium text-text" htmlFor={expiryWindowId}>
+            Expiry window
+          </label>
+          <select
+            id={expiryWindowId}
+            value={normalizedFilters.expirationWithinDays ?? ''}
+            onChange={(e) =>
+              updateFilters({
+                expirationWithinDays:
+                  e.target.value === '' ? null : (Number(e.target.value) as ExpirationWindow),
+              })
+            }
+            disabled={authRequired}
+            className="ds-input w-full rounded-lg border border-line px-3 py-2 focus:border-brand focus:ring-2 focus:ring-focus disabled:bg-surface-muted"
+          >
+            {EXPIRY_WINDOW_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
         <div className="flex justify-end">
           <button
             type="button"
@@ -344,10 +384,28 @@ export function PortfolioSearchPanel({
               No tenant domains matched the current filters.
             </div>
           ) : (
-            <div className="space-y-3">
-              {results.map((result) => (
-                <SearchResultCard key={result.id} result={result} />
-              ))}
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <caption className="sr-only">Portfolio search results by domain</caption>
+                <thead>
+                  <tr className="border-b border-line text-xs uppercase tracking-wide text-muted">
+                    <th scope="col" className="px-2 py-2 font-medium">
+                      Domain
+                    </th>
+                    <th scope="col" className="px-2 py-2 font-medium">
+                      Findings
+                    </th>
+                    <th scope="col" className="px-2 py-2 font-medium">
+                      Expiry
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {results.map((result) => (
+                    <SearchResultRow key={result.id} result={result} />
+                  ))}
+                </tbody>
+              </table>
             </div>
           )}
         </div>
@@ -356,7 +414,7 @@ export function PortfolioSearchPanel({
   );
 }
 
-function SearchResultCard({ result }: { result: SearchResult }) {
+function SearchResultRow({ result }: { result: SearchResult }) {
   const counts = result.findings.reduce(
     (acc, finding) => {
       acc[finding.severity] += 1;
@@ -366,33 +424,28 @@ function SearchResultCard({ result }: { result: SearchResult }) {
   );
 
   return (
-    <div className="rounded-lg border border-line bg-surface-muted p-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <Link
-            to="/domain/$domain"
-            params={{ domain: result.normalizedName }}
-            className="text-base font-medium text-brand hover:text-brand"
-          >
-            {result.name}
-          </Link>
-          <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted">
-            <span className="rounded bg-surface px-2 py-0.5 text-text">
-              {result.zoneManagement}
+    <tr className="border-b border-line align-top">
+      <th scope="row" className="px-2 py-3 font-normal">
+        <Link
+          to="/domain/$domain"
+          params={{ domain: result.normalizedName }}
+          className="text-base font-medium text-brand hover:text-brand"
+        >
+          {result.name}
+        </Link>
+        <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted">
+          <span className="rounded bg-surface px-2 py-0.5 text-text">{result.zoneManagement}</span>
+          {result.latestSnapshot ? (
+            <span>
+              {result.latestSnapshot.resultState} ·{' '}
+              {new Date(result.latestSnapshot.createdAt).toLocaleString()}
             </span>
-            {result.latestSnapshot ? (
-              <span>
-                {result.latestSnapshot.resultState} ·{' '}
-                {new Date(result.latestSnapshot.createdAt).toLocaleString()}
-              </span>
-            ) : (
-              <span>No snapshot available yet</span>
-            )}
-          </div>
+          ) : (
+            <span>No snapshot available yet</span>
+          )}
         </div>
-      </div>
-
-      <div className="mt-3 text-sm text-text">
+      </th>
+      <td className="px-2 py-3 text-text">
         {!result.findingsEvaluated ? (
           <span className="ds-badge ds-badge--unknown">
             Needs setup/evidence. {result.evaluationCoverage.errors[0]?.unknown.explanation}{' '}
@@ -411,7 +464,23 @@ function SearchResultCard({ result }: { result: SearchResult }) {
             ))}
           </div>
         )}
-      </div>
-    </div>
+      </td>
+      <td className="px-2 py-3 text-text">
+        {'expirationDate' in result.expiration ? (
+          <span className="flex flex-col gap-0.5">
+            <span>
+              {new Date(result.expiration.expirationDate).toLocaleDateString(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })}
+            </span>
+            <span className="text-xs text-muted">{result.expiration.bucket}</span>
+          </span>
+        ) : (
+          <span>UNKNOWN</span>
+        )}
+      </td>
+    </tr>
   );
 }

--- a/apps/web/app/components/SavedFiltersPanel.tsx
+++ b/apps/web/app/components/SavedFiltersPanel.tsx
@@ -596,6 +596,9 @@ function CriteriaPreview({ criteria }: { criteria: FilterCriteria }) {
   if (criteria.lastSnapshotWithin) {
     chips.push(`Snapshot <= ${criteria.lastSnapshotWithin}d`);
   }
+  if (criteria.expirationWithinDays) {
+    chips.push(`Expiry <= ${criteria.expirationWithinDays}d`);
+  }
 
   if (chips.length === 0) {
     return <span className="text-xs text-faint">No filters selected</span>;
@@ -631,5 +634,6 @@ function getCriteriaCount(criteria: FilterCriteria): number {
   if (criteria.findings?.severities?.length) count += criteria.findings.severities.length;
   if (criteria.findings?.types?.length) count += criteria.findings.types.length;
   if (criteria.lastSnapshotWithin) count += 1;
+  if (criteria.expirationWithinDays) count += 1;
   return count;
 }

--- a/apps/web/app/lib/portfolio-filters.test.ts
+++ b/apps/web/app/lib/portfolio-filters.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Portfolio Filter Criteria Tests - Issue #60
+ *
+ * Round-trip coverage for the expirationWithinDays criterion:
+ * current UI state -> saved criteria -> loaded UI state -> search request body.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  assessSavedCriteriaCompatibility,
+  type CurrentFilters,
+  currentFiltersToSavedCriteria,
+  currentFiltersToSearchBody,
+  EMPTY_CURRENT_FILTERS,
+  hasActiveFilters,
+  savedCriteriaToCurrentFilters,
+} from './portfolio-filters.js';
+
+describe('portfolio-filters expirationWithinDays round-trip', () => {
+  it('round-trips a 90-day expiry window through saved criteria and back', () => {
+    const current: CurrentFilters = {
+      ...EMPTY_CURRENT_FILTERS,
+      expirationWithinDays: 90,
+    };
+
+    const criteria = currentFiltersToSavedCriteria(current);
+    expect(criteria.expirationWithinDays).toBe(90);
+
+    const loaded = savedCriteriaToCurrentFilters(criteria);
+    expect(loaded.expirationWithinDays).toBe(90);
+    expect(loaded).toEqual(current);
+
+    const body = currentFiltersToSearchBody(loaded) as { expirationWithinDays?: number };
+    expect(body.expirationWithinDays).toBe(90);
+  });
+
+  it('round-trips 7 and 30 day windows', () => {
+    for (const window of [7, 30] as const) {
+      const current: CurrentFilters = { ...EMPTY_CURRENT_FILTERS, expirationWithinDays: window };
+      const criteria = currentFiltersToSavedCriteria(current);
+      const loaded = savedCriteriaToCurrentFilters(criteria);
+      const body = currentFiltersToSearchBody(loaded) as { expirationWithinDays?: number };
+      expect(loaded.expirationWithinDays).toBe(window);
+      expect(body.expirationWithinDays).toBe(window);
+    }
+  });
+
+  it('omits expirationWithinDays from saved criteria and search body when unset', () => {
+    const current = EMPTY_CURRENT_FILTERS;
+
+    const criteria = currentFiltersToSavedCriteria(current);
+    expect(criteria.expirationWithinDays).toBeUndefined();
+
+    const body = currentFiltersToSearchBody(current);
+    expect('expirationWithinDays' in body).toBe(false);
+  });
+
+  it('counts an expiry window as an active filter', () => {
+    expect(hasActiveFilters({ ...EMPTY_CURRENT_FILTERS, expirationWithinDays: 90 })).toBe(true);
+    expect(hasActiveFilters(EMPTY_CURRENT_FILTERS)).toBe(false);
+  });
+
+  it('combines the expiry window with other criteria without losing either', () => {
+    const current: CurrentFilters = {
+      query: 'example',
+      tags: ['production'],
+      severities: ['high'],
+      zoneManagement: ['managed'],
+      expirationWithinDays: 30,
+    };
+
+    const criteria = currentFiltersToSavedCriteria(current);
+    expect(criteria).toEqual({
+      domainPatterns: ['example'],
+      tags: ['production'],
+      findings: { severities: ['high'] },
+      zoneManagement: ['managed'],
+      expirationWithinDays: 30,
+    });
+
+    const loaded = savedCriteriaToCurrentFilters(criteria);
+    expect(loaded).toEqual(current);
+  });
+
+  it('marks persisted expiry values other than 7/30/90 as incompatible', () => {
+    for (const invalid of [45, 0, -7, 365]) {
+      const compatibility = assessSavedCriteriaCompatibility({
+        expirationWithinDays: invalid as 7 | 30 | 90,
+      });
+      expect(compatibility.supported).toBe(false);
+      expect(compatibility.reasons.join(' ')).toMatch(/expiry/i);
+    }
+  });
+
+  it('accepts persisted expiry criteria of exactly 7, 30, or 90', () => {
+    for (const valid of [7, 30, 90]) {
+      expect(
+        assessSavedCriteriaCompatibility({ expirationWithinDays: valid as 7 | 30 | 90 }).supported
+      ).toBe(true);
+    }
+  });
+
+  it('drops invalid persisted expiry values when loading into current filters', () => {
+    const loaded = savedCriteriaToCurrentFilters({
+      expirationWithinDays: 45 as 7 | 30 | 90,
+    });
+    expect(loaded.expirationWithinDays).toBeNull();
+  });
+
+  it('drops non-numeric persisted expiry values when loading into current filters', () => {
+    const loaded = savedCriteriaToCurrentFilters({
+      expirationWithinDays: '90' as unknown as 7 | 30 | 90,
+    });
+    expect(loaded.expirationWithinDays).toBeNull();
+  });
+});

--- a/apps/web/app/lib/portfolio-filters.ts
+++ b/apps/web/app/lib/portfolio-filters.ts
@@ -1,5 +1,14 @@
 export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type ZoneManagement = 'managed' | 'unmanaged' | 'unknown';
+export type ExpirationWindow = 7 | 30 | 90;
+
+export const EXPIRATION_WINDOWS: readonly ExpirationWindow[] = [7, 30, 90];
+
+function normalizeExpirationWindow(value: unknown): ExpirationWindow | null {
+  return EXPIRATION_WINDOWS.includes(value as ExpirationWindow)
+    ? (value as ExpirationWindow)
+    : null;
+}
 
 export interface FilterCriteria {
   domainPatterns?: string[];
@@ -11,6 +20,7 @@ export interface FilterCriteria {
   };
   tags?: string[];
   lastSnapshotWithin?: number;
+  expirationWithinDays?: ExpirationWindow;
 }
 
 export interface CurrentFilters {
@@ -18,6 +28,7 @@ export interface CurrentFilters {
   tags: string[];
   severities: Severity[];
   zoneManagement: ZoneManagement[];
+  expirationWithinDays?: ExpirationWindow | null;
 }
 
 export interface SavedFilterCriteriaCompatibility {
@@ -30,6 +41,7 @@ export const EMPTY_CURRENT_FILTERS: CurrentFilters = {
   tags: [],
   severities: [],
   zoneManagement: [],
+  expirationWithinDays: null,
 };
 
 export function normalizeCurrentFilters(filters: CurrentFilters): CurrentFilters {
@@ -38,6 +50,7 @@ export function normalizeCurrentFilters(filters: CurrentFilters): CurrentFilters
     tags: dedupe(filters.tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean)),
     severities: dedupe(filters.severities),
     zoneManagement: dedupe(filters.zoneManagement),
+    expirationWithinDays: normalizeExpirationWindow(filters.expirationWithinDays),
   };
 }
 
@@ -47,7 +60,8 @@ export function hasActiveFilters(filters: CurrentFilters): boolean {
     normalized.query.length > 0 ||
     normalized.tags.length > 0 ||
     normalized.severities.length > 0 ||
-    normalized.zoneManagement.length > 0
+    normalized.zoneManagement.length > 0 ||
+    normalized.expirationWithinDays !== null
   );
 }
 
@@ -67,6 +81,9 @@ export function currentFiltersToSavedCriteria(filters: CurrentFilters): FilterCr
   if (normalized.zoneManagement.length > 0) {
     criteria.zoneManagement = normalized.zoneManagement;
   }
+  if (normalized.expirationWithinDays !== null) {
+    criteria.expirationWithinDays = normalized.expirationWithinDays;
+  }
 
   return criteria;
 }
@@ -78,6 +95,9 @@ export function currentFiltersToSearchBody(filters: CurrentFilters): Record<stri
     ...(normalized.tags.length > 0 ? { tags: normalized.tags } : {}),
     ...(normalized.severities.length > 0 ? { severities: normalized.severities } : {}),
     ...(normalized.zoneManagement.length > 0 ? { zoneManagement: normalized.zoneManagement } : {}),
+    ...(normalized.expirationWithinDays !== null
+      ? { expirationWithinDays: normalized.expirationWithinDays }
+      : {}),
     limit: 20,
     offset: 0,
   };
@@ -100,6 +120,12 @@ export function assessSavedCriteriaCompatibility(
   if (criteria.lastSnapshotWithin) {
     reasons.push('snapshot recency');
   }
+  if (
+    criteria.expirationWithinDays !== undefined &&
+    !normalizeExpirationWindow(criteria.expirationWithinDays)
+  ) {
+    reasons.push('unsupported expiry window');
+  }
 
   return {
     supported: reasons.length === 0,
@@ -113,6 +139,7 @@ export function savedCriteriaToCurrentFilters(criteria: FilterCriteria): Current
     tags: criteria.tags || [],
     severities: criteria.findings?.severities || [],
     zoneManagement: criteria.zoneManagement || [],
+    expirationWithinDays: normalizeExpirationWindow(criteria.expirationWithinDays),
   });
 }
 

--- a/apps/web/e2e/portfolio-expiry.spec.ts
+++ b/apps/web/e2e/portfolio-expiry.spec.ts
@@ -1,0 +1,162 @@
+import { expect, type Page, test } from '@playwright/test';
+
+/**
+ * Issue #60 e2e: expiry column, expiry window selector, and saved-filter
+ * round-trip on the Portfolio Search panel.
+ */
+
+const OBSERVED_EXPIRY_ISO = '2026-12-15T00:00:00.000Z';
+
+function portfolioDomains() {
+  return [
+    {
+      id: 'domain-expiring',
+      name: 'expiring.example.test',
+      normalizedName: 'expiring.example.test',
+      zoneManagement: 'managed',
+      findings: [],
+      findingsEvaluated: true,
+      evaluationCoverage: { state: 'COMPLETE', errors: [] },
+      latestSnapshot: {
+        id: 'snap-1',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        resultState: 'complete',
+        rulesetVersionId: 'ruleset-v1',
+      },
+      expiration: {
+        status: 'OBSERVED',
+        expirationDate: OBSERVED_EXPIRY_ISO,
+        observedAt: '2026-08-01T00:00:00.000Z',
+        bucket: 'WITHIN_90',
+      },
+    },
+    {
+      id: 'domain-unknown',
+      name: 'unknown-expiry.example.test',
+      normalizedName: 'unknown-expiry.example.test',
+      zoneManagement: 'managed',
+      findings: [],
+      findingsEvaluated: true,
+      evaluationCoverage: { state: 'COMPLETE', errors: [] },
+      latestSnapshot: {
+        id: 'snap-2',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        resultState: 'complete',
+        rulesetVersionId: 'ruleset-v1',
+      },
+      expiration: { status: 'UNKNOWN' },
+    },
+  ];
+}
+
+async function mockPortfolioWorkspace(page: Page): Promise<void> {
+  await page.route('**/api/portfolio/tags', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ tags: [] }) })
+  );
+  await page.route('**/api/portfolio/search', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ domains: portfolioDomains() }),
+    })
+  );
+  await page.route('**/api/portfolio/filters', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ filters: [] }) })
+  );
+  await page.route('**/api/monitoring/domains', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ monitoredDomains: [] }),
+    })
+  );
+  await page.route('**/api/portfolio/audit?*', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ events: [] }) })
+  );
+  await page.route('**/api/alerts**', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        alerts: [],
+        pagination: { total: 0, offset: 0, hasMore: false },
+      }),
+    })
+  );
+}
+
+test.describe('Portfolio expiry radar', () => {
+  test('renders the Expiry column with the bucket or literal UNKNOWN', async ({ page }) => {
+    await mockPortfolioWorkspace(page);
+    await page.goto('/portfolio');
+
+    await expect(page.getByRole('heading', { name: /portfolio workflows/i })).toBeVisible();
+
+    const table = page.getByRole('table');
+    await expect(table).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Expiry' })).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Domain' })).toBeVisible();
+
+    const expiringRow = table.getByRole('row', { name: /expiring\.example\.test/ });
+    await expect(expiringRow.getByText('WITHIN_90')).toBeVisible();
+
+    const unknownRow = table.getByRole('row', { name: /unknown-expiry\.example\.test/ });
+    await expect(unknownRow.getByRole('cell', { name: 'UNKNOWN', exact: true })).toBeVisible();
+  });
+
+  test('sends expirationWithinDays when an expiry window is selected', async ({ page }) => {
+    await mockPortfolioWorkspace(page);
+    await page.goto('/portfolio');
+
+    const expiryWindow = page.getByLabel('Expiry window');
+    await expect(expiryWindow).toBeVisible();
+    await expect(expiryWindow).toHaveValue('');
+    await expect(page.getByRole('table')).toBeVisible();
+
+    const request = page.waitForRequest(
+      (candidate) =>
+        candidate.url().endsWith('/api/portfolio/search') &&
+        candidate.method() === 'POST' &&
+        (candidate.postDataJSON() as Record<string, unknown>).expirationWithinDays === 90
+    );
+    await expiryWindow.selectOption('90');
+    const captured = await request;
+    expect(captured).toBeDefined();
+    await expect(expiryWindow).toHaveValue('90');
+  });
+
+  test('loads a saved 90-day expiry filter and searches with it', async ({ page }) => {
+    await mockPortfolioWorkspace(page);
+    await page.route('**/api/portfolio/filters', (route) =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          filters: [
+            {
+              id: 'filter-expiring-90',
+              name: 'Expiring within 90 days',
+              description: 'Saved expiry radar filter',
+              criteria: { expirationWithinDays: 90 },
+              isShared: false,
+              createdBy: 'e2e-bot',
+              createdAt: '2026-08-01T00:00:00.000Z',
+              updatedAt: '2026-08-01T00:00:00.000Z',
+              canManage: true,
+            },
+          ],
+        }),
+      })
+    );
+
+    await page.goto('/portfolio');
+
+    await expect(page.getByText('Expiring within 90 days')).toBeVisible();
+
+    const request = page.waitForRequest(
+      (candidate) =>
+        candidate.url().endsWith('/api/portfolio/search') &&
+        candidate.method() === 'POST' &&
+        (candidate.postDataJSON() as Record<string, unknown>).expirationWithinDays === 90
+    );
+    await page.getByRole('button', { name: 'Load filter' }).click();
+    await request;
+    await expect(page.getByLabel('Expiry window')).toHaveValue('90');
+  });
+});

--- a/apps/web/e2e/portfolio-signal-room.spec.ts
+++ b/apps/web/e2e/portfolio-signal-room.spec.ts
@@ -28,6 +28,7 @@ async function mockPortfolioWorkspace(page: import('@playwright/test').Page): Pr
               ],
             },
             latestSnapshot: null,
+            expiration: { status: 'UNKNOWN' },
           },
         ],
       }),

--- a/apps/web/hono/routes/portfolio.expiry.test.ts
+++ b/apps/web/hono/routes/portfolio.expiry.test.ts
@@ -1,0 +1,637 @@
+/**
+ * Portfolio Expiry Radar Tests - Issue #60
+ *
+ * Focused route tests for the RDAP-derived expiration read model:
+ * - Only latest-snapshot, successful OBSERVED RDAP_EXPIRATION evidence becomes a date.
+ * - Missing, failed, conflicting, mismatched, or unparseable evidence is UNKNOWN.
+ * - Exact inclusive 7/30/90 day boundaries with a fixed clock.
+ * - Expiry filtering and sorting happen before pagination; `total` reflects all matches.
+ * - Tenant isolation at the response level.
+ *
+ * The mock database deliberately ignores Drizzle predicates (a known limitation of
+ * broad mocks) so these tests must assert on route output, not on predicate fidelity.
+ */
+
+import type { IDatabaseAdapter } from '@dns-ops/db';
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../types.js';
+import { portfolioRoutes } from './portfolio.js';
+
+const TENANT_A = '11111111-1111-4111-8111-111111111111';
+const TENANT_B = '22222222-2222-4222-8222-222222222222';
+
+// Fixed "now" for boundary tests: 2026-09-01T00:00:00.000Z
+const NOW = new Date('2026-09-01T00:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type MockDomain = {
+  id: string;
+  tenantId: string;
+  name: string;
+  normalizedName: string;
+  zoneManagement: 'managed' | 'unmanaged' | 'unknown';
+  createdAt: Date;
+  updatedAt: Date;
+  metadata?: Record<string, unknown> | null;
+};
+
+type MockSnapshot = {
+  id: string;
+  domainId: string;
+  domainName: string;
+  createdAt: Date;
+  resultState: 'complete' | 'partial';
+  rulesetVersionId: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+type MockProbeObservation = {
+  id: string;
+  snapshotId: string;
+  probeType: 'rdap' | 'tls_cert' | 'http';
+  status: 'success' | 'error';
+  hostname: string;
+  port: number | null;
+  success: boolean;
+  errorMessage: string | null;
+  probedAt: Date;
+  responseTimeMs: number | null;
+  probeData: Record<string, unknown> | null;
+};
+
+interface Fixture {
+  domains: MockDomain[];
+  snapshots: MockSnapshot[];
+  findings: Array<Record<string, unknown>>;
+  probeObservations: MockProbeObservation[];
+  savedFilters: Array<Record<string, unknown>>;
+}
+
+function domain(id: string, name: string, tenantId = TENANT_A): MockDomain {
+  return {
+    id,
+    tenantId,
+    name,
+    normalizedName: name,
+    zoneManagement: 'managed',
+    createdAt: NOW,
+    updatedAt: NOW,
+    metadata: null,
+  };
+}
+
+function snapshot(id: string, domainId: string, createdAt: Date): MockSnapshot {
+  return {
+    id,
+    domainId,
+    domainName: domainId,
+    createdAt,
+    resultState: 'complete',
+    rulesetVersionId: 'ruleset-v1',
+    metadata: { evaluation: { state: 'COMPLETE' } },
+  };
+}
+
+function rdapObservation(
+  id: string,
+  snapshotId: string,
+  domainName: string,
+  opts: {
+    probedAt?: Date;
+    status?: 'OBSERVED' | 'UNKNOWN';
+    check?: string;
+    expirationDate?: string;
+    evidenceDomain?: string;
+    evidenceKind?: string;
+    success?: boolean;
+  } = {}
+): MockProbeObservation {
+  const status = opts.status ?? 'OBSERVED';
+  const success = opts.success ?? status === 'OBSERVED';
+  return {
+    id,
+    snapshotId,
+    probeType: 'rdap',
+    status: success ? 'success' : 'error',
+    hostname: opts.evidenceDomain ?? domainName,
+    port: 443,
+    success,
+    errorMessage: success ? null : 'probe failed',
+    probedAt: opts.probedAt ?? NOW,
+    responseTimeMs: null,
+    probeData: {
+      check: opts.check ?? 'RDAP_EXPIRATION',
+      status,
+      evidence: {
+        kind: opts.evidenceKind ?? 'RDAP_EXPIRATION',
+        domain: opts.evidenceDomain ?? domainName,
+        sourceUrl: `https://rdap.example.test/domain/${domainName}`,
+        responseStatus: 200,
+        events: opts.expirationDate ? [{ action: 'expiration', date: opts.expirationDate }] : [],
+        expirationDate: opts.expirationDate,
+        notices: [],
+      },
+      unknown:
+        status === 'UNKNOWN'
+          ? {
+              reason: 'PROBE_FAILED',
+              explanation: 'x',
+              action: 'RETRY_PROBE',
+              actionLabel: 'Retry',
+              blocking: true,
+            }
+          : undefined,
+    },
+  };
+}
+
+function createMockDb(fixture: Fixture): IDatabaseAdapter {
+  const drizzleNameSymbol = Symbol.for('drizzle:Name');
+  const tableNameOf = (table: unknown): string =>
+    (table as Record<symbol, unknown>)[drizzleNameSymbol] as string;
+
+  const drizzle = {
+    query: {
+      domains: {
+        // Deliberately ignores the where predicate: the route must enforce
+        // tenant ownership in memory (defense in depth asserted by these tests).
+        findMany: vi.fn(async () => fixture.domains),
+      },
+      snapshots: {
+        findMany: vi.fn(async () =>
+          [...fixture.snapshots].sort(
+            (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          )
+        ),
+      },
+      findings: {
+        findMany: vi.fn(async () => fixture.findings),
+      },
+      probeObservations: {
+        // Honor the route's newest-first ordering like real Drizzle would.
+        findMany: vi.fn(async () =>
+          [...fixture.probeObservations].sort(
+            (a, b) => new Date(b.probedAt).getTime() - new Date(a.probedAt).getTime()
+          )
+        ),
+      },
+    },
+  };
+
+  return {
+    getDrizzle: () => drizzle,
+    select: vi.fn(async (table: unknown) => {
+      if (tableNameOf(table) === 'saved_filters') return [...fixture.savedFilters];
+      return [];
+    }),
+    selectWhere: vi.fn(async (table: unknown) => {
+      if (tableNameOf(table) === 'saved_filters') return [...fixture.savedFilters];
+      return [];
+    }),
+    selectOne: vi.fn(async (table: unknown) => {
+      if (tableNameOf(table) === 'saved_filters') {
+        return fixture.savedFilters[0];
+      }
+      return undefined;
+    }),
+    insert: vi.fn(async (table: unknown, values: Record<string, unknown>) => {
+      if (tableNameOf(table) === 'saved_filters') {
+        const record = {
+          id: `filter-${fixture.savedFilters.length + 1}`,
+          ...values,
+          createdAt: NOW,
+          updatedAt: NOW,
+        };
+        fixture.savedFilters.push(record);
+        return record;
+      }
+      return values;
+    }),
+    updateOne: vi.fn(async () => undefined),
+    deleteOne: vi.fn(async () => undefined),
+    transaction: vi.fn(),
+  } as unknown as IDatabaseAdapter;
+}
+
+function createApp(tenantId: string, fixture: Fixture): Hono<Env> {
+  const app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    c.set('db', createMockDb(fixture) as Env['Variables']['db']);
+    c.set('tenantId', tenantId);
+    c.set('actorId', 'actor-a');
+    c.set('actorEmail', 'actor-a@example.test');
+    await next();
+  });
+  app.route('/api/portfolio', portfolioRoutes);
+  return app;
+}
+
+async function search(app: Hono<Env>, body: Record<string, unknown> = {}) {
+  const res = await app.request('/api/portfolio/search', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+function names(body: Record<string, unknown>): string[] {
+  return ((body.domains as Array<Record<string, unknown>>) || []).map((d) => d.name as string);
+}
+
+function expirationOf(body: Record<string, unknown>, name: string): Record<string, unknown> {
+  const row = (body.domains as Array<Record<string, unknown>>).find((d) => d.name === name);
+  return row?.expiration as Record<string, unknown>;
+}
+
+let fixture: Fixture;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  fixture = { domains: [], snapshots: [], findings: [], probeObservations: [], savedFilters: [] };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('issue #60: RDAP expiration projection', () => {
+  it('projects only successful OBSERVED RDAP_EXPIRATION evidence as a dated expiry', async () => {
+    const expires = new Date(NOW.getTime() + 4 * DAY_MS).toISOString();
+    fixture.domains.push(domain('d1', 'expiring.example.test'));
+    fixture.snapshots.push(snapshot('s1', 'd1', NOW));
+    fixture.probeObservations.push(
+      rdapObservation('p1', 's1', 'expiring.example.test', {
+        probedAt: new Date(NOW.getTime() - DAY_MS),
+        expirationDate: expires,
+      })
+    );
+
+    const app = createApp(TENANT_A, fixture);
+    const { status, body } = await search(app);
+
+    expect(status).toBe(200);
+    expect(expirationOf(body, 'expiring.example.test')).toEqual({
+      status: 'OBSERVED',
+      expirationDate: expires,
+      observedAt: new Date(NOW.getTime() - DAY_MS).toISOString(),
+      bucket: 'WITHIN_7',
+    });
+  });
+
+  it('returns UNKNOWN for every missing or invalid evidence case', async () => {
+    const futureDate = new Date(NOW.getTime() + 5 * DAY_MS).toISOString();
+
+    fixture.domains.push(
+      domain('d1', 'no-snapshot.example.test'),
+      domain('d2', 'no-rdap-row.example.test'),
+      domain('d3', 'unknown-with-date.example.test'),
+      domain('d4', 'failed-probe.example.test'),
+      domain('d5', 'domain-mismatch.example.test'),
+      domain('d6', 'no-date.example.test'),
+      domain('d7', 'unparseable-date.example.test'),
+      domain('d8', 'wrong-kind.example.test'),
+      domain('d9', 'wrong-check.example.test')
+    );
+    fixture.snapshots.push(
+      snapshot('s2', 'd2', NOW),
+      snapshot('s3', 'd3', NOW),
+      snapshot('s4', 'd4', NOW),
+      snapshot('s5', 'd5', NOW),
+      snapshot('s6', 'd6', NOW),
+      snapshot('s7', 'd7', NOW),
+      snapshot('s8', 'd8', NOW),
+      snapshot('s9', 'd9', NOW)
+    );
+    fixture.probeObservations.push(
+      // UNKNOWN status that still carries an embedded expiration date
+      rdapObservation('p3', 's3', 'unknown-with-date.example.test', {
+        status: 'UNKNOWN',
+        expirationDate: futureDate,
+      }),
+      // row marked failed
+      rdapObservation('p4', 's4', 'failed-probe.example.test', {
+        success: false,
+        status: 'OBSERVED',
+        expirationDate: futureDate,
+      }),
+      // evidence domain does not match the portfolio domain
+      rdapObservation('p5', 's5', 'domain-mismatch.example.test', {
+        expirationDate: futureDate,
+        evidenceDomain: 'other.example.test',
+      }),
+      // no expiration date on the evidence
+      rdapObservation('p6', 's6', 'no-date.example.test'),
+      // date that does not parse
+      rdapObservation('p7', 's7', 'unparseable-date.example.test', {
+        expirationDate: 'not-a-date',
+      }),
+      // evidence of a different kind
+      rdapObservation('p8', 's8', 'wrong-kind.example.test', {
+        expirationDate: futureDate,
+        evidenceKind: 'TLS_CERTIFICATE',
+      }),
+      // probeData check does not match RDAP expiration
+      rdapObservation('p9', 's9', 'wrong-check.example.test', {
+        expirationDate: futureDate,
+        check: 'TLS_CERTIFICATE',
+      })
+    );
+
+    const app = createApp(TENANT_A, fixture);
+    const { status, body } = await search(app);
+
+    expect(status).toBe(200);
+    for (const name of names(body)) {
+      expect(expirationOf(body, name)).toEqual({ status: 'UNKNOWN' });
+    }
+    expect(names(body)).toHaveLength(9);
+
+    // UNKNOWN rows, including domains with no snapshot, do not match within filters.
+    const filtered = await search(app, { expirationWithinDays: 90 });
+    expect(names(filtered.body)).toEqual([]);
+    expect(filtered.body.total).toBe(0);
+  });
+
+  it('rejects date-only values that violate the collector RFC3339 date-time contract', async () => {
+    fixture.domains.push(
+      domain('d1', 'date-only.example.test'),
+      domain('d2', 'offset-datetime.example.test')
+    );
+    fixture.snapshots.push(snapshot('s1', 'd1', NOW), snapshot('s2', 'd2', NOW));
+    fixture.probeObservations.push(
+      // Parses via Date.parse but apps/collector/src/probes/rdap.ts rejects it.
+      rdapObservation('p1', 's1', 'date-only.example.test', {
+        expirationDate: '2026-12-15',
+      }),
+      // Numeric offsets are valid RFC3339 date-times and stay OBSERVED.
+      rdapObservation('p2', 's2', 'offset-datetime.example.test', {
+        expirationDate: '2026-09-05T12:00:00+02:00',
+      })
+    );
+
+    const app = createApp(TENANT_A, fixture);
+    const { body } = await search(app);
+
+    expect(expirationOf(body, 'date-only.example.test')).toEqual({ status: 'UNKNOWN' });
+    expect(expirationOf(body, 'offset-datetime.example.test')).toMatchObject({
+      status: 'OBSERVED',
+      bucket: 'WITHIN_7',
+    });
+  });
+
+  it('uses only the latest snapshot and the newest RDAP row within it', async () => {
+    const futureDate = new Date(NOW.getTime() + 5 * DAY_MS).toISOString();
+    fixture.domains.push(
+      domain('d1', 'stale-snapshot.example.test'),
+      domain('d2', 'superseded-row.example.test')
+    );
+
+    // d1: older snapshot OBSERVED, latest snapshot UNKNOWN -> UNKNOWN
+    fixture.snapshots.push(
+      snapshot('s-old', 'd1', new Date(NOW.getTime() - 10 * DAY_MS)),
+      snapshot('s-new', 'd1', new Date(NOW.getTime() - 1 * DAY_MS))
+    );
+    fixture.probeObservations.push(
+      rdapObservation('p-old', 's-old', 'stale-snapshot.example.test', {
+        expirationDate: futureDate,
+      }),
+      rdapObservation('p-new', 's-new', 'stale-snapshot.example.test', {
+        status: 'UNKNOWN',
+        expirationDate: futureDate,
+      })
+    );
+
+    // d2: within one snapshot, an older OBSERVED row is superseded by a newer UNKNOWN row
+    fixture.snapshots.push(snapshot('s2', 'd2', NOW));
+    fixture.probeObservations.push(
+      rdapObservation('p2-old', 's2', 'superseded-row.example.test', {
+        probedAt: new Date(NOW.getTime() - 2 * DAY_MS),
+        expirationDate: futureDate,
+      }),
+      rdapObservation('p2-new', 's2', 'superseded-row.example.test', {
+        probedAt: new Date(NOW.getTime() - 1 * DAY_MS),
+        status: 'UNKNOWN',
+        expirationDate: futureDate,
+      })
+    );
+
+    const app = createApp(TENANT_A, fixture);
+    const { body } = await search(app);
+
+    expect(expirationOf(body, 'stale-snapshot.example.test')).toEqual({ status: 'UNKNOWN' });
+    expect(expirationOf(body, 'superseded-row.example.test')).toEqual({ status: 'UNKNOWN' });
+  });
+});
+
+describe('issue #60: exact 7/30/90 day boundaries', () => {
+  it('buckets and filters with inclusive upper boundaries', async () => {
+    const cases: Array<{
+      name: string;
+      offsetMs: number;
+      bucket: string;
+      maxWindow: number | null;
+    }> = [
+      { name: 'at-seven-days', offsetMs: 7 * DAY_MS, bucket: 'WITHIN_7', maxWindow: 7 },
+      { name: 'seven-plus-one-ms', offsetMs: 7 * DAY_MS + 1, bucket: 'WITHIN_30', maxWindow: 30 },
+      { name: 'at-thirty-days', offsetMs: 30 * DAY_MS, bucket: 'WITHIN_30', maxWindow: 30 },
+      {
+        name: 'thirty-plus-one-ms',
+        offsetMs: 30 * DAY_MS + 1,
+        bucket: 'WITHIN_90',
+        maxWindow: 90,
+      },
+      { name: 'at-ninety-days', offsetMs: 90 * DAY_MS, bucket: 'WITHIN_90', maxWindow: 90 },
+      { name: 'ninety-plus-one-ms', offsetMs: 90 * DAY_MS + 1, bucket: 'LATER', maxWindow: null },
+    ];
+
+    for (const [index, testCase] of cases.entries()) {
+      fixture.domains.push(domain(`d-${index}`, `${testCase.name}.example.test`));
+      fixture.snapshots.push(snapshot(`s-${index}`, `d-${index}`, NOW));
+      fixture.probeObservations.push(
+        rdapObservation(`p-${index}`, `s-${index}`, `${testCase.name}.example.test`, {
+          expirationDate: new Date(NOW.getTime() + testCase.offsetMs).toISOString(),
+        })
+      );
+    }
+
+    const app = createApp(TENANT_A, fixture);
+
+    for (const testCase of cases) {
+      const { body } = await search(app);
+      expect(expirationOf(body, `${testCase.name}.example.test`).bucket).toBe(testCase.bucket);
+    }
+
+    // Each window includes every bucket at or below it and excludes the rest.
+    const windows: Array<{ window: number; expected: string[] }> = [
+      { window: 7, expected: ['at-seven-days.example.test'] },
+      {
+        window: 30,
+        expected: [
+          'at-seven-days.example.test',
+          'seven-plus-one-ms.example.test',
+          'at-thirty-days.example.test',
+        ],
+      },
+      {
+        window: 90,
+        expected: [
+          'at-seven-days.example.test',
+          'seven-plus-one-ms.example.test',
+          'at-thirty-days.example.test',
+          'thirty-plus-one-ms.example.test',
+          'at-ninety-days.example.test',
+        ],
+      },
+    ];
+    for (const { window, expected } of windows) {
+      const { body } = await search(app, { expirationWithinDays: window });
+      expect(names(body)).toEqual(expected);
+      expect(body.total).toBe(expected.length);
+    }
+  });
+
+  it('excludes expired and exactly-now expirations from within windows', async () => {
+    fixture.domains.push(
+      domain('d-past', 'already-expired.example.test'),
+      domain('d-now', 'expires-now.example.test')
+    );
+    fixture.snapshots.push(snapshot('s-past', 'd-past', NOW), snapshot('s-now', 'd-now', NOW));
+    fixture.probeObservations.push(
+      rdapObservation('p-past', 's-past', 'already-expired.example.test', {
+        expirationDate: new Date(NOW.getTime() - DAY_MS).toISOString(),
+      }),
+      rdapObservation('p-now', 's-now', 'expires-now.example.test', {
+        expirationDate: NOW.toISOString(),
+      })
+    );
+
+    const app = createApp(TENANT_A, fixture);
+
+    const unfiltered = await search(app);
+    expect(expirationOf(unfiltered.body, 'already-expired.example.test').bucket).toBe('EXPIRED');
+    expect(expirationOf(unfiltered.body, 'expires-now.example.test').bucket).toBe('EXPIRED');
+
+    const { body } = await search(app, { expirationWithinDays: 90 });
+    expect(names(body)).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it('rejects expirationWithinDays values other than 7, 30, or 90', async () => {
+    const app = createApp(TENANT_A, fixture);
+    for (const invalid of [45, 0, 365]) {
+      const { status, body } = await search(app, { expirationWithinDays: invalid });
+      expect(status).toBe(400);
+      expect(body.error).toBeDefined();
+    }
+    const stringWindow = await search(app, { expirationWithinDays: '90' });
+    expect(stringWindow.status).toBe(400);
+  });
+});
+
+describe('issue #60: sort and paginate after filtering', () => {
+  it('sorts observed expirations ascending with UNKNOWN last and a name tie-break', async () => {
+    fixture.domains.push(
+      domain('d1', 'zzz-later.example.test'),
+      domain('d2', 'aaa-soonest.example.test'),
+      domain('d3', 'mmm-unknown-b.example.test'),
+      domain('d4', 'bbb-soon.example.test'),
+      domain('d5', 'aaa-unknown-a.example.test')
+    );
+    const at = (days: number) => new Date(NOW.getTime() + days * DAY_MS).toISOString();
+    for (const [dId, sId, name, days] of [
+      ['d1', 's1', 'zzz-later.example.test', 60],
+      ['d2', 's2', 'aaa-soonest.example.test', 2],
+      ['d4', 's4', 'bbb-soon.example.test', 10],
+    ] as const) {
+      fixture.snapshots.push(snapshot(sId, dId, NOW));
+      fixture.probeObservations.push(
+        rdapObservation(`p-${sId}`, sId, name, { expirationDate: at(days) })
+      );
+    }
+
+    const app = createApp(TENANT_A, fixture);
+    const { body } = await search(app);
+
+    expect(names(body)).toEqual([
+      'aaa-soonest.example.test',
+      'bbb-soon.example.test',
+      'zzz-later.example.test',
+      'aaa-unknown-a.example.test',
+      'mmm-unknown-b.example.test',
+    ]);
+  });
+
+  it('reflects all filtered rows in total and slices the page afterward', async () => {
+    const at = (days: number) => new Date(NOW.getTime() + days * DAY_MS).toISOString();
+    for (let i = 1; i <= 3; i += 1) {
+      fixture.domains.push(domain(`d${i}`, `page-${i}.example.test`));
+      fixture.snapshots.push(snapshot(`s${i}`, `d${i}`, NOW));
+      fixture.probeObservations.push(
+        rdapObservation(`p${i}`, `s${i}`, `page-${i}.example.test`, {
+          expirationDate: at(i * 10),
+        })
+      );
+    }
+
+    const app = createApp(TENANT_A, fixture);
+
+    const pageOne = await search(app, { expirationWithinDays: 90, limit: 1, offset: 0 });
+    expect(pageOne.body.total).toBe(3);
+    expect(names(pageOne.body)).toEqual(['page-1.example.test']);
+
+    const pageThree = await search(app, { expirationWithinDays: 90, limit: 1, offset: 2 });
+    expect(pageThree.body.total).toBe(3);
+    expect(names(pageThree.body)).toEqual(['page-3.example.test']);
+  });
+});
+
+describe('issue #60: tenant isolation', () => {
+  it('never returns another tenant domain or its probe evidence', async () => {
+    const nearExpiry = new Date(NOW.getTime() + 3 * DAY_MS).toISOString();
+    fixture.domains.push(
+      domain('d-a', 'tenant-a.example.test', TENANT_A),
+      domain('d-b', 'tenant-b.example.test', TENANT_B)
+    );
+    fixture.snapshots.push(snapshot('s-a', 'd-a', NOW), snapshot('s-b', 'd-b', NOW));
+    fixture.probeObservations.push(
+      rdapObservation('p-a', 's-a', 'tenant-a.example.test', { expirationDate: nearExpiry }),
+      rdapObservation('p-b', 's-b', 'tenant-b.example.test', { expirationDate: nearExpiry })
+    );
+
+    const app = createApp(TENANT_A, fixture);
+    const { body } = await search(app, { expirationWithinDays: 7 });
+
+    expect(names(body)).toEqual(['tenant-a.example.test']);
+    expect(body.total).toBe(1);
+    expect(JSON.stringify(body)).not.toContain('tenant-b.example.test');
+  });
+});
+
+describe('issue #60: saved 90-day filter round-trip', () => {
+  it('stores and reloads expirationWithinDays criteria through the saved-filter route', async () => {
+    const app = createApp(TENANT_A, fixture);
+
+    const createRes = await app.request('/api/portfolio/filters', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Expiring within 90 days',
+        criteria: { expirationWithinDays: 90 },
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const created = (await createRes.json()) as { filter: { criteria: Record<string, unknown> } };
+    expect(created.filter.criteria).toEqual({ expirationWithinDays: 90 });
+
+    const listRes = await app.request('/api/portfolio/filters');
+    expect(listRes.status).toBe(200);
+    const listed = (await listRes.json()) as {
+      filters: Array<{ criteria: Record<string, unknown> }>;
+    };
+    const loaded = listed.filters.find((f) => f.criteria.expirationWithinDays === 90);
+    expect(loaded).toBeDefined();
+  });
+});

--- a/apps/web/hono/routes/portfolio.test.ts
+++ b/apps/web/hono/routes/portfolio.test.ts
@@ -255,6 +255,9 @@ function createMockDb(data: MockData) {
       findings: {
         findMany: vi.fn(async () => data.findings),
       },
+      probeObservations: {
+        findMany: vi.fn(async () => []),
+      },
     },
   };
 

--- a/apps/web/hono/routes/portfolio.ts
+++ b/apps/web/hono/routes/portfolio.ts
@@ -334,9 +334,7 @@ portfolioRoutes.post('/search', async (c) => {
     const hasFindingCriteria = hasSeverityFilter || findingTypePrefix !== undefined;
     const severitySet = new Set(severities ?? []);
     const stalenessCutoffMs =
-      snapshotOlderThanDays !== undefined
-        ? now - snapshotOlderThanDays * DAY_MS
-        : null;
+      snapshotOlderThanDays !== undefined ? now - snapshotOlderThanDays * DAY_MS : null;
     const allFindings =
       snapshotIds.length > 0
         ? await db.getDrizzle().query.findings.findMany({
@@ -397,7 +395,8 @@ portfolioRoutes.post('/search', async (c) => {
       if (
         stalenessCutoffMs !== null &&
         (!latestSnapshot || new Date(latestSnapshot.createdAt).getTime() > stalenessCutoffMs)
-      ) continue;
+      )
+        continue;
 
       if (!latestSnapshot) {
         // Missing evidence is UNKNOWN and cannot match a within window.

--- a/apps/web/hono/routes/portfolio.ts
+++ b/apps/web/hono/routes/portfolio.ts
@@ -14,7 +14,7 @@ import {
   SavedFilterRepository,
   TemplateOverrideRepository,
 } from '@dns-ops/db';
-import { domains, findings, snapshots } from '@dns-ops/db/schema';
+import { domains, findings, probeObservations, snapshots } from '@dns-ops/db/schema';
 import { and, desc, eq, inArray, like, or } from 'drizzle-orm';
 import { Hono } from 'hono';
 import {
@@ -40,6 +40,148 @@ export const portfolioRoutes = new Hono<Env>();
 portfolioRoutes.use('*', requireAuth);
 
 // =============================================================================
+// EXPIRATION READ MODEL (Issue #60)
+//
+// Derives a portfolio expiry projection from persisted RDAP probe observations
+// only. No RDAP client and no network lookups happen here: the latest snapshot's
+// newest RDAP row is the sole evidence source. Anything missing, failed,
+// UNKNOWN, mismatched, or unparseable is UNKNOWN — never a healthy date.
+//
+// Freshness follow-up (Issue #60): this read model is deliberately
+// threshold-free — the latest snapshot's newest successful RDAP row stays
+// OBSERVED no matter how old it is, while docs/playbooks/domain-expiry.md
+// ultimately requires stale evidence to render UNKNOWN. Add a probe-age
+// threshold here when that freshness policy is decided.
+// =============================================================================
+
+const EXPIRATION_WITHIN_DAYS = [7, 30, 90] as const;
+type ExpirationWithinDays = (typeof EXPIRATION_WITHIN_DAYS)[number];
+
+type ExpirationBucket = 'EXPIRED' | 'WITHIN_7' | 'WITHIN_30' | 'WITHIN_90' | 'LATER';
+
+type Expiration =
+  | {
+      status: 'OBSERVED';
+      expirationDate: string;
+      observedAt: string;
+      bucket: ExpirationBucket;
+    }
+  | { status: 'UNKNOWN' };
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// RFC3339 date-time only, mirroring the collector's evidence contract
+// (apps/collector/src/probes/rdap.ts). A date-only value such as
+// "2026-12-15" parses via Date.parse but is not valid collector evidence and
+// must not be promoted to OBSERVED here.
+const RFC3339_DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|([+-])(\d{2}):(\d{2}))$/;
+
+function isValidRfc3339DateTime(value: string): boolean {
+  const match = RFC3339_DATE_TIME.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = match[8] === undefined ? 0 : Number(match[8]);
+  const offsetMinute = match[9] === undefined ? 0 : Number(match[9]);
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) return false;
+  if (offsetHour > 23 || offsetMinute > 59) return false;
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return day >= 1 && day <= daysInMonth && !Number.isNaN(Date.parse(value));
+}
+
+function expirationWindowOfBucket(bucket: ExpirationBucket): ExpirationWithinDays | null {
+  switch (bucket) {
+    case 'WITHIN_7':
+      return 7;
+    case 'WITHIN_30':
+      return 30;
+    case 'WITHIN_90':
+      return 90;
+    default:
+      return null; // EXPIRED is excluded from within filters; LATER is beyond 90 days
+  }
+}
+
+function deriveExpiration(
+  observation: typeof probeObservations.$inferSelect | undefined,
+  normalizedDomainName: string,
+  now: number
+): Expiration {
+  const data = observation?.probeData as
+    | {
+        check?: string;
+        status?: string;
+        evidence?: {
+          kind?: string;
+          domain?: string;
+          expirationDate?: unknown;
+        };
+      }
+    | null
+    | undefined;
+
+  // Gate on the persisted check status, not merely date presence: an UNKNOWN
+  // result (malformed/conflicting events) can still carry evidence.expirationDate.
+  if (
+    !observation ||
+    observation.probeType !== 'rdap' ||
+    !observation.success ||
+    !data ||
+    data.check !== 'RDAP_EXPIRATION' ||
+    data.status !== 'OBSERVED'
+  ) {
+    return { status: 'UNKNOWN' };
+  }
+
+  const evidence = data.evidence;
+  if (!evidence || evidence.kind !== 'RDAP_EXPIRATION') {
+    return { status: 'UNKNOWN' };
+  }
+
+  const evidenceDomain = evidence.domain?.toLowerCase().replace(/\.$/, '');
+  if (!evidenceDomain || evidenceDomain !== normalizedDomainName) {
+    return { status: 'UNKNOWN' };
+  }
+
+  if (
+    typeof evidence.expirationDate !== 'string' ||
+    !isValidRfc3339DateTime(evidence.expirationDate)
+  ) {
+    return { status: 'UNKNOWN' };
+  }
+
+  const expiresAt = Date.parse(evidence.expirationDate);
+  if (Number.isNaN(expiresAt)) {
+    return { status: 'UNKNOWN' };
+  }
+
+  // Exact upper boundaries are inclusive: one millisecond beyond enters the next bucket.
+  const delta = expiresAt - now;
+  const bucket: ExpirationBucket =
+    delta <= 0
+      ? 'EXPIRED'
+      : delta <= 7 * DAY_MS
+        ? 'WITHIN_7'
+        : delta <= 30 * DAY_MS
+          ? 'WITHIN_30'
+          : delta <= 90 * DAY_MS
+            ? 'WITHIN_90'
+            : 'LATER';
+
+  return {
+    status: 'OBSERVED',
+    expirationDate: evidence.expirationDate,
+    observedAt: observation.probedAt.toISOString(),
+    bucket,
+  };
+}
+
+// =============================================================================
 // PORTFOLIO SEARCH
 // =============================================================================
 
@@ -63,6 +205,18 @@ portfolioRoutes.post('/search', async (c) => {
       required: false,
     }),
     coverage: optionalString('coverage', { maxLength: 20 }),
+    expirationWithinDays: (value: unknown): ExpirationWithinDays | undefined => {
+      if (value === undefined || value === null) {
+        return undefined;
+      }
+      if (
+        typeof value !== 'number' ||
+        !EXPIRATION_WITHIN_DAYS.includes(value as ExpirationWithinDays)
+      ) {
+        throw new Error('expirationWithinDays must be one of: 7, 30, 90');
+      }
+      return value as ExpirationWithinDays;
+    },
     limit: integer('limit', { min: 1, max: 100, required: false }),
     offset: integer('offset', { min: 0, required: false }),
   });
@@ -79,13 +233,13 @@ portfolioRoutes.post('/search', async (c) => {
     findingTypePrefix,
     snapshotOlderThanDays,
     coverage,
+    expirationWithinDays,
     limit = 20,
     offset = 0,
   } = validation.data;
+  // One request-scoped clock keeps bucketing, filtering, and sorting consistent.
+  const now = Date.now();
 
-  // Built-in view criteria (issue #63): only the incomplete-coverage view
-  // exists today, so any other value is a client error rather than a silent
-  // no-op filter.
   if (coverage !== undefined && coverage !== 'incomplete') {
     return c.json({ error: 'coverage must be "incomplete"' }, 400);
   }
@@ -128,22 +282,28 @@ portfolioRoutes.post('/search', async (c) => {
       (conditions.length > 1 ? and(...conditions) : conditions[0]) ??
       eq(domains.tenantId, tenantId);
 
-    // Fetch matching domains
+    // Fetch matching domains.
+    // ponytail: no DB-level pagination — expiry filtering/sorting needs the whole
+    // tenant match set before slicing; move to a DB-native read model only if a
+    // portfolio grows large enough for this to measurably hurt.
     const results = await db.getDrizzle().query.domains.findMany({
       where: whereClause,
-      limit,
-      offset,
       orderBy: desc(domains.updatedAt),
     });
 
     // PERF-001: Batch query optimization
     // Instead of N queries for snapshots (one per domain), we do 1 query with IN clause
-    // Same for findings - batch by snapshot IDs
+    // Same for findings and RDAP observations - batch by snapshot IDs
 
+    // Re-assert tenant ownership in memory before deriving snapshot IDs so a
+    // predicate-ignoring data layer cannot leak another tenant's evidence.
     const portfolioResults = results.filter(
-      (domain) => (domain.metadata as { portfolio?: boolean } | null)?.portfolio !== false
+      (domain) =>
+        domain.tenantId === tenantId &&
+        (domain.metadata as { portfolio?: boolean } | null)?.portfolio !== false
     );
     const resultDomainIds = portfolioResults.map((d) => d.id);
+    const resultDomainIdSet = new Set(resultDomainIds);
 
     // Batch fetch all snapshots for these domains
     const allSnapshots =
@@ -157,7 +317,10 @@ portfolioRoutes.post('/search', async (c) => {
     // Build a map of domainId -> latest snapshot
     const latestSnapshotByDomain = new Map<string, (typeof allSnapshots)[0]>();
     for (const snapshot of allSnapshots) {
-      if (!latestSnapshotByDomain.has(snapshot.domainId)) {
+      if (
+        resultDomainIdSet.has(snapshot.domainId) &&
+        !latestSnapshotByDomain.has(snapshot.domainId)
+      ) {
         latestSnapshotByDomain.set(snapshot.domainId, snapshot);
       }
     }
@@ -165,8 +328,15 @@ portfolioRoutes.post('/search', async (c) => {
     // Get all snapshot IDs for findings query
     const snapshotIds = Array.from(latestSnapshotByDomain.values()).map((s) => s.id);
 
-    // Batch fetch all findings for these snapshots
+    // Batch fetch all findings for these snapshots. Severity matching happens in
+    // memory so the filter applies to the full result set, not just a page.
     const hasSeverityFilter = severities && severities.length > 0;
+    const hasFindingCriteria = hasSeverityFilter || findingTypePrefix !== undefined;
+    const severitySet = new Set(severities ?? []);
+    const stalenessCutoffMs =
+      snapshotOlderThanDays !== undefined
+        ? now - snapshotOlderThanDays * DAY_MS
+        : null;
     const allFindings =
       snapshotIds.length > 0
         ? await db.getDrizzle().query.findings.findMany({
@@ -191,75 +361,127 @@ portfolioRoutes.post('/search', async (c) => {
       findingsBySnapshot.get(finding.snapshotId)?.push(finding);
     }
 
-    // Process results using the batched data
-    const hasFindingCriteria = hasSeverityFilter || findingTypePrefix !== undefined;
-    const stalenessCutoffMs =
-      snapshotOlderThanDays !== undefined
-        ? startTime - snapshotOlderThanDays * 24 * 60 * 60 * 1000
-        : null;
+    // Batch fetch RDAP probe observations for these snapshots (Issue #60).
+    // Ordered newest-first so the first row per snapshot is the newest evidence.
+    const rdapObservations =
+      snapshotIds.length > 0
+        ? await db.getDrizzle().query.probeObservations.findMany({
+            where: and(
+              inArray(probeObservations.snapshotId, snapshotIds),
+              eq(probeObservations.probeType, 'rdap')
+            ),
+            orderBy: desc(probeObservations.probedAt),
+          })
+        : [];
 
-    const filteredDomains = portfolioResults.map((domain) => {
+    const latestRdapBySnapshot = new Map<string, (typeof rdapObservations)[number]>();
+    for (const observation of rdapObservations) {
+      if (!latestRdapBySnapshot.has(observation.snapshotId)) {
+        latestRdapBySnapshot.set(observation.snapshotId, observation);
+      }
+    }
+
+    // Enrich, filter (severity + expiry), and sort before pagination so `total`
+    // reflects the whole filtered tenant portfolio (Issue #60).
+    const enriched: Array<{
+      domain: Record<string, unknown> & { normalizedName: string };
+      sortInstant: number | null;
+    }> = [];
+
+    for (const domain of portfolioResults) {
       const latestSnapshot = latestSnapshotByDomain.get(domain.id);
       const evaluationCoverage = evaluationCoverageOrUnknown(latestSnapshot?.metadata?.evaluation);
       const findingsEvaluated = isEvaluationComplete(evaluationCoverage);
 
-      // Built-in "incomplete coverage" view: keep only domains whose latest
-      // evidence was not fully evaluated. A domain without a snapshot counts
-      // as incomplete.
-      if (coverage === 'incomplete' && findingsEvaluated) {
-        return null;
-      }
-
-      // Built-in "expiring evidence" view: keep only domains whose latest
-      // snapshot is older than the requested window. Domains without a
-      // snapshot have no evidence to expire and are excluded.
+      if (coverage === 'incomplete' && findingsEvaluated) continue;
       if (
         stalenessCutoffMs !== null &&
         (!latestSnapshot || new Date(latestSnapshot.createdAt).getTime() > stalenessCutoffMs)
-      ) {
-        return null;
-      }
+      ) continue;
 
       if (!latestSnapshot) {
-        return {
-          ...domain,
-          findings: [],
-          findingsEvaluated,
-          evaluationCoverage,
-          latestSnapshot: null,
-        };
+        // Missing evidence is UNKNOWN and cannot match a within window.
+        if (expirationWithinDays !== undefined) {
+          continue;
+        }
+        enriched.push({
+          domain: {
+            ...domain,
+            findings: [],
+            findingsEvaluated,
+            evaluationCoverage,
+            latestSnapshot: null,
+            expiration: { status: 'UNKNOWN' } as const,
+          },
+          sortInstant: null,
+        });
+        continue;
       }
 
-      // Built-in "mail broken" view narrows the snapshot's findings to the
-      // requested type prefix (e.g. `mail.`) before the evaluated-empty rule
-      // applies, so only domains with matching findings survive.
-      const domainFindings = findingTypePrefix
-        ? (findingsBySnapshot.get(latestSnapshot.id) || []).filter((finding) =>
-            finding.type.startsWith(findingTypePrefix)
-          )
-        : findingsBySnapshot.get(latestSnapshot.id) || [];
+      // Only explicit complete coverage permits a zero-finding result to filter
+      // the domain out. A ruleset ID alone does not prove every check completed.
+      const domainFindings = (findingsBySnapshot.get(latestSnapshot.id) || []).filter(
+        (finding) =>
+          (!severitySet.size || severitySet.has(finding.severity)) &&
+          (!findingTypePrefix || finding.type.startsWith(findingTypePrefix))
+      );
 
-      // Filter out if finding criteria doesn't match AND findings were evaluated
+      // Filter out if severity filter doesn't match AND findings were evaluated
       // Don't filter out if findings weren't evaluated (might have matching findings once evaluated)
       if (hasFindingCriteria && domainFindings.length === 0 && findingsEvaluated) {
-        return null;
+        continue;
       }
 
-      return {
-        ...domain,
-        findings: domainFindings,
-        findingsEvaluated,
-        evaluationCoverage,
-        latestSnapshot: {
-          id: latestSnapshot.id,
-          createdAt: latestSnapshot.createdAt,
-          resultState: latestSnapshot.resultState,
-          rulesetVersionId: latestSnapshot.rulesetVersionId,
+      const expiration = deriveExpiration(
+        latestRdapBySnapshot.get(latestSnapshot.id),
+        domain.normalizedName,
+        now
+      );
+
+      if (expirationWithinDays !== undefined) {
+        const bucketWindow =
+          expiration.status === 'OBSERVED' ? expirationWindowOfBucket(expiration.bucket) : null;
+        // EXPIRED/LATER and UNKNOWN never match a within window.
+        if (bucketWindow === null || bucketWindow > expirationWithinDays) {
+          continue;
+        }
+      }
+
+      enriched.push({
+        domain: {
+          ...domain,
+          findings: domainFindings,
+          findingsEvaluated,
+          evaluationCoverage,
+          latestSnapshot: {
+            id: latestSnapshot.id,
+            createdAt: latestSnapshot.createdAt,
+            resultState: latestSnapshot.resultState,
+            rulesetVersionId: latestSnapshot.rulesetVersionId,
+          },
+          expiration,
         },
-      };
+        sortInstant:
+          expiration.status === 'OBSERVED' ? Date.parse(expiration.expirationDate) : null,
+      });
+    }
+
+    // Sort observed expiration instants ascending, UNKNOWN last, then name.
+    enriched.sort((a, b) => {
+      if (a.sortInstant === null || b.sortInstant === null) {
+        if (a.sortInstant === b.sortInstant) {
+          return a.domain.normalizedName.localeCompare(b.domain.normalizedName);
+        }
+        return a.sortInstant === null ? 1 : -1;
+      }
+      if (a.sortInstant !== b.sortInstant) {
+        return a.sortInstant - b.sortInstant;
+      }
+      return a.domain.normalizedName.localeCompare(b.domain.normalizedName);
     });
 
-    const domainResults = filteredDomains.filter(Boolean);
+    const total = enriched.length;
+    const domainResults = enriched.slice(offset, offset + limit).map((entry) => entry.domain);
 
     // Track search event (Bead 14.4)
     trackSearch({
@@ -272,6 +494,7 @@ portfolioRoutes.post('/search', async (c) => {
         findingTypePrefix,
         snapshotOlderThanDays,
         coverage,
+        expirationWithinDays,
       },
       resultCount: domainResults.length,
       durationMs: Date.now() - startTime,
@@ -279,7 +502,7 @@ portfolioRoutes.post('/search', async (c) => {
 
     return c.json({
       domains: domainResults,
-      total: domainResults.length,
+      total,
       limit,
       offset,
     });

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -572,6 +572,8 @@ export const savedFilters = pgTable(
       };
       tags?: string[];
       lastSnapshotWithin?: number; // hours
+      // Issue #60: RDAP expiry window criterion (days); UI accepts 7 | 30 | 90 only.
+      expirationWithinDays?: 7 | 30 | 90;
     }>(),
 
     // Visibility

--- a/verification/receipts/20260903-223822Z-ac43b22-issue60-portfolio-expiry--portfolio.search.md
+++ b/verification/receipts/20260903-223822Z-ac43b22-issue60-portfolio-expiry--portfolio.search.md
@@ -1,0 +1,50 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-223822Z-ac43b22-issue60-portfolio-expiry
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 7a4c5df6763c6ca9b1a5d8c6dfc7fe665f6eabd0
+code_digest: fcb7cbd42b2806c10d62e992b4770a50c1cb030ec2eacb9c50aebc12ed226d62
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry
+created_at: 2026-09-03T22:40:31.169Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` showed **Portfolio workflows** and **Portfolio Search** → confirmed in the captured page screenshot.
+- Query accepted input and returned a real authenticated `POST /api/portfolio/search` response → readback contains seeded domains and HTTP-200 response.
+- Expiry window select offered Any / Within 7 days / Within 30 days / Within 90 days and drove `expirationWithinDays` requests → confirmed by the expiry drive assertions and rendered controls.
+- Results rendered an Expiry column → screenshot and drive completed against the real page.
+- Seeded RDAP `RDAP_EXPIRATION` OBSERVED evidence rendered as `WITHIN_90` with date; domain without usable RDAP evidence rendered `UNKNOWN` → `readback/portfolio-search.json` records `verify-expiry-observed.example.test` as OBSERVED / WITHIN_90 and the unknown fixture as UNKNOWN.
+- `trace.zip` records the browser interaction and network responses; doctor health was HTTP 200 healthy.
+
+## Forbidden (… → confirmed absent)
+- Sign-in warning used as success → absent; local e2e tenant/actor headers returned authenticated seeded results.
+- Class selectors → harness uses semantic roles/labels and the feature drive completed without class selectors.
+- Expiry derived from findings or DOMAIN_EXPIRING_SOON → response readback shows the RDAP_EXPIRATION evidence projection.
+
+## Read-back
+- `readback/portfolio-search.json` contains the real response and seeded fixture metadata.
+- `trace.zip`, `portfolio-search.png`, and `video/*.webm` are captured from the live drive.
+- `console.log` and `failed-requests.log` were captured; no feature assertion failed.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry/console.log | log | aux · unrecognized .log | a0cab3bf0f0596bc8ea77a62a530e64af97583143d4dd910637770cd11f5eac4 |
+| verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry/env.txt | env | aux | e7acd8acbda8812ff8b34719751b73a20bee47be357ceb4f90c69b76ad4b4794 |
+| verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry/failed-requests.log | log | aux · unrecognized .log | 22a0d187afeeb20718e46536f713d8d2914b2ad56af6c56bef75636a6707d813 |
+| verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry/observations.md | md | aux · unrecognized .md | a65fac13edcbde8e5542a3f031755249633004fa31085209b342dfc7f95a5985 |
+| verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry/portfolio-search.png | png | evidence · 1280x3749 | 4d49b60cdcb086bb7eac169e05fe5020d13f5fe22b4e2baabb91d3a8f7816d6d |
+| verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry/readback/portfolio-search.json | readback | evidence | 7f601b2a17c909ce5a1c988e5c33d89ef3f30ee79f5913ec6fd090f0613da7db |
+| verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry/trace.zip | trace | evidence · playwright trace | 851f6a9c3f05a32d59073160041fdbfee406512fc71e44ba202c0d83a1a4f034 |
+| verification/runs/20260903-223822Z-ac43b22-issue60-portfolio-expiry/video/c9670882c40a748765bddc9cc70d8e52.webm | video | evidence | f002f71f803841502167298cb686e8048c639e33755b5bb02d4274b6772cf785 |

--- a/verification/receipts/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3--domain.overview.md
+++ b/verification/receipts/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3--domain.overview.md
@@ -1,0 +1,46 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 8017ec5b7edc8e31515a432f7c94dd9d83453f01
+code_digest: 2588d58491c1cae1d0f055899578b6a111a588e0a3d9a959f72d256d435caca2
+dirty: true
+untracked: 0
+status: blocked
+reason: "Shared verification harness changed for portfolio expiry and was not driven for Domain 360 in this run; run a Domain 360 drive before treating it as verified."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3
+created_at: 2026-09-03T22:48:30.942Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/console.log | log | aux · unrecognized .log | 8a51a20a2e7c6eefe99c4ad69dd3f1ba34191089a4234044d0b9497b607cbed0 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/env.txt | env | aux | 256fe329a4c466b71173e40a637d5a4e6f347a785f50b54ec46b88dcc80b24c4 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/failed-requests.log | log | aux · unrecognized .log | 90d46cd8a7c5a1115fb3e8da91ca8af72fc641dab7303ac255c4a270b01f4bfb |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/observations.md | md | aux · unrecognized .md | 3326f2c98d0d584220530c613f1a5fc6af0611ed220fde0e68f74357e3626521 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/portfolio-search.png | png | evidence · 1280x3564 | 53369e61e786ade50443e56be2f7ce074ff1d130cc6db662360a0e90b3c961c1 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/readback/portfolio-expiry.json | readback | evidence | 9d3e14a7a5b8744d6bf3c335a71bb8728e3d77cb06dd61d0ed339831fa352cfa |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/readback/portfolio-search.json | readback | evidence | 68132f3a990a365c55b967c5b81d73dbfcc9ef73b594bdc7126b1338c0c21a24 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/trace.zip | trace | evidence · playwright trace | 20ee423c776ea76bef10f28aab718b056b95da4db0611a8eb585b89f1d0b9581 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/video/ed83cb686d7fa8c95d4cefdec72fad4f.webm | video | evidence | d8d72698a717af081e36e6d25444a8ab9c5701b31c2ca6e0ca4ff6e58a3284f9 |

--- a/verification/receipts/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3--portfolio.search.md
+++ b/verification/receipts/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3--portfolio.search.md
@@ -1,0 +1,52 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 8017ec5b7edc8e31515a432f7c94dd9d83453f01
+code_digest: 2588d58491c1cae1d0f055899578b6a111a588e0a3d9a959f72d256d435caca2
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3
+created_at: 2026-09-03T22:48:13.922Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` showed **Portfolio workflows**, **Portfolio Search**, and **Built-in views**; Query accepted `verify-expiry` → confirmed by the live drive.
+- Search returned the seeded observed and unknown domains with HTTP 200 → `readback/portfolio-search.json` records both fixture domains.
+- Observed RDAP expiration rendered in the Expiry column as `WITHIN_90`; the no-RDAP domain rendered literal `UNKNOWN` → confirmed by semantic table assertions.
+- Selecting Expiry window `Within 90 days` issued a real POST carrying `expirationWithinDays: 90` and retained only the observed fixture → captured in `readback/portfolio-expiry.json`.
+- Built-in Mail broken, Expiring evidence, and Incomplete coverage buttons issued their expected request criteria; active Incomplete coverage toggled off and cleared its criteria → captured in `readback/built-in-view-requests.json`.
+- Browser screenshot, video, and Playwright trace were captured; web health returned HTTP 200 healthy.
+
+## Forbidden (… → confirmed absent)
+- Sign-in warning used as success → absent; local e2e tenant/actor headers returned authenticated seeded results.
+- Class selectors → no class selectors were used by the harness assertions.
+- Expiry derived from findings or `DOMAIN_EXPIRING_SOON` → response projection came from RDAP expiration evidence.
+
+## Read-back
+- `readback/portfolio-search.json` and `readback/portfolio-expiry.json` contain real response JSON.
+- `readback/built-in-view-requests.json` records exact built-in request bodies.
+- `trace.zip`, `portfolio-search.png`, `video/*.webm`, `console.log`, and `failed-requests.log` are present.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/console.log | log | aux · unrecognized .log | 8a51a20a2e7c6eefe99c4ad69dd3f1ba34191089a4234044d0b9497b607cbed0 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/env.txt | env | aux | 256fe329a4c466b71173e40a637d5a4e6f347a785f50b54ec46b88dcc80b24c4 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/failed-requests.log | log | aux · unrecognized .log | 90d46cd8a7c5a1115fb3e8da91ca8af72fc641dab7303ac255c4a270b01f4bfb |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/observations.md | md | aux · unrecognized .md | 3326f2c98d0d584220530c613f1a5fc6af0611ed220fde0e68f74357e3626521 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/portfolio-search.png | png | evidence · 1280x3564 | 53369e61e786ade50443e56be2f7ce074ff1d130cc6db662360a0e90b3c961c1 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/readback/portfolio-expiry.json | readback | evidence | 9d3e14a7a5b8744d6bf3c335a71bb8728e3d77cb06dd61d0ed339831fa352cfa |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/readback/portfolio-search.json | readback | evidence | 68132f3a990a365c55b967c5b81d73dbfcc9ef73b594bdc7126b1338c0c21a24 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/trace.zip | trace | evidence · playwright trace | 20ee423c776ea76bef10f28aab718b056b95da4db0611a8eb585b89f1d0b9581 |
+| verification/runs/20260903-224732Z-ac43b22-issue60-portfolio-expiry-rebased-v3/video/ed83cb686d7fa8c95d4cefdec72fad4f.webm | video | evidence | d8d72698a717af081e36e6d25444a8ab9c5701b31c2ca6e0ca4ff6e58a3284f9 |

--- a/verification/receipts/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final--domain.overview.md
+++ b/verification/receipts/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final--domain.overview.md
@@ -1,0 +1,46 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-224852Z-ac43b22-issue60-portfolio-expiry-final
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 70710c98bcc582fe981705fd9cff01c8de4f08bc
+code_digest: f9fbad92f42e524e41795653f89c4ab8e2dad25b80729de9fa3be7f49bfb3082
+dirty: true
+untracked: 1
+status: blocked
+reason: "Shared verification harness changed for portfolio expiry and was not driven for Domain 360 in this run; run a Domain 360 drive before treating it as verified."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final
+created_at: 2026-09-03T22:49:25.574Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/console.log | log | aux · unrecognized .log | 0b6e00138fbe3f5a0986bed9914bbad821a78f3d9c186b38aa944a37d42bd2b5 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/env.txt | env | aux | c18598f46b414cdaae2b9f3145f9906c6ae5f47276b7bf72097edfa377b5705f |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/failed-requests.log | log | aux · unrecognized .log | 0b081f395f9aae60ed0e743fc21f9d0e0bb9248a2d87bf52863668f4a59680bf |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/observations.md | md | aux · unrecognized .md | 3326f2c98d0d584220530c613f1a5fc6af0611ed220fde0e68f74357e3626521 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/portfolio-search.png | png | evidence · 1280x3564 | a9ff50e3b5ae29b7490c07e37e5cbfa17138955704297ba27269f690fe13b20c |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/readback/portfolio-expiry.json | readback | evidence | cdc94224c63634bed4a8c34bcc1310c384a128fa9ccdd7db67234fdb7fc2870d |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/readback/portfolio-search.json | readback | evidence | 39802419aaa6da4bb160de2698784f65ba5f95707a2653658eaf9e02c81f77f5 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/trace.zip | trace | evidence · playwright trace | 5abf177026f2c10b6d663dba2e055481106c00f958ce74c70025d26185f02584 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/video/9ea854fc4e373591c3efbdbb8363d51d.webm | video | evidence | ed5bcf42f3e2f95787214da31cb7c29409e46bb16ca412cd2f6b66a2549f6f2a |

--- a/verification/receipts/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final--portfolio.search.md
+++ b/verification/receipts/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final--portfolio.search.md
@@ -1,0 +1,52 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-224852Z-ac43b22-issue60-portfolio-expiry-final
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 70710c98bcc582fe981705fd9cff01c8de4f08bc
+code_digest: f9fbad92f42e524e41795653f89c4ab8e2dad25b80729de9fa3be7f49bfb3082
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final
+created_at: 2026-09-03T22:49:25.469Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` showed **Portfolio workflows**, **Portfolio Search**, and **Built-in views**; Query accepted `verify-expiry` → confirmed by the live drive.
+- Search returned the seeded observed and unknown domains with HTTP 200 → `readback/portfolio-search.json` records both fixture domains.
+- Observed RDAP expiration rendered in the Expiry column as `WITHIN_90`; the no-RDAP domain rendered literal `UNKNOWN` → confirmed by semantic table assertions.
+- Selecting Expiry window `Within 90 days` issued a real POST carrying `expirationWithinDays: 90` and retained only the observed fixture → captured in `readback/portfolio-expiry.json`.
+- Built-in Mail broken, Expiring evidence, and Incomplete coverage buttons issued their expected request criteria; active Incomplete coverage toggled off and cleared its criteria → captured in `readback/built-in-view-requests.json`.
+- Browser screenshot, video, and Playwright trace were captured; web health returned HTTP 200 healthy.
+
+## Forbidden (… → confirmed absent)
+- Sign-in warning used as success → absent; local e2e tenant/actor headers returned authenticated seeded results.
+- Class selectors → no class selectors were used by the harness assertions.
+- Expiry derived from findings or `DOMAIN_EXPIRING_SOON` → response projection came from RDAP expiration evidence.
+
+## Read-back
+- `readback/portfolio-search.json` and `readback/portfolio-expiry.json` contain real response JSON.
+- `readback/built-in-view-requests.json` records exact built-in request bodies.
+- `trace.zip`, `portfolio-search.png`, `video/*.webm`, `console.log`, and `failed-requests.log` are present.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/console.log | log | aux · unrecognized .log | 0b6e00138fbe3f5a0986bed9914bbad821a78f3d9c186b38aa944a37d42bd2b5 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/env.txt | env | aux | c18598f46b414cdaae2b9f3145f9906c6ae5f47276b7bf72097edfa377b5705f |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/failed-requests.log | log | aux · unrecognized .log | 0b081f395f9aae60ed0e743fc21f9d0e0bb9248a2d87bf52863668f4a59680bf |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/observations.md | md | aux · unrecognized .md | 3326f2c98d0d584220530c613f1a5fc6af0611ed220fde0e68f74357e3626521 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/portfolio-search.png | png | evidence · 1280x3564 | a9ff50e3b5ae29b7490c07e37e5cbfa17138955704297ba27269f690fe13b20c |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/readback/portfolio-expiry.json | readback | evidence | cdc94224c63634bed4a8c34bcc1310c384a128fa9ccdd7db67234fdb7fc2870d |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/readback/portfolio-search.json | readback | evidence | 39802419aaa6da4bb160de2698784f65ba5f95707a2653658eaf9e02c81f77f5 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/trace.zip | trace | evidence · playwright trace | 5abf177026f2c10b6d663dba2e055481106c00f958ce74c70025d26185f02584 |
+| verification/runs/20260903-224852Z-ac43b22-issue60-portfolio-expiry-final/video/9ea854fc4e373591c3efbdbb8363d51d.webm | video | evidence | ed5bcf42f3e2f95787214da31cb7c29409e46bb16ca412cd2f6b66a2549f6f2a |

--- a/verification/receipts/20260903-225041Z-fa4a04c-fresh--portfolio.search.md
+++ b/verification/receipts/20260903-225041Z-fa4a04c-fresh--portfolio.search.md
@@ -1,0 +1,61 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-225041Z-fa4a04c-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: fa4a04cc4df5a7d8e83da421e5d5af22cbda1ef8
+code_digest: f9fbad92f42e524e41795653f89c4ab8e2dad25b80729de9fa3be7f49bfb3082
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260903-225041Z-fa4a04c-fresh
+created_at: 2026-09-03T23:04:49.480Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- Launch used this worktree at HEAD `fa4a04cc4df5a7d8e83da421e5d5af22cbda1ef8`; web ran on localhost:3000 against isolated `dns-ops-issue63-pg` database (`127.0.0.1:55591/dns_ops`). Doctor passed: bun present, node present, `/api/health` HTTP 200 `{"status":"healthy","service":"dns-ops-web"}`.
+- Playwright real-user drive reached `/portfolio`: headings `Portfolio workflows`, `Portfolio Search`, and `Built-in views` were visible; `Query` accepted `verify-expiry`.
+- Built-in button request bodies observed in `readback/built-in-view-requests.json`: Mail broken sent `findingTypePrefix:"mail."` and severities `["high","critical"]`; Expiring evidence sent `snapshotOlderThanDays:30`; Incomplete coverage sent `coverage:"incomplete"` and set `aria-pressed="true"`; re-click sent a cleared body with no view criteria.
+- Browser drive seeded `verify-expiry-observed.example.test` and `verify-expiry-unknown.example.test`. Unfiltered browser search returned both; OBSERVED evidence had expiration bucket `WITHIN_90`; UNKNOWN evidence had status `UNKNOWN`. Table showed an `Expiry` column, localized date + `WITHIN_90`, and literal `UNKNOWN` for the unknown row.
+- Selecting `Expiry window` = `Within 90 days` sent `expirationWithinDays:90` and returned only the observed fixture. Evidence is in `readback/portfolio-expiry.json` and `portfolio-search.png`.
+- Independent HTTP read-back with the same tenant/actor headers returned 200 for unfiltered, each built-in criteria body, and expiry criteria. Returned sets were consistent: all=`mailbroken.example,stale.example,unevaluated.example`; mail-broken=`mailbroken.example,unevaluated.example`; expiring=`stale.example`; incomplete=`unevaluated.example`; expiry90 fixture result was only observed in the browser drive. Full exchanges are in `readback/direct-portfolio-search.json`.
+- Saved-filter round trip through the UI persisted criteria `{expirationWithinDays:90}`, reset the select, then Load Filter restored select value `90`; independent GET `/api/portfolio/filters` returned the persisted criteria. Temporary filter was deleted via API with HTTP 200. Evidence: `readback/saved-filter-roundtrip.json`, `saved-filter-roundtrip.png`.
+
+## Forbidden (expected → confirmed absent)
+- No unauthenticated/sign-in warning was used as a successful search; all product assertions used the authenticated local e2e tenant headers and successful 200 API responses.
+- Cross-tenant read-back with `X-Dev-Tenant:fresh-unrelated-tenant` returned HTTP 200 with `domains:[]`.
+- Malformed search body `{limit:-1,offset:0}` returned HTTP 400 `VALIDATION_ERROR` (`limit must be at least 1`) with no write path involved.
+- No class selectors were used by the product harness flow.
+
+## Read-back
+- `readback/direct-portfolio-search.json` contains concrete status, request bodies, and domain result sets for the independent POST checks.
+- `readback/built-in-view-requests.json` contains concrete request bodies captured from the browser-driven button actions.
+- `readback/saved-filter-roundtrip.json` records persisted filter id/criteria, restored `expiryValue:"90"`, and cleanup status 200.
+
+Incidental non-feature issues: the dev server emitted a client CSS 404 and external Google font CORS/blocked requests; these did not prevent the portfolio route, API responses, or assertions. Two search requests were logged as aborted during React Query transitions; each corresponding final request completed with HTTP 200.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-225041Z-fa4a04c-fresh/console.log | log | aux · unrecognized .log | 2b7806bdfb8c4609216031639db20314dfcef13e83730b461240c13d81301ee0 |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/doctor.txt | txt | aux · unrecognized .txt | e04b82087084a16734a3457477977117baaf65fe4ae265360e4d4b267fa00c88 |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/env.txt | env | aux | 854623d4e6f724c07cef402df80d44326c3301ddbf152d3626b919c67b5c2252 |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/failed-requests.log | log | aux · unrecognized .log | 03ffd36d9859a796a52d4f7f249531c52a7d85152a052c94fb8c6e818b98142c |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/health-response.json | json | aux · unrecognized .json | 4f225704aca08fcf916ead3da4af87d0c08b31662c4252b9cba20db53690728b |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/observations.md | md | aux · unrecognized .md | fea07899ea6188f6f55190a3a98f36707ffc589e88df5ad523609684df09ea99 |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/portfolio-search.png | png | evidence · 1280x3564 | c245661d42ab5567b8c8bdac901ee8ff06026c3ee639a24ad95dc7fb7e6270ae |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/readback/direct-portfolio-search.json | readback | evidence | 91f0e8bb56381d939e0cff244b43c74524e170d4579f69423ef92bb69cb2be5d |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/readback/portfolio-expiry.json | readback | evidence | c33c9814864356ec139b028cf540c394e50c90fa2419d22d4329bd1e6bc04d23 |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/readback/portfolio-search.json | readback | evidence | 9712ac924b6255fb9e74305371c3b857f3bb702157b69d38d6841353322498d4 |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/readback/saved-filter-roundtrip.json | readback | evidence | fded223cb97599e0f600581ce4e76777d3e43a28b5e75fa04370ce390afca7f8 |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/saved-filter-roundtrip.png | png | evidence · 1280x4758 | ea3861546b2828861475d2c51baba18dac8a17a14113a8d7390aec1de126eb9c |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/trace.zip | trace | evidence · playwright trace | a54f3b86a8fcb8e27a6545ef0eef5b49594d6de9297d595e79f98654650640cb |
+| verification/runs/20260903-225041Z-fa4a04c-fresh/video/4fd81fc3036d4ceae3cd3241b84ec31a.webm | video | evidence | 9bb4797f6f03c853582156e66db58b6381086549b38392f95b18da138a9fcc8d |


### PR DESCRIPTION
Closes #60. Adds RDAP-derived expiry projection, 7/30/90-day filtering, sorted/paginated results, expiry column, and saved-filter round trips. Includes focused route/filter tests and live verification evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #60. Portfolio search now projects expiry from RDAP evidence, so results gain an Expiry column, a 7/30/90-day window filter, and saved filters round-trip the window. The shared verification harness now seeds RDAP expiry fixtures; `domain.overview` verification is blocked until re-run.

**New Features**
- Expiry comes from the latest snapshot's newest RDAP `RDAP_EXPIRATION` evidence; missing, failed, mismatched, or unparseable evidence renders as `UNKNOWN`.
- The Expiry window selector sends `expirationWithinDays`; values other than 7, 30, or 90 return 400.
- The results list is now a table; the Expiry column shows a localized date plus bucket, or literal `UNKNOWN`.

**Bug Fixes**
- Search filters and sorts the full tenant match set before slicing the page, so `total` now reflects all filtered matches and observed expirations sort ascending with `UNKNOWN` last.

<sup>Written for commit 71925d2ddd939025acd7dc5681cd1ed5d9d8ab5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

