### PR TITLE
feat(mcp): add explain_case tool returning the playbook for a case kind (#61)

### DIFF
--- a/apps/web/hono/lib/case-playbooks.test.ts
+++ b/apps/web/hono/lib/case-playbooks.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { loadCasePlaybook } from './case-playbooks.js';
+
+// The closed-world case-kind set (InternalSignalKind in @dns-ops/contracts).
+const CASE_KINDS = [
+  'DOMAIN_EXPIRING_SOON',
+  'TLS_CERTIFICATE_REGRESSION',
+  'HTTP_ENDPOINT_UNAVAILABLE',
+  'REDIRECT_TOPOLOGY_REGRESSION',
+  'HOMEPAGE_INDEXABILITY_REGRESSION',
+  'MAIL_DNS_CONFIGURATION_REGRESSION',
+] as const;
+
+const EXPECTED_PLAYBOOKS: Record<(typeof CASE_KINDS)[number], string> = {
+  DOMAIN_EXPIRING_SOON: 'domain-expiry',
+  TLS_CERTIFICATE_REGRESSION: 'tls-regression',
+  HTTP_ENDPOINT_UNAVAILABLE: 'unknown-evidence',
+  REDIRECT_TOPOLOGY_REGRESSION: 'redirect-regression',
+  HOMEPAGE_INDEXABILITY_REGRESSION: 'indexability-regression',
+  MAIL_DNS_CONFIGURATION_REGRESSION: 'mail-dns-configuration-regression',
+};
+
+describe('case playbooks', () => {
+  it('maps every case kind to its approved playbook with the required sections', async () => {
+    for (const caseKind of CASE_KINDS) {
+      const playbook = await loadCasePlaybook(caseKind);
+      expect(playbook, caseKind).not.toBeNull();
+      expect(playbook?.playbookId, caseKind).toBe(EXPECTED_PLAYBOOKS[caseKind]);
+      expect(playbook?.sections['What the condition proves'], caseKind).toBeTruthy();
+      expect(playbook?.sections['Safe next action'], caseKind).toBeTruthy();
+      expect(playbook?.sections['Escalation boundary'], caseKind).toBeTruthy();
+    }
+  });
+
+  it('returns the domain-expiry excerpt from the real document', async () => {
+    const playbook = await loadCasePlaybook('DOMAIN_EXPIRING_SOON');
+    expect(playbook?.title).toBe('Domain expiry');
+    expect(playbook?.sections['What the condition proves']).toContain('RDAP');
+  });
+
+  it('returns null for a kind outside the closed world', async () => {
+    await expect(loadCasePlaybook('NOT_A_CASE_KIND')).resolves.toBeNull();
+  });
+});

--- a/apps/web/hono/lib/case-playbooks.ts
+++ b/apps/web/hono/lib/case-playbooks.ts
@@ -1,0 +1,59 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type { InternalSignalKind } from '@dns-ops/contracts';
+
+/**
+ * Closed-world mapping from case kind (InternalSignalKind) to its approved
+ * playbook in docs/playbooks/. The excerpt is parsed from the document itself:
+ * no LLM, and no second copy of the playbook content to drift out of date.
+ */
+const CASE_KIND_PLAYBOOKS: Record<InternalSignalKind, string> = {
+  DOMAIN_EXPIRING_SOON: 'domain-expiry',
+  TLS_CERTIFICATE_REGRESSION: 'tls-regression',
+  REDIRECT_TOPOLOGY_REGRESSION: 'redirect-regression',
+  HOMEPAGE_INDEXABILITY_REGRESSION: 'indexability-regression',
+  MAIL_DNS_CONFIGURATION_REGRESSION: 'mail-dns-configuration-regression',
+  // There is no HTTP-health probe/evaluator (day-0 gate 1 marks the condition
+  // DISABLED), so an unavailable-endpoint case is a missing-evidence case and
+  // uses the unknown-evidence playbook.
+  HTTP_ENDPOINT_UNAVAILABLE: 'unknown-evidence',
+};
+
+export interface CasePlaybook {
+  caseKind: string;
+  playbookId: string;
+  title: string;
+  sections: Record<string, string>;
+}
+
+function playbookPath(playbookId: string): string {
+  // Resolved from this source file so both the dev server and vitest find
+  // docs/playbooks regardless of process cwd.
+  return fileURLToPath(new URL(`../../../../docs/playbooks/${playbookId}.md`, import.meta.url));
+}
+
+function splitSections(markdown: string): Record<string, string> {
+  const sections: Record<string, string> = {};
+  let current: string | null = null;
+  let buffer: string[] = [];
+  for (const line of markdown.split('\n')) {
+    if (line.startsWith('## ')) {
+      if (current) sections[current] = buffer.join('\n').trim();
+      current = line.slice(3).trim();
+      buffer = [];
+    } else if (current) {
+      buffer.push(line);
+    }
+  }
+  if (current) sections[current] = buffer.join('\n').trim();
+  return sections;
+}
+
+/** Returns the playbook excerpt for a case kind, or null for unknown kinds. */
+export async function loadCasePlaybook(caseKind: string): Promise<CasePlaybook | null> {
+  const playbookId = CASE_KIND_PLAYBOOKS[caseKind as InternalSignalKind];
+  if (!playbookId) return null;
+  const markdown = await readFile(playbookPath(playbookId), 'utf-8');
+  const title = /^# (.+)$/m.exec(markdown)?.[1] ?? playbookId;
+  return { caseKind, playbookId, title, sections: splitSections(markdown) };
+}

--- a/apps/web/hono/lib/mcp-dispatch.ts
+++ b/apps/web/hono/lib/mcp-dispatch.ts
@@ -85,6 +85,9 @@ export async function dispatchMcpTool(
     case 'case_get':
       value = await read.caseGet(args.caseId as string);
       break;
+    case 'explain_case':
+      value = await read.explainCase(args.caseKind as string);
+      break;
     case 'case_open':
       value = await new McpCaseCommandService(db, principal).caseOpen(
         args as { domainId: string; conditionKey: string; idempotencyKey: string }

--- a/apps/web/hono/lib/mcp-read-service.ts
+++ b/apps/web/hono/lib/mcp-read-service.ts
@@ -9,6 +9,7 @@ import {
   SnapshotRepository,
 } from '@dns-ops/db';
 import { compareSnapshots } from '@dns-ops/parsing';
+import { loadCasePlaybook } from './case-playbooks.js';
 import { type AuthenticatedMcpPrincipal, requireMcpScope } from './mcp-auth.js';
 
 export class McpNotFoundError extends Error {
@@ -133,6 +134,13 @@ export class McpReadService {
     );
     if (!result) throw new McpNotFoundError();
     return result;
+  }
+
+  async explainCase(caseKind: string) {
+    requireMcpScope(this.principal, 'CASE_READ');
+    const playbook = await loadCasePlaybook(caseKind);
+    if (!playbook) throw new McpNotFoundError();
+    return playbook;
   }
 
   private async ownedDomain(domainId: string) {

--- a/apps/web/hono/lib/mcp-tools.test.ts
+++ b/apps/web/hono/lib/mcp-tools.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { getMcpTool, MCP_TOOL_NAMES, MCP_TOOLS } from './mcp-tools.js';
 
 describe('MCP Phase 1 tool contract', () => {
-  it('exposes exactly the approved ten tools', () => {
-    expect(MCP_TOOLS).toHaveLength(10);
+  it('exposes exactly the approved tool set (issue #61 added explain_case)', () => {
+    expect(MCP_TOOLS).toHaveLength(11);
     expect(MCP_TOOLS.map((tool) => tool.name)).toEqual(MCP_TOOL_NAMES);
   });
 
@@ -19,6 +19,7 @@ describe('MCP Phase 1 tool contract', () => {
     expect(getMcpTool('evidence_get')?.requiredScope).toBe('DOMAIN_READ');
     expect(getMcpTool('signal_list')?.requiredScope).toBe('SIGNAL_READ');
     expect(getMcpTool('case_get')?.requiredScope).toBe('CASE_READ');
+    expect(getMcpTool('explain_case')?.requiredScope).toBe('CASE_READ');
   });
 
   it('does not resolve unapproved tools', () => {

--- a/apps/web/hono/lib/mcp-tools.ts
+++ b/apps/web/hono/lib/mcp-tools.ts
@@ -6,6 +6,7 @@ export const MCP_TOOL_NAMES = [
   'evidence_get',
   'signal_list',
   'case_get',
+  'explain_case',
   'case_open',
   'case_set_disposition',
   'scan_request',
@@ -74,6 +75,13 @@ export const MCP_TOOLS: readonly McpToolDefinition[] = [
     readOnly: true,
     requiredScope: 'CASE_READ',
     inputSchema: { type: 'object', required: ['caseId'], properties: { caseId: id } },
+  },
+  {
+    // Issue #61: deterministic playbook excerpt for a case kind. No LLM.
+    name: 'explain_case',
+    readOnly: true,
+    requiredScope: 'CASE_READ',
+    inputSchema: { type: 'object', required: ['caseKind'], properties: { caseKind: id } },
   },
   {
     name: 'case_open',

--- a/apps/web/hono/routes/mcp.harness.test.ts
+++ b/apps/web/hono/routes/mcp.harness.test.ts
@@ -54,6 +54,11 @@ const cases = [
   ['signal_list', { domainId: 'domain-a' }, []],
   ['case_get', { caseId: 'case-a' }, { case: { id: 'case-a' } }],
   [
+    'explain_case',
+    { caseKind: 'DOMAIN_EXPIRING_SOON' },
+    { caseKind: 'DOMAIN_EXPIRING_SOON', playbookId: 'domain-expiry', title: 'Domain expiry' },
+  ],
+  [
     'case_open',
     { domainId: 'domain-a', conditionKey: 'mail.no-spf-record', idempotencyKey: 'open-1' },
     { ok: true, value: { case: { id: 'case-a' } }, replayed: false },
@@ -86,6 +91,12 @@ describe('deterministic MCP transport harness', () => {
     vi.spyOn(McpReadService.prototype, 'signalList').mockResolvedValue([]);
     vi.spyOn(McpReadService.prototype, 'caseGet').mockResolvedValue({
       case: { id: 'case-a' },
+    } as never);
+    vi.spyOn(McpReadService.prototype, 'explainCase').mockResolvedValue({
+      caseKind: 'DOMAIN_EXPIRING_SOON',
+      playbookId: 'domain-expiry',
+      title: 'Domain expiry',
+      sections: {},
     } as never);
     vi.spyOn(McpCaseCommandService.prototype, 'caseOpen').mockResolvedValue({
       ok: true,

--- a/apps/web/hono/routes/mcp.test.ts
+++ b/apps/web/hono/routes/mcp.test.ts
@@ -86,9 +86,9 @@ describe('MCP discovery transport', () => {
       ]),
     };
     const response = await app().request('/mcp', rpc('tools/list'), limitedEnv);
-    await expect(response.json()).resolves.toMatchObject({
-      result: { tools: [{ name: 'case_get', requiredScope: 'CASE_READ' }] },
-    });
+    const body = (await response.json()) as { result: { tools: Array<{ name: string }> } };
+    const names = body.result.tools.map((tool) => tool.name).sort();
+    expect(names).toEqual(['case_get', 'explain_case']);
   });
 
   it('rejects malformed and unimplemented transport methods without leaking exceptions', async () => {

--- a/docs/domain-operations/phase-0-1/03-seeded-tests-and-mcp.md
+++ b/docs/domain-operations/phase-0-1/03-seeded-tests-and-mcp.md
@@ -189,7 +189,7 @@ Cloudflare Access authenticates the edge; the application map authorizes DNS Ops
 
 ## 13.3 Required tools
 
-Exactly ten tools:
+Exactly eleven tools (issue #61 added `explain_case`):
 
 ### Read
 
@@ -201,6 +201,7 @@ snapshot_compare
 evidence_get
 signal_list
 case_get
+explain_case
 ```
 
 ### Commands
@@ -214,6 +215,17 @@ scan_request
 `scan_request` is mandatory because the full MCP loop must be exercised through MCP rather than through an application-service bypass.
 
 ## 13.4 Command controls
+
+### `case_get`
+
+- requires `CASE_READ`.
+
+### `explain_case`
+
+- requires `CASE_READ`;
+- takes a case kind (closed-world `InternalSignalKind`);
+- returns the matching approved playbook excerpt parsed from `docs/playbooks/`;
+- deterministic: no LLM and no provider access.
 
 ### `case_open`
 


### PR DESCRIPTION
Closes #61.

Adds a deterministic `explain_case` MCP read tool (CASE_READ): maps each closed-world `InternalSignalKind` to its approved playbook in `docs/playbooks/` and returns the parsed excerpt (title + `##` sections). No LLM, no provider access; content is read from the playbook docs at request time (single source of truth).

- `HTTP_ENDPOINT_UNAVAILABLE` maps to `unknown-evidence` (no HTTP-health evaluator exists per day-0 gate 1; an unavailable-endpoint case is a missing-evidence case).
- Unknown case kinds return MCP not-found (-32004).
- Tests: mapping totality + real-document content, tool-contract count/scope, scope-disclosure list, harness dispatch round trip.

Phase-1 MCP doc updated to "eleven tools" with the new `explain_case` contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic `explain_case` MCP read tool that maps each closed-world `InternalSignalKind` to its approved playbook in `docs/playbooks/` and returns the parsed excerpt. Closes #61.

**Details**
- `HTTP_ENDPOINT_UNAVAILABLE` maps to `unknown-evidence` since no HTTP-health evaluator exists.
- Unknown case kinds return MCP not-found (-32004).
- Playbook content is read from the docs at request time, so there's no second copy to drift.
- Adds tests covering mapping totality, real-document content, tool contract, scope disclosure, and harness dispatch.
- Updates the Phase-1 MCP doc to eleven tools.

<sup>Written for commit 62972455745a75ee8c5904c76834c7756b884217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

