### PR TITLE
feat(web): evaluate pasted dig and bounce evidence (#56)

### DIFF
--- a/apps/web/app/components/PasteEvidencePanel.tsx
+++ b/apps/web/app/components/PasteEvidencePanel.tsx
@@ -1,0 +1,122 @@
+import { useId, useState } from 'react';
+
+interface PasteFinding {
+  type: string;
+  title: string;
+  description: string;
+  severity: string;
+}
+
+interface PasteResponse {
+  kind?: string;
+  findings?: PasteFinding[];
+  summary?: { totalFindings: number };
+  error?: string;
+}
+
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: 'text-danger',
+  high: 'text-danger',
+  medium: 'text-warning',
+  low: 'text-text',
+  info: 'text-muted',
+};
+
+/**
+ * Paste dig output or a bounce header (issue #56) and evaluate it through the
+ * snapshot ruleset without collecting anything. Results are labeled as pasted
+ * evidence, never persisted as snapshot findings.
+ */
+export function PasteEvidencePanel({ domain }: { domain: string }) {
+  const [content, setContent] = useState('');
+  const [result, setResult] = useState<PasteResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const headingId = `${useId()}-paste-evidence-heading`;
+  const inputId = `${useId()}-paste-evidence-input`;
+
+  const analyze = async () => {
+    setBusy(true);
+    setResult(null);
+    try {
+      const response = await fetch('/api/paste/findings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ domain, content }),
+      });
+      setResult((await response.json()) as PasteResponse);
+    } catch {
+      setResult({ error: 'Paste analysis request failed' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="ds-panel portfolio-panel" aria-labelledby={headingId}>
+      <div className="border-b border-line px-4 py-3">
+        <h3 className="text-lg font-medium text-ink" id={headingId}>
+          Paste evidence
+        </h3>
+        <p className="text-sm text-muted">
+          Paste dig output or a bounce header for {domain}. It is evaluated with the snapshot
+          ruleset and marked as pasted evidence — not collected, not saved.
+        </p>
+      </div>
+      <div className="space-y-3 p-4">
+        <label className="sr-only" htmlFor={inputId}>
+          Pasted dig output or bounce header
+        </label>
+        <textarea
+          id={inputId}
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          rows={6}
+          disabled={busy}
+          placeholder={
+            'example.com. 300 IN MX 10 mail.example.com.\n—or—\nAuthentication-Results: mx; spf=pass smtp.mailfrom=user@example.com'
+          }
+          className="ds-input w-full rounded-lg border border-line px-3 py-2 font-mono text-xs focus:border-brand focus:ring-2 focus:ring-focus"
+        />
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={analyze}
+            disabled={busy || content.trim().length === 0}
+            className="ds-button ds-button--primary ds-button--sm"
+          >
+            {busy ? 'Analyzing…' : 'Analyze pasted evidence'}
+          </button>
+        </div>
+
+        {result?.error && (
+          <p className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
+            {result.error}
+          </p>
+        )}
+
+        {result && !result.error && (
+          <div className="space-y-2">
+            <p className="text-sm text-muted">
+              Pasted evidence ({result.kind}) — {result.summary?.totalFindings ?? 0} finding
+              {result.summary?.totalFindings === 1 ? '' : 's'}. Not collected, not saved.
+            </p>
+            <ul className="space-y-2">
+              {(result.findings ?? []).map((finding) => (
+                <li key={finding.type} className="rounded-lg border border-line p-3">
+                  <p className="text-sm font-medium text-ink">
+                    <span className={SEVERITY_COLOR[finding.severity] ?? 'text-text'}>
+                      [{finding.severity}]
+                    </span>{' '}
+                    {finding.title}
+                  </p>
+                  <p className="mt-1 text-sm text-muted">{finding.description}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/routes/domain/$domain.tsx
+++ b/apps/web/app/routes/domain/$domain.tsx
@@ -11,6 +11,7 @@ import { DomainEvidencePanel } from '../../components/DomainEvidencePanel.js';
 import { MailFindingsPanel } from '../../components/MailFindingsPanel.js';
 import { MailDiagnostics } from '../../components/mail/index.js';
 import { NotesPanel } from '../../components/NotesPanel.js';
+import { PasteEvidencePanel } from '../../components/PasteEvidencePanel.js';
 import { SimulationPanel } from '../../components/SimulationPanel.js';
 import { SnapshotHistoryPanel } from '../../components/SnapshotHistoryPanel.js';
 import { ResultStateBadge, ZoneManagementBadge } from '../../components/StatusBadges.js';
@@ -746,6 +747,8 @@ function OverviewTab({
           color={errorCount > 0 ? 'red' : 'gray'}
         />
       </div>
+
+      <PasteEvidencePanel domain={domain} />
 
       {SIMULATION_ENABLED && (
         <div>

--- a/apps/web/hono/routes/api.ts
+++ b/apps/web/hono/routes/api.ts
@@ -34,6 +34,7 @@ import { legacyToolsRoutes } from './legacy-tools.js';
 import { mailRoutes } from './mail.js';
 import migrateRoutes from './migrate.js';
 import { monitoringRoutes } from './monitoring.js';
+import { pasteRoutes } from './paste.js';
 import { portfolioRoutes } from './portfolio.js';
 import { providerTemplateRoutes } from './provider-templates.js';
 import { rulesetVersionRoutes } from './ruleset-versions.js';
@@ -208,6 +209,7 @@ apiRoutes.route('/monitoring', monitoringRoutes);
 apiRoutes.route('/alerts', alertRoutes);
 apiRoutes.route('/fleet-report', fleetReportRoutes);
 apiRoutes.route('/simulate', simulationRoutes);
+apiRoutes.route('/paste', pasteRoutes);
 apiRoutes.route('/suggestions', suggestionsRoutes);
 
 // Domain read — tenant-scoped via resolveAccessibleSnapshot

--- a/apps/web/hono/routes/auth-policy-matrix.test.ts
+++ b/apps/web/hono/routes/auth-policy-matrix.test.ts
@@ -456,6 +456,13 @@ export const AUTH_POLICY_MATRIX: RoutePolicy[] = [
   },
   // Simulation (tenant-scoped)
   { path: '/api/simulate', method: 'POST', policy: 'auth-read', notes: 'Uses tenant isolation' },
+  // Pasted evidence (issue #56): evaluates pasted text, persists nothing
+  {
+    path: '/api/paste/findings',
+    method: 'POST',
+    policy: 'auth-read',
+    notes: 'Pasted dig/bounce evaluation; requireAuth only, no persistence',
+  },
   // Suggestions (actorId checked in handler)
   {
     path: '/api/suggestions/:suggestionId',

--- a/apps/web/hono/routes/paste.test.ts
+++ b/apps/web/hono/routes/paste.test.ts
@@ -1,0 +1,91 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../types.js';
+import { pasteRoutes } from './paste.js';
+
+function createApp() {
+  const app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    c.set('db', {} as Env['Variables']['db']);
+    c.set('tenantId', 'tenant-1');
+    c.set('actorId', 'actor-1');
+    c.set('actorEmail', 'actor-1@example.test');
+    await next();
+  });
+  app.route('/api/paste', pasteRoutes);
+  return app;
+}
+
+const DIG_SPF_OK = `; <<>> DiG 9.18.1 <<>> example.com TXT
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR
+;; ANSWER SECTION:
+example.com.		300	IN	TXT	"v=spf1 -all"
+
+;; MSG SIZE  rcvd: 48`;
+
+const BOUNCE = `Received: from mail.example.net (mail.example.net. [203.0.113.9]) by mx.example.org with SMTP
+Authentication-Results: mx.example.org; spf=none smtp.mailfrom=example.com; dmarc=pass header.from=example.com`;
+
+async function post(app: Hono<Env>, body: Record<string, unknown>) {
+  const res = await app.request('/api/paste/findings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe('POST /api/paste/findings', () => {
+  let app: Hono<Env>;
+
+  beforeEach(() => {
+    app = createApp();
+  });
+
+  it('evaluates pasted dig output through the snapshot ruleset without persisting', async () => {
+    const { status, body } = await post(app, { domain: 'example.com', content: DIG_SPF_OK });
+
+    expect(status).toBe(200);
+    expect(body.collected).toBe(false);
+    expect(body.evidenceSource).toBe('pasted');
+    expect(body.kind).toBe('dig');
+    expect(body.rulesEvaluated).toBeGreaterThan(0);
+    expect(body.evaluationCoverage).toEqual({ state: 'COMPLETE', errors: [] });
+    const findings = body.findings as Array<Record<string, unknown>>;
+    const types = findings.map((f) => f.type);
+    expect(types).toContain('mail.spf-present');
+    // Parity with snapshot evaluation: the same observation set would produce
+    // the same absence findings (no MX / no DMARC were pasted).
+    expect(types).toContain('mail.no-mx-record');
+    const spf = findings.find((f) => f.type === 'mail.spf-present');
+    expect(['info', 'medium']).toContain(spf?.severity);
+  });
+
+  it('maps pasted bounce headers to the same finding vocabulary', async () => {
+    const { status, body } = await post(app, { domain: 'example.com', content: BOUNCE });
+
+    expect(status).toBe(200);
+    expect(body.collected).toBe(false);
+    expect(body.kind).toBe('bounce-header');
+    const findings = body.findings as Array<Record<string, unknown>>;
+    expect(findings.map((f) => f.type)).toEqual(['mail.no-spf-record', 'mail.dmarc-present']);
+    expect((body.parse as Record<string, unknown>).receivedHosts).toEqual(['mail.example.net']);
+  });
+
+  it('rejects unrecognizable pastes with 422', async () => {
+    const { status, body } = await post(app, {
+      domain: 'example.com',
+      content: 'random prose without structure',
+    });
+    expect(status).toBe(422);
+    expect(String(body.error)).toMatch(/dig output or an RFC5322 header block/);
+  });
+
+  it('validates required fields', async () => {
+    const missingDomain = await post(app, { content: DIG_SPF_OK });
+    expect(missingDomain.status).toBe(400);
+
+    const blankContent = await post(app, { domain: 'example.com', content: '' });
+    expect(blankContent.status).toBe(400);
+  });
+});

--- a/apps/web/hono/routes/paste.ts
+++ b/apps/web/hono/routes/paste.ts
@@ -1,0 +1,142 @@
+/**
+ * Pasted Evidence Routes (Issue #56)
+ *
+ * POST /api/paste/findings — evaluate operator-pasted dig output or an
+ * RFC5322 bounce/report header block through the SAME ruleset a snapshot
+ * uses and return the findings immediately, marked as pasted evidence that
+ * was not collected. Nothing is persisted: no snapshot, observations,
+ * record sets, or findings rows are written.
+ */
+
+import type { NewFinding, NewSuggestion } from '@dns-ops/db/schema';
+import {
+  authResultsToFindings,
+  detectPasteKind,
+  parseBounceHeaders,
+  parseDigOutput,
+} from '@dns-ops/parsing';
+import { type RuleContext, RulesEngine } from '@dns-ops/rules';
+import { type Context, Hono } from 'hono';
+import { requireAuth } from '../middleware/authorization.js';
+import { requiredString, validateBody, validationErrorResponse } from '../middleware/validation.js';
+import type { Env } from '../types.js';
+import { createCombinedRuleset } from './findings.js';
+
+export const pasteRoutes = new Hono<Env>();
+
+const MAX_PASTE_LENGTH = 100_000;
+
+pasteRoutes.post('/findings', requireAuth, async (c) => {
+  const validation = await validateBody(c, {
+    domain: requiredString('domain', { minLength: 1, maxLength: 253 }),
+    content: requiredString('content', { minLength: 1, maxLength: MAX_PASTE_LENGTH }),
+    vantageType: (value: unknown) => {
+      if (value === undefined || value === null) return undefined;
+      if (
+        value !== 'public-recursive' &&
+        value !== 'authoritative' &&
+        value !== 'parent-zone' &&
+        value !== 'probe'
+      ) {
+        throw new Error(
+          'vantageType must be one of: public-recursive, authoritative, parent-zone, probe'
+        );
+      }
+      return value;
+    },
+  });
+
+  if (!validation.success) {
+    return validationErrorResponse(c, validation.error);
+  }
+
+  const domain = validation.data.domain.trim().toLowerCase();
+  const content = validation.data.content;
+  const kind = detectPasteKind(content);
+
+  if (kind === 'unknown') {
+    return c.json({ error: 'Paste did not look like dig output or an RFC5322 header block' }, 422);
+  }
+
+  const ruleset = createCombinedRuleset();
+  const engine = new RulesEngine(ruleset);
+
+  if (kind === 'bounce-header') {
+    const parsed = parseBounceHeaders(content);
+    const findings = authResultsToFindings(parsed.authResults);
+    return respondPasted(c, {
+      kind,
+      domain,
+      findings,
+      suggestions: [],
+      rulesEvaluated: 0,
+      evaluationCoverage: null,
+      parse: {
+        headerCount: Object.keys(parsed.headers).length,
+        authenticationResults: parsed.authResults.map(
+          (ar) => `${ar.method}=${ar.result}${ar.domain ? ` (${ar.domain})` : ''}`
+        ),
+        receivedHosts: parsed.receivedHosts,
+      },
+    });
+  }
+
+  // dig paste: run the real ruleset over the parsed records.
+  const parsed = parseDigOutput(content, { vantageType: validation.data.vantageType });
+
+  const context: RuleContext = {
+    snapshotId: parsed.observations[0]?.snapshotId ?? '00000000-0000-4000-8000-000000000000',
+    domainId: '00000000-0000-4000-8000-000000000001',
+    domainName: domain,
+    zoneManagement: 'unknown',
+    observations: parsed.observations,
+    recordSets: parsed.recordSets,
+    rulesetVersion: ruleset.version,
+  };
+
+  const { findings, suggestions, errors, complete } = engine.evaluate(context);
+  const evaluationCoverage = {
+    state: complete ? ('COMPLETE' as const) : ('PARTIAL' as const),
+    errors,
+  };
+
+  return respondPasted(c, {
+    kind,
+    domain,
+    findings,
+    suggestions,
+    rulesEvaluated: engine.getEnabledRulesCount(),
+    evaluationCoverage,
+    parse: parsed.parse,
+  });
+});
+
+function respondPasted(
+  c: Context<Env>,
+  payload: {
+    kind: string;
+    domain: string;
+    findings: NewFinding[];
+    suggestions: NewSuggestion[];
+    rulesEvaluated: number;
+    evaluationCoverage: unknown;
+    parse: unknown;
+  }
+) {
+  return c.json({
+    evidenceSource: 'pasted',
+    collected: false,
+    kind: payload.kind,
+    domain: payload.domain,
+    rulesetVersion: null,
+    rulesEvaluated: payload.rulesEvaluated,
+    evaluationCoverage: payload.evaluationCoverage,
+    parse: payload.parse,
+    summary: {
+      totalFindings: payload.findings.length,
+      suggestions: payload.suggestions.length,
+    },
+    findings: payload.findings,
+    suggestions: payload.suggestions,
+  });
+}

--- a/packages/parsing/src/index.ts
+++ b/packages/parsing/src/index.ts
@@ -67,7 +67,6 @@ export {
   toPunycode,
 } from './idn/index.js';
 export * from './mail/index.js';
-
 // Mail Result-based parsing (gradual migration)
 export {
   isMailParseError,
@@ -81,3 +80,4 @@ export {
   parseSPFResult,
   partitionMailResults,
 } from './mail/result.js';
+export * from './paste/index.js';

--- a/packages/parsing/src/paste/index.test.ts
+++ b/packages/parsing/src/paste/index.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  authResultsToFindings,
+  detectPasteKind,
+  parseBounceHeaders,
+  parseDigOutput,
+} from './index.js';
+
+const DIG_MX_TXT = `; <<>> DiG 9.18.1 <<>> example.com MX
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12345
+;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
+
+;; ANSWER SECTION:
+example.com.		300	IN	MX	10 mail.example.com.
+example.com.		3600	IN	TXT	"v=spf1 -all"
+
+;; Query time: 20 msec
+;; MSG SIZE  rcvd: 65`;
+
+const BOUNCE = `Received: from mail-out.example.net (mail-out.example.net. [203.0.113.9]) by mx.example.org with SMTP id 123
+Authentication-Results: mx.example.org; spf=pass smtp.mailfrom=user@example.com; dkim=pass header.d=example.com; dmarc=none header.from=example.com
+DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=sel1;
+Subject: Delivery Status Notification`;
+
+describe('detectPasteKind', () => {
+  it('detects dig output by header, sections, and bare record lines', () => {
+    expect(detectPasteKind(DIG_MX_TXT)).toBe('dig');
+    expect(detectPasteKind('example.com. 300 IN A 93.184.216.34')).toBe('dig');
+    expect(detectPasteKind(';; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN')).toBe('dig');
+  });
+
+  it('detects RFC5322 header blocks and unknown text', () => {
+    expect(detectPasteKind(BOUNCE)).toBe('bounce-header');
+    expect(detectPasteKind('Received: from mx.example.org by mx2 with ESMTPS')).toBe(
+      'bounce-header'
+    );
+    expect(detectPasteKind('')).toBe('unknown');
+    expect(detectPasteKind('random prose without structure')).toBe('unknown');
+  });
+});
+
+describe('parseDigOutput', () => {
+  it('builds one observation and record set per name/type with TXT quotes stripped', () => {
+    const { observations, recordSets, parse } = parseDigOutput(DIG_MX_TXT);
+
+    expect(parse.rcode).toBe('NOERROR');
+    expect(parse.flags).toEqual({ qr: true, rd: true, ra: true });
+    expect(parse.queryName).toBe('example.com');
+    expect(parse.queryType).toBe('MX');
+    expect(parse.recordCount).toBe(2);
+
+    expect(observations).toHaveLength(2);
+    const mx = observations.find((o) => o.queryType === 'MX');
+    expect(mx?.queryName).toBe('example.com');
+    expect(mx?.status).toBe('success');
+    expect(mx?.vantageType).toBe('public-recursive');
+    expect(mx?.vantageIdentifier).toBe('pasted');
+    expect(mx?.answerSection).toEqual([
+      { name: 'example.com', type: 'MX', ttl: 300, data: '10 mail.example.com.' },
+    ]);
+
+    const txtRecordSet = recordSets.find((rs) => rs.type === 'TXT');
+    expect(txtRecordSet?.values).toEqual(['v=spf1 -all']);
+    expect(txtRecordSet?.isConsistent).toBe(true);
+  });
+
+  it('maps rcode to status and skips record sets on failure', () => {
+    const nxdomain = parseDigOutput(
+      ';; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN\n;; flags: qr rd ra;'
+    );
+    expect(nxdomain.observations).toHaveLength(0);
+    expect(nxdomain.recordSets).toHaveLength(0);
+    expect(nxdomain.parse.rcode).toBe('NXDOMAIN');
+  });
+
+  it('ignores non-record lines and unknown types', () => {
+    const result = parseDigOutput(
+      'example.com. 300 IN MX 10 mail.example.com.\nexample.com. 300 IN BOGUS x\n;; Query time: 1 msec\nNote this line'
+    );
+    expect(result.parse.recordCount).toBe(1);
+    expect(result.observations).toHaveLength(1);
+  });
+});
+
+describe('parseBounceHeaders', () => {
+  it('extracts header block, authentication results, and received hosts', () => {
+    const parsed = parseBounceHeaders(BOUNCE);
+    expect(Object.keys(parsed.headers)).toContain('dkim-signature');
+    expect(parsed.receivedHosts).toEqual(['mail-out.example.net']);
+    expect(parsed.authResults).toEqual([
+      { method: 'spf', result: 'pass', domain: 'example.com' },
+      { method: 'dkim', result: 'pass', domain: 'example.com' },
+      { method: 'dmarc', result: 'none', domain: 'example.com' },
+    ]);
+  });
+
+  it('stops at the body and handles continuation lines', () => {
+    const parsed = parseBounceHeaders(
+      'Authentication-Results: mx.test;\n\tspf=fail smtp.mailfrom=other.example;\n\nBody line: not a header'
+    );
+    expect(parsed.headers['authentication-results']).toContain('spf=fail');
+    expect(parsed.authResults).toEqual([
+      { method: 'spf', result: 'fail', domain: 'other.example' },
+    ]);
+  });
+});
+
+describe('authResultsToFindings', () => {
+  it('maps provable pass/none results to snapshot finding types', () => {
+    const findings = authResultsToFindings([
+      { method: 'spf', result: 'pass', domain: 'example.com' },
+      { method: 'spf', result: 'none', domain: 'example.com' },
+      { method: 'dmarc', result: 'none', domain: 'example.com' },
+      { method: 'dmarc', result: 'pass', domain: 'example.com' },
+      { method: 'dkim', result: 'pass', domain: 'example.com' },
+    ]);
+
+    expect(findings.map((f) => f.type)).toEqual([
+      'mail.spf-present',
+      'mail.no-spf-record',
+      'mail.no-dmarc-record',
+      'mail.dmarc-present',
+      'mail.dkim-keys-present',
+    ]);
+    expect(findings[0].ruleId).toBe('paste.auth-results.v1');
+    expect(findings.find((f) => f.type === 'mail.no-spf-record')?.severity).toBe('high');
+    for (const finding of findings) {
+      expect(JSON.stringify(finding.evidence)).toContain('pasted evidence');
+    }
+  });
+
+  it('never maps per-message failures to configuration findings', () => {
+    const findings = authResultsToFindings([
+      { method: 'spf', result: 'fail', domain: 'example.com' },
+      { method: 'spf', result: 'softfail', domain: 'example.com' },
+      { method: 'dkim', result: 'none', domain: 'example.com' },
+      { method: 'dmarc', result: 'temperror', domain: 'example.com' },
+    ]);
+    expect(findings).toEqual([]);
+  });
+});

--- a/packages/parsing/src/paste/index.ts
+++ b/packages/parsing/src/paste/index.ts
@@ -1,0 +1,383 @@
+/**
+ * Pasted Evidence Parsing (Issue #56)
+ *
+ * Turns operator-pasted text — dig output or an RFC5322 bounce/report header
+ * block — into the same observation/finding vocabulary a snapshot produces,
+ * without collecting anything. Nothing here performs I/O; callers decide how
+ * (or whether) to persist. Every produced finding is marked with
+ * `paste` rule ids so downstream surfaces can label it as pasted evidence.
+ */
+
+import type {
+  DNSRecord,
+  EvidenceLink,
+  NewFinding,
+  Observation,
+  RecordSet,
+} from '@dns-ops/db/schema';
+import { normalizeDomain } from '../dns/index.js';
+
+export type PasteKind = 'dig' | 'bounce-header' | 'unknown';
+
+/** Synthetic snapshot id used for pasted-evidence evaluation (never persisted). */
+export const PASTE_SNAPSHOT_ID = '00000000-0000-4000-8000-000000000000';
+
+const PASTE_RULE_ID = 'paste.auth-results.v1';
+const PASTE_RULE_VERSION = '1.0.0';
+
+const KNOWN_RECORD_TYPES = new Set([
+  'A',
+  'AAAA',
+  'CAA',
+  'CNAME',
+  'DNAME',
+  'DNSKEY',
+  'DS',
+  'HINFO',
+  'HTTPS',
+  'LOC',
+  'MX',
+  'NAPTR',
+  'NS',
+  'NSEC',
+  'NSEC3',
+  'PTR',
+  'SOA',
+  'SPF',
+  'SRV',
+  'SVCB',
+  'TLSA',
+  'TXT',
+]);
+
+const RCODE_TO_STATUS: Record<string, { status: Observation['status']; code: number }> = {
+  NOERROR: { status: 'success', code: 0 },
+  FORMERR: { status: 'error', code: 1 },
+  SERVFAIL: { status: 'error', code: 2 },
+  NXDOMAIN: { status: 'nxdomain', code: 3 },
+  NOTIMP: { status: 'error', code: 4 },
+  REFUSED: { status: 'refused', code: 5 },
+};
+
+/** Cheap structural detection; ambiguity must fail closed to `unknown`. */
+export function detectPasteKind(text: string): PasteKind {
+  const trimmed = text.trim();
+  if (!trimmed) return 'unknown';
+  if (trimmed.includes('<<>>') || /^\s*;;/m.test(trimmed)) return 'dig';
+  if (DIG_RECORD_LINE.test(trimmed)) return 'dig';
+  if (/^[A-Za-z0-9-]+:\s/m.test(trimmed)) return 'bounce-header';
+  return 'unknown';
+}
+
+const DIG_RECORD_LINE = /^(\*?\S+?)\.?\s+(\d+)\s+(?:IN\s+)?([A-Z]{1,10})\s+(\S.*)$/m;
+
+function parseDigTtlData(data: string): string {
+  const quoted = data.match(/"([^"]*)"/g);
+  if (!quoted) return data.trim();
+  // RFC 1035: TXT character-strings concatenate without separators.
+  return quoted.map((chunk) => chunk.slice(1, -1)).join('');
+}
+
+export interface DigParseResult {
+  observations: Observation[];
+  recordSets: RecordSet[];
+  parse: {
+    queryName: string | null;
+    queryType: string | null;
+    rcode: string | null;
+    flags: Record<string, boolean> | null;
+    recordCount: number;
+  };
+}
+
+/**
+ * Parse dig answer output into synthetic observations and record sets.
+ * Only the ANSWER SECTION content (and bare record lines) is evidence; the
+ * question/header sections set query context, status, and flags.
+ */
+export function parseDigOutput(
+  text: string,
+  options: { vantageType?: Observation['vantageType'] } = {}
+): DigParseResult {
+  const queryMatch = text.match(/<<>>\s+DiG\s[\s\S]*?<<>>\s*([^\n]*)/);
+  let queryName: string | null = null;
+  let queryType: string | null = null;
+  if (queryMatch) {
+    const args = queryMatch[1]
+      .trim()
+      .split(/\s+/)
+      .filter((t) => !/^[+@-]/.test(t));
+    if (args.length > 0) queryName = normalizeDomain(args[0]);
+    if (args.length > 1 && /^[A-Za-z]{1,10}$/.test(args[1])) queryType = args[1].toUpperCase();
+  }
+
+  const rcodeMatch = text.match(/status:\s*([A-Z]+)/);
+  const rcode = rcodeMatch ? rcodeMatch[1] : null;
+
+  let flags: Record<string, boolean> | null = null;
+  const flagsMatch = text.match(/flags:\s*([^;\n]+);/);
+  if (flagsMatch) {
+    flags = {};
+    for (const token of flagsMatch[1].trim().split(/\s+/)) {
+      if (/^[a-z]{2,4}$/.test(token)) flags[token] = true;
+    }
+  }
+
+  const records: DNSRecord[] = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith(';')) continue;
+    const match = DIG_RECORD_LINE.exec(line);
+    if (!match) continue;
+    const [, name, ttl, type, data] = match;
+    if (!KNOWN_RECORD_TYPES.has(type)) continue;
+    records.push({
+      name: normalizeDomain(name),
+      type,
+      ttl: Number(ttl),
+      data: type === 'TXT' ? parseDigTtlData(data) : data.trim(),
+    });
+  }
+
+  const rcodeInfo = rcode ? RCODE_TO_STATUS[rcode] : undefined;
+  const status: Observation['status'] = rcodeInfo
+    ? rcodeInfo.status
+    : records.length > 0
+      ? 'success'
+      : 'error';
+  const responseCode = rcodeInfo ? rcodeInfo.code : null;
+  const vantageType = options.vantageType ?? 'public-recursive';
+
+  const groups = new Map<string, DNSRecord[]>();
+  for (const record of records) {
+    const key = `${record.name}|${record.type}`;
+    const group = groups.get(key);
+    if (group) group.push(record);
+    else groups.set(key, [record]);
+  }
+
+  const observations: Observation[] = [];
+  const recordSets: RecordSet[] = [];
+  for (const [key, groupRecords] of groups) {
+    const [name, type] = key.split('|');
+    const observation: Observation = {
+      id: crypto.randomUUID(),
+      snapshotId: PASTE_SNAPSHOT_ID,
+      queryName: name,
+      queryType: type,
+      vantageType,
+      vantageIdentifier: 'pasted',
+      status,
+      queriedAt: new Date(),
+      responseTimeMs: null,
+      responseCode,
+      flags,
+      answerSection: groupRecords,
+      authoritySection: null,
+      additionalSection: null,
+      errorMessage: status === 'success' ? null : `pasted dig status: ${rcode ?? 'unknown'}`,
+      errorDetails: null,
+      rawResponse: null,
+    };
+    observations.push(observation);
+    recordSets.push({
+      id: crypto.randomUUID(),
+      snapshotId: PASTE_SNAPSHOT_ID,
+      name,
+      type,
+      ttl: groupRecords[0].ttl,
+      values: groupRecords.map((r) => r.data),
+      sourceObservationIds: [observation.id],
+      sourceVantages: ['pasted'],
+      isConsistent: true,
+      consolidationNotes: 'pasted dig output',
+      createdAt: new Date(),
+    });
+  }
+
+  return {
+    observations,
+    recordSets: status === 'success' ? recordSets : [],
+    parse: {
+      queryName,
+      queryType,
+      rcode,
+      flags,
+      recordCount: records.length,
+    },
+  };
+}
+
+export interface PasteAuthResult {
+  method: 'spf' | 'dkim' | 'dmarc';
+  result: string;
+  domain: string | null;
+}
+
+export interface BounceHeaderParseResult {
+  headers: Record<string, string>;
+  authResults: PasteAuthResult[];
+  receivedHosts: string[];
+}
+
+function authResultsDomain(token: string): string | null {
+  const value = token.split('=').slice(1).join('=').trim();
+  if (!value) return null;
+  const parts = value.split('@');
+  const candidate = parts.length > 1 ? parts[parts.length - 1] : value;
+  const normalized = normalizeDomain(candidate.replace(/[<>]/g, ''));
+  return /^[a-z0-9.-]+$/.test(normalized) ? normalized : null;
+}
+
+function parseAuthResults(value: string): PasteAuthResult[] {
+  const results: PasteAuthResult[] = [];
+  // First chunk is the authserv-id; the rest are `method=result` / property tokens.
+  for (const chunk of value.split(';').slice(1)) {
+    const token = chunk.trim();
+    const match = /^(spf|dkim|dmarc)=([a-z]+)\b/i.exec(token);
+    if (!match) continue;
+    const method = match[1].toLowerCase() as PasteAuthResult['method'];
+    const domainToken = token
+      .split(/\s+/)
+      .find((t) =>
+        t.startsWith(
+          method === 'spf' ? 'smtp.mailfrom=' : method === 'dkim' ? 'header.d=' : 'header.from='
+        )
+      );
+    results.push({
+      method,
+      result: match[2].toLowerCase(),
+      domain: domainToken ? authResultsDomain(domainToken) : null,
+    });
+  }
+  return results;
+}
+
+/** Parse an RFC5322 header block (bounce / DMARC report cover message). */
+export function parseBounceHeaders(text: string): BounceHeaderParseResult {
+  const headers: Record<string, string> = {};
+  const receivedHosts: string[] = [];
+
+  let currentName: string | null = null;
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (!rawLine.trim()) {
+      if (currentName) break; // blank line ends the header block
+      continue;
+    }
+    if (/^[ \t]/.test(rawLine) && currentName) {
+      headers[currentName] += ` ${rawLine.trim()}`;
+      continue;
+    }
+    const match = /^([A-Za-z0-9-]+):\s*(.*)$/.exec(rawLine);
+    if (!match) {
+      if (currentName) break; // body content reached
+      continue;
+    }
+    currentName = match[1].toLowerCase();
+    headers[currentName] = match[2].trim();
+    if (currentName === 'received') {
+      const from = match[2].match(/^from\s+(\S+)/i);
+      if (from) receivedHosts.push(from[1].replace(/[();,]+$/g, ''));
+    }
+  }
+
+  const authResults = (
+    headers['authentication-results'] ? [headers['authentication-results']] : []
+  ).flatMap(parseAuthResults);
+
+  return { headers, authResults, receivedHosts };
+}
+
+function pasteFinding(input: {
+  type: string;
+  title: string;
+  description: string;
+  severity: NewFinding['severity'];
+  evidence: EvidenceLink[];
+}): NewFinding {
+  return {
+    id: crypto.randomUUID(),
+    snapshotId: PASTE_SNAPSHOT_ID,
+    type: input.type,
+    title: input.title,
+    description: input.description,
+    severity: input.severity,
+    confidence: 'certain',
+    riskPosture: input.severity === 'info' ? 'safe' : 'medium',
+    blastRadius: 'single-domain',
+    reviewOnly: false,
+    evidence: input.evidence,
+    ruleId: PASTE_RULE_ID,
+    ruleVersion: PASTE_RULE_VERSION,
+    rulesetVersionId: 'pasted',
+    createdAt: new Date(),
+  };
+}
+
+const PRESENT_TYPES: Record<PasteAuthResult['method'], { type: string; label: string }> = {
+  spf: { type: 'mail.spf-present', label: 'SPF record' },
+  dkim: { type: 'mail.dkim-keys-present', label: 'DKIM keys' },
+  dmarc: { type: 'mail.dmarc-present', label: 'DMARC policy' },
+};
+
+const NONE_TYPES: Partial<
+  Record<
+    PasteAuthResult['method'],
+    { type: string; label: string; severity: NewFinding['severity'] }
+  >
+> = {
+  // spf=none / dmarc=none are authoritative per RFC 7208/7489: no record was
+  // found for the domain. dkim=none only means this message was not DKIM'd —
+  // it proves nothing about published keys, so it produces no finding.
+  spf: { type: 'mail.no-spf-record', label: 'SPF record', severity: 'high' },
+  dmarc: { type: 'mail.no-dmarc-record', label: 'DMARC policy', severity: 'high' },
+};
+
+/**
+ * Map pasted Authentication-Results entries to the same finding types a
+ * snapshot evaluation produces. Only `none` (record provably absent) and
+ * `pass` (record provably present and evaluated) map; per-message failure
+ * results cannot establish configuration facts, so they are skipped.
+ */
+export function authResultsToFindings(authResults: PasteAuthResult[]): NewFinding[] {
+  const findings: NewFinding[] = [];
+  for (const entry of authResults) {
+    const description = `Pasted Authentication-Results carries ${entry.method}=${entry.result}${
+      entry.domain ? ` for ${entry.domain}` : ''
+    }. This is per-message evaluation of the pasted header, not a fresh DNS collection.`;
+    const evidence: EvidenceLink[] = [
+      {
+        observationId: PASTE_SNAPSHOT_ID,
+        description: `Authentication-Results: ${entry.method}=${entry.result}${
+          entry.domain ? ` (domain ${entry.domain})` : ''
+        } — pasted evidence`,
+      },
+    ];
+    if (entry.result === 'pass') {
+      const present = PRESENT_TYPES[entry.method];
+      findings.push(
+        pasteFinding({
+          type: present.type,
+          title: `${present.label} present for ${entry.domain ?? 'pasted domain'} (pasted evidence)`,
+          description,
+          severity: 'info',
+          evidence,
+        })
+      );
+      continue;
+    }
+    const absent = NONE_TYPES[entry.method];
+    if (absent && entry.result === 'none') {
+      findings.push(
+        pasteFinding({
+          type: absent.type,
+          title: `No ${absent.label.toLowerCase()} found for ${entry.domain ?? 'pasted domain'} (pasted evidence)`,
+          description,
+          severity: absent.severity,
+          evidence,
+        })
+      );
+    }
+  }
+  return findings;
+}

--- a/verification/receipts/20260903-233023Z-1f39ce5-issue56-paste-evidence--domain.overview.md
+++ b/verification/receipts/20260903-233023Z-1f39ce5-issue56-paste-evidence--domain.overview.md
@@ -1,0 +1,43 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-233023Z-1f39ce5-issue56-paste-evidence
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 1f39ce5cc08dfce4c11b74ca640750cbde055742
+code_digest: 4d5234ed773ce20af167c68f0cf39c5fc6e8663039277b9e3d89eaec7bc47c99
+dirty: true
+untracked: 0
+status: blocked
+reason: "Analyze drive requires a live collector for fresh google.com collection; collector dev cannot start in this environment (tsx EMFILE). Domain page with the new pasted-evidence panel proven by 27 passing Playwright e2e tests against this exact tree."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence
+created_at: 2026-09-03T23:33:35.711Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/console.log | log | aux · unrecognized .log | be09aaf459162736f5e29233517088611ceb7865dcb95911794292273a4d667e |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/env.txt | env | aux | 670150cef8d885640d68d06b15ab40b5170b7a26a46c2beffe1d1749b0f38d55 |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/failed-requests.log | log | aux · unrecognized .log | 3d80c4859285aa8aac7ea6333f34c50528dc6f5c55a59b57c76ce4c342a42da6 |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/http/01-web-health.json | http | evidence | 07f9e666d670899e77f76278e9302444a6c336ceb4d87a9f10b81fb803b5aabe |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/observations.md | md | aux · unrecognized .md | 321a8c5e7ee14f97813f50ec65649e8887efff2e92f6a6e3c0ab7c9982a00541 |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/trace.zip | trace | evidence · playwright trace | 84c117201f9b9545c607cca0bd0d8bf57d04303fa9d15d2949b778b103da8347 |

--- a/verification/receipts/20260903-233023Z-1f39ce5-issue56-paste-evidence--health.public.md
+++ b/verification/receipts/20260903-233023Z-1f39ce5-issue56-paste-evidence--health.public.md
@@ -1,0 +1,43 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-233023Z-1f39ce5-issue56-paste-evidence
+feature_id: health.public
+profile: changed
+surface: api
+sha: 1f39ce5cc08dfce4c11b74ca640750cbde055742
+code_digest: 4d5234ed773ce20af167c68f0cf39c5fc6e8663039277b9e3d89eaec7bc47c99
+dirty: true
+untracked: 1
+status: blocked
+reason: "Doctor verified web /api/health 200 healthy on this tree; the full health.public drive also requires collector /healthz and /readyz with matching revisions, and no collector instance is runnable in this lane (collector dev EMFILE crash). Diff only mounts the additive /api/paste route and does not touch health endpoints."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence
+created_at: 2026-09-03T23:33:42.330Z
+---
+
+# Receipt: health.public — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/console.log | log | aux · unrecognized .log | be09aaf459162736f5e29233517088611ceb7865dcb95911794292273a4d667e |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/env.txt | env | aux | 670150cef8d885640d68d06b15ab40b5170b7a26a46c2beffe1d1749b0f38d55 |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/failed-requests.log | log | aux · unrecognized .log | 3d80c4859285aa8aac7ea6333f34c50528dc6f5c55a59b57c76ce4c342a42da6 |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/http/01-web-health.json | http | evidence | 07f9e666d670899e77f76278e9302444a6c336ceb4d87a9f10b81fb803b5aabe |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/observations.md | md | aux · unrecognized .md | 321a8c5e7ee14f97813f50ec65649e8887efff2e92f6a6e3c0ab7c9982a00541 |
+| verification/runs/20260903-233023Z-1f39ce5-issue56-paste-evidence/trace.zip | trace | evidence · playwright trace | 84c117201f9b9545c607cca0bd0d8bf57d04303fa9d15d2949b778b103da8347 |


### PR DESCRIPTION
Closes #56. Adds paste-evidence evaluation for dig output and RFC5322 bounce headers using existing parsers/rules, marked as pasted and not collected, with a Domain 360 panel and tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds paste-evidence evaluation for dig output and RFC5322 bounce headers on the domain overview page, closing #56. Pasted text runs through the same ruleset a snapshot uses but is marked as pasted evidence and never persisted.

- Adds a paste panel to the domain overview page and a new `POST /api/paste/findings` route behind `auth-read`.
- Detects dig output and bounce headers; unrecognizable pastes return 422 and missing required fields return 400.
- Dig output is parsed into observations and record sets and evaluated with the snapshot ruleset; bounce headers map `Authentication-Results` entries to the existing finding types.
- Bounce findings only include `pass` and `none` results, since per-message failures can't prove configuration facts.

<sup>Written for commit a675e8adc402dffa87836791f9331e8169106f76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

