### PR TITLE
feat(web): copy provider-aligned mail records (#59)

### DIFF
--- a/apps/web/app/components/CopyProviderRecords.tsx
+++ b/apps/web/app/components/CopyProviderRecords.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copy provider records (issue #59).
+ *
+ * Clipboard-only affordance on the finding and guidance surfaces: copies the
+ * provider-aligned MX/SPF/DKIM records so operators stop retyping them.
+ * No DNS apply — nothing is sent to any API.
+ */
+
+import { useState } from 'react';
+import {
+  type CopyableProvider,
+  providerName,
+  recordsToClipboardText,
+} from '../lib/provider-records.js';
+
+const PROVIDERS: CopyableProvider[] = ['google-workspace', 'microsoft-365'];
+
+export function CopyProviderRecords({ domain }: { domain: string }) {
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+
+  const copy = async (provider: CopyableProvider) => {
+    setError('');
+    try {
+      await navigator.clipboard.writeText(recordsToClipboardText(provider, domain));
+      setStatus(
+        `${providerName(provider)} MX, SPF, and DKIM records for ${domain} copied. Fill the <placeholders> from your provider admin; nothing is applied here.`
+      );
+    } catch {
+      setStatus('');
+      setError('Clipboard access was blocked by the browser.');
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-blue-200 bg-blue-50 p-3">
+      <h6 className="text-xs font-semibold text-blue-900 uppercase tracking-wider">
+        Copy provider records
+      </h6>
+      <p className="mt-1 text-xs text-blue-900">
+        Copy provider-aligned MX, SPF, and DKIM records for {domain} to paste into your DNS
+        provider. Tenant-specific values are marked {'<like this>'}. No DNS changes are applied.
+      </p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {PROVIDERS.map((provider) => (
+          <button
+            key={provider}
+            type="button"
+            aria-label={`Copy ${providerName(provider)} records for ${domain}`}
+            onClick={() => void copy(provider)}
+            className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 bg-white border border-blue-300 rounded-md hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            Copy {providerName(provider)} records
+          </button>
+        ))}
+      </div>
+      {status && (
+        <p className="mt-2 text-xs text-green-700" role="status">
+          {status}
+        </p>
+      )}
+      {error && (
+        <p className="mt-2 text-xs text-red-700" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/components/MailFindingsPanel.tsx
+++ b/apps/web/app/components/MailFindingsPanel.tsx
@@ -9,6 +9,7 @@ import type { GuidanceOnlySuggestion } from '@dns-ops/contracts';
 import type { Finding, Suggestion } from '@dns-ops/db/schema';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { CopyProviderRecords } from './CopyProviderRecords.js';
 import { Button } from './ui/Button.js';
 import { EmptyState, ErrorState, LoadingState } from './ui/StateDisplay.js';
 
@@ -305,6 +306,10 @@ export function MailFindingsPanel({ snapshotId }: MailFindingsPanelProps) {
               {findings.length} finding{findings.length !== 1 ? 's' : ''}
             </span>
           )}
+        </div>
+
+        <div className="mb-4">
+          <CopyProviderRecords domain={data.domain} />
         </div>
 
         {findings.length === 0 && data.evaluationCoverage.state === 'COMPLETE' && (

--- a/apps/web/app/components/SimulationPanel.tsx
+++ b/apps/web/app/components/SimulationPanel.tsx
@@ -7,6 +7,7 @@
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { CopyProviderRecords } from './CopyProviderRecords.js';
 import { EmptyState, ErrorState, LoadingState } from './ui/StateDisplay.js';
 
 interface GuidanceOnlySuggestion {
@@ -187,6 +188,8 @@ export function SimulationPanel({ snapshotId }: SimulationPanelProps) {
           </div>
         </section>
       )}
+
+      <CopyProviderRecords domain={result.domain} />
 
       {result.currentFindings.length > 0 && (
         <section>

--- a/apps/web/app/lib/provider-records.test.ts
+++ b/apps/web/app/lib/provider-records.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasTenantPlaceholder,
+  normalizeZoneName,
+  providerName,
+  providerRecords,
+  recordsToClipboardText,
+} from './provider-records.js';
+
+describe('provider-records copy blocks (issue #59)', () => {
+  it('returns the MX/SPF/DKIM trio for Google Workspace', () => {
+    const records = providerRecords('google-workspace', 'Example.com.');
+    expect(records.map((r) => r.kind)).toEqual(['MX', 'SPF', 'DKIM']);
+    expect(records[0]).toMatchObject({ type: 'MX', name: '@', value: '10 smtp.google.com.' });
+    expect(records[1]?.value).toBe('v=spf1 include:_spf.google.com ~all');
+    expect(records[2]).toMatchObject({
+      type: 'TXT',
+      name: 'google._domainkey.example.com',
+    });
+  });
+
+  it('returns MX/SPF plus the selector1/selector2 DKIM CNAME pair for Microsoft 365', () => {
+    const records = providerRecords('microsoft-365', 'example.com');
+    expect(records.map((r) => r.kind)).toEqual(['MX', 'SPF', 'DKIM', 'DKIM']);
+    expect(records[0]?.value).toContain('.mail.protection.outlook.com.');
+    expect(records[1]?.value).toBe('v=spf1 include:spf.protection.outlook.com -all');
+    expect(records[2]).toMatchObject({
+      type: 'CNAME',
+      name: 'selector1._domainkey.example.com',
+    });
+    expect(records[3]).toMatchObject({
+      type: 'CNAME',
+      name: 'selector2._domainkey.example.com',
+    });
+  });
+
+  it('marks every per-tenant value with a <placeholder> and a note', () => {
+    for (const provider of ['google-workspace', 'microsoft-365'] as const) {
+      for (const record of providerRecords(provider, 'example.com')) {
+        if (record.note) {
+          expect(hasTenantPlaceholder(record.value)).toBe(true);
+          expect(record.note.length).toBeGreaterThan(10);
+        } else {
+          expect(hasTenantPlaceholder(record.value)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('keeps provider values aligned: no cross-provider endpoints', () => {
+    const google = JSON.stringify(providerRecords('google-workspace', 'example.com'));
+    const microsoft = JSON.stringify(providerRecords('microsoft-365', 'example.com'));
+    expect(google).not.toMatch(/outlook|microsoft/i);
+    expect(microsoft).not.toMatch(/google/i);
+  });
+
+  it('renders a clipboard block with provider name, FQDN hosts, and the no-apply notice', () => {
+    const text = recordsToClipboardText('google-workspace', 'example.com');
+    expect(text.startsWith('Google Workspace mail records for example.com')).toBe(true);
+    expect(text).toContain('10 smtp.google.com.');
+    expect(text).toContain('google._domainkey.example.com');
+    expect(text).toContain('Nothing is applied by this tool');
+    expect(providerName('microsoft-365')).toBe('Microsoft 365');
+  });
+
+  it('normalizes zone names used in hosts', () => {
+    expect(normalizeZoneName('  Example.COM. ')).toBe('example.com');
+  });
+});

--- a/apps/web/app/lib/provider-records.ts
+++ b/apps/web/app/lib/provider-records.ts
@@ -1,0 +1,115 @@
+/**
+ * Provider-aligned copy records — issue #59.
+ *
+ * Builds the three provider-aligned mail records (MX, SPF, DKIM) for Google
+ * Workspace and Microsoft 365 so an operator can paste them into their DNS
+ * provider instead of retyping them. Static values are the providers'
+ * published defaults; per-tenant values are `<placeholder>` markers the
+ * operator fills from the provider admin console. Clipboard only — this
+ * module never applies or proposes DNS changes.
+ */
+
+export type CopyableProvider = 'google-workspace' | 'microsoft-365';
+
+export interface ProviderRecord {
+  /** Record category within the provider setup (always the trio MX/SPF/DKIM). */
+  kind: 'MX' | 'SPF' | 'DKIM';
+  type: 'MX' | 'TXT' | 'CNAME';
+  /** Record name relative to the zone ('@' = zone apex). */
+  name: string;
+  value: string;
+  /** Set when the value contains a per-tenant `<placeholder>`. */
+  note?: string;
+}
+
+/** Trim, lowercase, and strip one trailing dot so names render consistently. */
+export function normalizeZoneName(domain: string): string {
+  return domain.trim().toLowerCase().replace(/\.$/, '');
+}
+
+const TENANT_PLACEHOLDER = /<[^>]+>/;
+
+export function hasTenantPlaceholder(value: string): boolean {
+  return TENANT_PLACEHOLDER.test(value);
+}
+
+export function providerRecords(provider: CopyableProvider, domain: string): ProviderRecord[] {
+  const zone = normalizeZoneName(domain);
+
+  if (provider === 'google-workspace') {
+    return [
+      { kind: 'MX', type: 'MX', name: '@', value: '10 smtp.google.com.' },
+      {
+        kind: 'SPF',
+        type: 'TXT',
+        name: '@',
+        value: 'v=spf1 include:_spf.google.com ~all',
+      },
+      {
+        kind: 'DKIM',
+        type: 'TXT',
+        name: `google._domainkey.${zone}`,
+        value: 'v=DKIM1; k=rsa; p=<public key generated in the Google Admin console>',
+        note: 'Generate the key in Google Admin → Apps → Google Workspace → Gmail → Authenticate email.',
+      },
+    ];
+  }
+
+  return [
+    {
+      kind: 'MX',
+      type: 'MX',
+      name: '@',
+      value: '10 <mx-token>.mail.protection.outlook.com.',
+      note: '<mx-token> is shown in the Microsoft 365 admin center when the domain is added (the initial .onmicrosoft.com domain).',
+    },
+    {
+      kind: 'SPF',
+      type: 'TXT',
+      name: '@',
+      value: 'v=spf1 include:spf.protection.outlook.com -all',
+    },
+    {
+      kind: 'DKIM',
+      type: 'CNAME',
+      name: `selector1._domainkey.${zone}`,
+      value: 'selector1-<domainGUID>._domainkey.<tenantDomain>.onmicrosoft.com.',
+      note: 'Enable DKIM in the Microsoft Defender portal first; it issues the <domainGUID>.',
+    },
+    {
+      kind: 'DKIM',
+      type: 'CNAME',
+      name: `selector2._domainkey.${zone}`,
+      value: 'selector2-<domainGUID>._domainkey.<tenantDomain>.onmicrosoft.com.',
+      note: 'Enable DKIM in the Microsoft Defender portal first; it issues the <domainGUID>.',
+    },
+  ];
+}
+
+const PROVIDER_NAMES: Record<CopyableProvider, string> = {
+  'google-workspace': 'Google Workspace',
+  'microsoft-365': 'Microsoft 365',
+};
+
+export function providerName(provider: CopyableProvider): string {
+  return PROVIDER_NAMES[provider];
+}
+
+/** Clipboard block: every record with its host and value, plus the no-apply notice. */
+export function recordsToClipboardText(provider: CopyableProvider, domain: string): string {
+  const zone = normalizeZoneName(domain);
+  const lines: string[] = [
+    `${PROVIDER_NAMES[provider]} mail records for ${zone}`,
+    'Paste into your DNS provider. Values in <angle brackets> are tenant-specific — fill them from your provider admin console. Nothing is applied by this tool.',
+    '',
+  ];
+
+  for (const record of providerRecords(provider, zone)) {
+    const host = record.name === '@' ? zone : record.name;
+    lines.push(`${record.kind} ${record.type} · ${host}`);
+    lines.push(`  ${record.value}`);
+    if (record.note) lines.push(`  note: ${record.note}`);
+  }
+
+  return lines.join('\n');
+}

--- a/verification/receipts/20260903-232225Z-1f39ce5-issue59-copy-provider-records--domain.overview.md
+++ b/verification/receipts/20260903-232225Z-1f39ce5-issue59-copy-provider-records--domain.overview.md
@@ -1,0 +1,38 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-232225Z-1f39ce5-issue59-copy-provider-records
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 1f39ce5cc08dfce4c11b74ca640750cbde055742
+code_digest: 29e68547ced446436406f4d12d7222802a9a71900cadd9d789e70d5b77e5c3c2
+dirty: true
+untracked: 0
+status: blocked
+reason: "Dev server launch fails with inotify EMFILE in this environment and the production build cannot serve local e2e auth; full unit suite, typecheck, lint, and workspace build pass for this tree. CI E2E covers the changed panel."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-232225Z-1f39ce5-issue59-copy-provider-records
+created_at: 2026-09-03T23:23:01.565Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-232225Z-1f39ce5-issue59-copy-provider-records/env.txt | env | aux | 7e16fd83c353b20e3a42bed048d71b085222568122b2b10beb52b25e244a1c16 |
+| verification/runs/20260903-232225Z-1f39ce5-issue59-copy-provider-records/observations.md | md | aux · unrecognized .md | d64b385ef9d74504d192c7b82cc706954ffae89e17e784b0361391d0ac50c222 |


### PR DESCRIPTION
Closes #59. Adds clipboard copy for Google Workspace and M365 MX/SPF/DKIM records from findings and simulation guidance, without DNS apply.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clipboard copy for Google Workspace and Microsoft 365 MX/SPF/DKIM records from findings and simulation guidance, so operators no longer retype provider-aligned records. No DNS changes are applied; tenant-specific values are shown as placeholders the user fills from their provider admin console. Closes #59.

<sup>Written for commit c90a4c2e43cc7b174eda6d912b2d7c94a96527e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

