### PR TITLE
feat(web): add two-person confirmed live drill starts (#62)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ verification/registry.json
 
 # verify-fresh generated marker; exclude it from working-tree digests.
 /.verify-fresh-worktree
+
+# Live drill harness artifacts (redacted, mode 0600; never commit)
+/.live-drills/

--- a/apps/web/app/components/LiveDrillsPanel.tsx
+++ b/apps/web/app/components/LiveDrillsPanel.tsx
@@ -1,0 +1,237 @@
+/**
+ * Live Drills Panel - Issue #62
+ *
+ * Operator surface for starting the fail-closed controlled-live harness
+ * against the allowlisted asorin.ai tuples. Starts require two distinct
+ * operators (request + confirm); every other domain stays observation-only.
+ * This panel never sees provider or fixture secrets — the harness resolves
+ * its own runtime credentials and fails closed without them.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+interface DrillTuple {
+  name: string;
+  types: string[];
+  mutationIds: string[];
+}
+
+interface DrillRunRow {
+  id: string;
+  mutationId: string;
+  recordName: string;
+  status: string;
+  requesterActor: string;
+  confirmerActor: string | null;
+  recoveryArtifact: string | null;
+  runnerMessage: string | null;
+  createdAt: string;
+}
+
+interface DrillsPayload {
+  harness: { available: boolean; manifestId: string | null; zone: string | null };
+  tuples: DrillTuple[];
+  scenarios: Record<string, { host: string; expectedSignal: string }>;
+  runs: DrillRunRow[];
+}
+
+async function fetchDrills(): Promise<DrillsPayload> {
+  const response = await fetch('/api/portfolio/drills', { credentials: 'include' });
+  if (!response.ok) throw new Error('Failed to load live drills');
+  return (await response.json()) as DrillsPayload;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  requested: 'Awaiting second-operator confirm',
+  approved: 'Confirmed — ready to start',
+  started: 'Harness running',
+  fault_applied: 'Fault applied — restore required',
+  failed: 'Failed (fail-closed)',
+};
+
+export function LiveDrillsPanel() {
+  const queryClient = useQueryClient();
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['live-drills'],
+    queryFn: fetchDrills,
+  });
+
+  const act = useMutation({
+    mutationFn: async ({ path, body }: { path: string; body?: Record<string, unknown> }) => {
+      const response = await fetch(path, {
+        method: 'POST',
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(payload.error || 'Drill action failed');
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      setActionError(null);
+      queryClient.invalidateQueries({ queryKey: ['live-drills'] });
+    },
+    onError: (mutationError) => setActionError((mutationError as Error).message),
+  });
+
+  const tuples = data?.tuples ?? [];
+  const runs = data?.runs ?? [];
+  const openRun = runs.find((run) => ['requested', 'approved', 'started'].includes(run.status));
+  const settledRuns = runs.filter(
+    (run) => !['requested', 'approved', 'started'].includes(run.status)
+  );
+
+  return (
+    <div className="ds-panel portfolio-panel">
+      <div className="border-b border-line px-4 py-3">
+        <h3 className="text-lg font-medium text-ink">Live drills</h3>
+        <p className="text-sm text-muted">
+          Controlled LIVE-01–03 runs through the fail-closed harness. Starting a drill requires a
+          second operator to confirm; only the allowlisted asorin.ai tuples can start. All other
+          domains stay observation-only.
+        </p>
+      </div>
+
+      <div className="space-y-4 p-4">
+        {error && (
+          <div className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
+            Live drills are unavailable right now.
+          </div>
+        )}
+        {isLoading && <div className="py-4 text-center text-muted">Loading live drills...</div>}
+
+        {data && !data.harness.available && (
+          <div className="rounded-lg border border-warning bg-warning-surface p-3 text-sm text-warning">
+            The controlled-live harness is not available in this deployment. Drills can only be
+            started where the harness and its runtime secret files are provisioned.
+          </div>
+        )}
+
+        {actionError && (
+          <div className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
+            {actionError}
+          </div>
+        )}
+
+        {data?.harness.available && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <caption className="sr-only">Allowlisted live drill tuples</caption>
+              <thead>
+                <tr className="border-b border-line text-xs uppercase tracking-wide text-muted">
+                  <th scope="col" className="px-2 py-2 font-medium">
+                    Record
+                  </th>
+                  <th scope="col" className="px-2 py-2 font-medium">
+                    Types
+                  </th>
+                  <th scope="col" className="px-2 py-2 font-medium">
+                    Scenario
+                  </th>
+                  <th scope="col" className="px-2 py-2 font-medium">
+                    Action
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {tuples.map((tuple) =>
+                  tuple.mutationIds.map((mutationId) => {
+                    const scenario = data.scenarios[mutationId];
+                    const busy = openRun !== undefined;
+                    return (
+                      <tr key={`${tuple.name}-${mutationId}`} className="border-b border-line">
+                        <td className="px-2 py-2 font-medium text-ink">{tuple.name}</td>
+                        <td className="px-2 py-2">{tuple.types.join(', ')}</td>
+                        <td className="px-2 py-2">
+                          {mutationId}
+                          {scenario?.host ? ` · ${scenario.host}` : ''}
+                        </td>
+                        <td className="px-2 py-2">
+                          <button
+                            type="button"
+                            disabled={busy || act.isPending}
+                            onClick={() =>
+                              act.mutate({ path: '/api/portfolio/drills', body: { mutationId } })
+                            }
+                            className="ds-button ds-button--secondary ds-button--sm"
+                          >
+                            Request drill
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {openRun && (
+          <div className="rounded-lg border border-brand bg-info-surface p-3 text-sm text-text">
+            <p className="font-medium text-ink">
+              {openRun.mutationId} · {openRun.recordName} —{' '}
+              {STATUS_LABELS[openRun.status] ?? openRun.status}
+            </p>
+            <p className="mt-1 text-muted">
+              Requested by {openRun.requesterActor}
+              {openRun.confirmerActor ? ` · confirmed by ${openRun.confirmerActor}` : ''}
+            </p>
+            <div className="mt-2 flex gap-2">
+              {openRun.status === 'requested' && (
+                <button
+                  type="button"
+                  disabled={act.isPending}
+                  onClick={() =>
+                    act.mutate({ path: `/api/portfolio/drills/${openRun.id}/confirm` })
+                  }
+                  className="ds-button ds-button--primary ds-button--sm"
+                >
+                  Confirm as second operator
+                </button>
+              )}
+              {openRun.status === 'approved' && (
+                <button
+                  type="button"
+                  disabled={act.isPending}
+                  onClick={() => act.mutate({ path: `/api/portfolio/drills/${openRun.id}/start` })}
+                  className="ds-button ds-button--primary ds-button--sm"
+                >
+                  Start harness
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {settledRuns.length > 0 && (
+          <div>
+            <h4 className="mb-2 font-medium text-ink">Recent drill runs</h4>
+            <ul className="space-y-2 text-sm">
+              {settledRuns.slice(0, 5).map((run) => (
+                <li key={run.id} className="rounded-lg border border-line p-3">
+                  <p className="font-medium text-ink">
+                    {run.mutationId} · {run.recordName} — {STATUS_LABELS[run.status] ?? run.status}
+                  </p>
+                  {run.recoveryArtifact && (
+                    <p className="mt-1 text-muted">
+                      Recovery artifact: {run.recoveryArtifact}. Restore with{' '}
+                      <code>tools/controlled-live-harness/runner.mjs</code> before the next drill.
+                    </p>
+                  )}
+                  {run.runnerMessage && <p className="mt-1 text-muted">{run.runnerMessage}</p>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/routes/portfolio.tsx
+++ b/apps/web/app/routes/portfolio.tsx
@@ -5,6 +5,7 @@ import { AuditLogPanel } from '../components/AuditLogPanel.js';
 import { AuthPending } from '../components/AuthPending.js';
 import { BuiltInViewsPanel } from '../components/BuiltInViewsPanel.js';
 import { FleetReportsPanel } from '../components/FleetReportsPanel.js';
+import { LiveDrillsPanel } from '../components/LiveDrillsPanel.js';
 import { MonitoredDomainsPanel } from '../components/MonitoredDomainsPanel.js';
 import { PortfolioSearchPanel } from '../components/PortfolioSearchPanel.js';
 import { SavedFiltersPanel } from '../components/SavedFiltersPanel.js';
@@ -72,6 +73,7 @@ function PortfolioWorkspace() {
 
       <MonitoredDomainsPanel />
       <AlertsPanel />
+      <LiveDrillsPanel />
       <SharedReportsPanel />
       <FleetReportsPanel />
       <TemplateOverridesPanel />

--- a/apps/web/e2e/portfolio-expiry.spec.ts
+++ b/apps/web/e2e/portfolio-expiry.spec.ts
@@ -1,0 +1,164 @@
+import { expect, type Page, test } from '@playwright/test';
+
+/**
+ * Issue #60 e2e: expiry column, expiry window selector, and saved-filter
+ * round-trip on the Portfolio Search panel.
+ */
+
+const OBSERVED_EXPIRY_ISO = '2026-12-15T00:00:00.000Z';
+
+function portfolioDomains() {
+  return [
+    {
+      id: 'domain-expiring',
+      name: 'expiring.example.test',
+      normalizedName: 'expiring.example.test',
+      zoneManagement: 'managed',
+      findings: [],
+      findingsEvaluated: true,
+      evaluationCoverage: { state: 'COMPLETE', errors: [] },
+      latestSnapshot: {
+        id: 'snap-1',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        resultState: 'complete',
+        rulesetVersionId: 'ruleset-v1',
+      },
+      expiration: {
+        status: 'OBSERVED',
+        expirationDate: OBSERVED_EXPIRY_ISO,
+        observedAt: '2026-08-01T00:00:00.000Z',
+        bucket: 'WITHIN_90',
+      },
+    },
+    {
+      id: 'domain-unknown',
+      name: 'unknown-expiry.example.test',
+      normalizedName: 'unknown-expiry.example.test',
+      zoneManagement: 'managed',
+      findings: [],
+      findingsEvaluated: true,
+      evaluationCoverage: { state: 'COMPLETE', errors: [] },
+      latestSnapshot: {
+        id: 'snap-2',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        resultState: 'complete',
+        rulesetVersionId: 'ruleset-v1',
+      },
+      expiration: { status: 'UNKNOWN' },
+    },
+  ];
+}
+
+async function mockPortfolioWorkspace(page: Page): Promise<void> {
+  await page.route('**/api/portfolio/tags', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ tags: [] }) })
+  );
+  await page.route('**/api/portfolio/search', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ domains: portfolioDomains() }),
+    })
+  );
+  await page.route('**/api/portfolio/filters', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ filters: [] }) })
+  );
+  await page.route('**/api/monitoring/domains', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ monitoredDomains: [] }),
+    })
+  );
+  await page.route('**/api/portfolio/audit?*', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ events: [] }) })
+  );
+  await page.route('**/api/alerts**', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        alerts: [],
+        pagination: { total: 0, offset: 0, hasMore: false },
+      }),
+    })
+  );
+}
+
+test.describe('Portfolio expiry radar', () => {
+  test('renders the Expiry column with the bucket or literal UNKNOWN', async ({ page }) => {
+    await mockPortfolioWorkspace(page);
+    await page.goto('/portfolio');
+
+    await expect(page.getByRole('heading', { name: /portfolio workflows/i })).toBeVisible();
+
+    const table = page.getByRole('table', { name: 'Portfolio search results by domain' });
+    await expect(table).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Expiry' })).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Domain' })).toBeVisible();
+
+    const expiringRow = table.getByRole('row', { name: /expiring\.example\.test/ });
+    await expect(expiringRow.getByText('WITHIN_90')).toBeVisible();
+
+    const unknownRow = table.getByRole('row', { name: /unknown-expiry\.example\.test/ });
+    await expect(unknownRow.getByRole('cell', { name: 'UNKNOWN', exact: true })).toBeVisible();
+  });
+
+  test('sends expirationWithinDays when an expiry window is selected', async ({ page }) => {
+    await mockPortfolioWorkspace(page);
+    await page.goto('/portfolio');
+
+    const expiryWindow = page.getByLabel('Expiry window');
+    await expect(expiryWindow).toBeVisible();
+    await expect(expiryWindow).toHaveValue('');
+    await expect(
+      page.getByRole('table', { name: 'Portfolio search results by domain' })
+    ).toBeVisible();
+
+    const request = page.waitForRequest(
+      (candidate) =>
+        candidate.url().endsWith('/api/portfolio/search') &&
+        candidate.method() === 'POST' &&
+        (candidate.postDataJSON() as Record<string, unknown>).expirationWithinDays === 90
+    );
+    await expiryWindow.selectOption('90');
+    const captured = await request;
+    expect(captured).toBeDefined();
+    await expect(expiryWindow).toHaveValue('90');
+  });
+
+  test('loads a saved 90-day expiry filter and searches with it', async ({ page }) => {
+    await mockPortfolioWorkspace(page);
+    await page.route('**/api/portfolio/filters', (route) =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          filters: [
+            {
+              id: 'filter-expiring-90',
+              name: 'Expiring within 90 days',
+              description: 'Saved expiry radar filter',
+              criteria: { expirationWithinDays: 90 },
+              isShared: false,
+              createdBy: 'e2e-bot',
+              createdAt: '2026-08-01T00:00:00.000Z',
+              updatedAt: '2026-08-01T00:00:00.000Z',
+              canManage: true,
+            },
+          ],
+        }),
+      })
+    );
+
+    await page.goto('/portfolio');
+
+    await expect(page.getByText('Expiring within 90 days')).toBeVisible();
+
+    const request = page.waitForRequest(
+      (candidate) =>
+        candidate.url().endsWith('/api/portfolio/search') &&
+        candidate.method() === 'POST' &&
+        (candidate.postDataJSON() as Record<string, unknown>).expirationWithinDays === 90
+    );
+    await page.getByRole('button', { name: 'Load filter' }).click();
+    await request;
+    await expect(page.getByLabel('Expiry window')).toHaveValue('90');
+  });
+});

--- a/apps/web/e2e/portfolio-signal-room.spec.ts
+++ b/apps/web/e2e/portfolio-signal-room.spec.ts
@@ -84,7 +84,7 @@ test.describe('Portfolio Signal Room', () => {
 
     const workspace = page.locator('.portfolio-workspace');
     await expect(workspace).toBeVisible();
-    await expect(workspace.locator('.portfolio-panel')).toHaveCount(9);
+    await expect(workspace.locator('.portfolio-panel')).toHaveCount(10);
     await expect(page.getByRole('heading', { name: 'Portfolio workflows' })).toBeVisible();
     await expect(
       page.getByRole('heading', { name: 'Portfolio Search' }).locator('xpath=../..')
@@ -114,7 +114,7 @@ test.describe('Portfolio Signal Room', () => {
   test('keeps the complete workspace within the viewport at supported widths', async ({ page }) => {
     await mockPortfolioWorkspace(page);
     await page.goto('/portfolio');
-    await expect(page.locator('.portfolio-panel')).toHaveCount(9);
+    await expect(page.locator('.portfolio-panel')).toHaveCount(10);
 
     for (const width of [320, 375, 414, 768]) {
       await page.setViewportSize({ width, height: 900 });

--- a/apps/web/e2e/portfolio-signal-room.spec.ts
+++ b/apps/web/e2e/portfolio-signal-room.spec.ts
@@ -28,6 +28,7 @@ async function mockPortfolioWorkspace(page: import('@playwright/test').Page): Pr
               ],
             },
             latestSnapshot: null,
+            expiration: { status: 'UNKNOWN' },
           },
         ],
       }),

--- a/apps/web/e2e/portfolio-signal-room.spec.ts
+++ b/apps/web/e2e/portfolio-signal-room.spec.ts
@@ -91,7 +91,10 @@ test.describe('Portfolio Signal Room', () => {
       page.getByRole('heading', { name: 'Portfolio Search' }).locator('xpath=../..')
     ).toHaveClass(/ds-panel/);
     await expect(page.getByPlaceholder('example.com').first()).toHaveClass(/ds-input/);
-    await expect(page.getByText('Needs setup/evidence.')).toHaveClass(/ds-badge--unknown/);
+    const searchPanel = page
+      .getByRole('heading', { name: 'Portfolio Search' })
+      .locator('xpath=../..');
+    await expect(searchPanel.getByText('Needs setup/evidence.')).toHaveClass(/ds-badge--unknown/);
     const alertsPanel = page
       .locator('.portfolio-panel')
       .filter({ has: page.getByRole('heading', { name: 'Alerts', exact: true }) });

--- a/apps/web/hono/routes/auth-policy-matrix.test.ts
+++ b/apps/web/hono/routes/auth-policy-matrix.test.ts
@@ -379,6 +379,31 @@ export const AUTH_POLICY_MATRIX: RoutePolicy[] = [
   // Alerts read (tenant-scoped)
   { path: '/api/alerts', method: 'GET', policy: 'auth-read', notes: 'Uses tenant isolation' },
   { path: '/api/alerts/:id', method: 'GET', policy: 'auth-read', notes: 'Uses tenant isolation' },
+  // Live drills (issue #62): fail-closed harness starts with two-person confirm
+  {
+    path: '/api/portfolio/drills',
+    method: 'GET',
+    policy: 'auth-read',
+    notes: 'Allowlisted drill tuples and tenant run history',
+  },
+  {
+    path: '/api/portfolio/drills',
+    method: 'POST',
+    policy: 'auth-write',
+    notes: 'Request a drill start (first operator)',
+  },
+  {
+    path: '/api/portfolio/drills/:id/confirm',
+    method: 'POST',
+    policy: 'auth-write',
+    notes: 'Second-operator confirm; must differ from requester',
+  },
+  {
+    path: '/api/portfolio/drills/:id/start',
+    method: 'POST',
+    policy: 'auth-write',
+    notes: 'Start the fail-closed harness after confirmation',
+  },
   {
     path: '/api/alerts/reports',
     method: 'GET',

--- a/apps/web/hono/routes/drills.test.ts
+++ b/apps/web/hono/routes/drills.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Live Drill Routes Tests - Issue #62
+ *
+ * Route-level coverage for the two-person-confirmed drill starts:
+ * - Only manifest-allowlisted LIVE-01–03 tuples can be requested; the record
+ *   name always comes from the manifest, never from the request.
+ * - A second, distinct operator must confirm before start; same-actor confirm
+ *   is rejected.
+ * - Start only runs the exact fail-closed runner argv built from the manifest
+ *   scenario, and non-zero runner exits mark the run failed (fail-closed).
+ * - A missing harness or manifest makes every start fail closed.
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import type { Env } from '../types.js';
+import {
+  createDrillRoutes,
+  type DrillRunStore,
+  OPEN_RUN_STATUSES,
+  parseDrillManifest,
+  planDrillStart,
+  type RunnerOutcome,
+  type SpawnRunner,
+} from './drills.js';
+
+const TENANT_A = '11111111-1111-4111-8111-111111111111';
+const TENANT_B = '22222222-2222-4222-8222-222222222222';
+
+const MANIFEST = {
+  manifestId: 'TEST-CONTROLLED-LIVE',
+  zone: 'asorin.ai',
+  zoneId: 'zone-id',
+  provider: 'cloudflare',
+  providerCredentialFingerprint: 'sha256:f'.padEnd(71, '0'),
+  allowlist: [
+    { name: 'www.asorin.ai', types: ['CNAME'], mutationIds: ['LIVE-01'] },
+    { name: 'asorin.ai', types: ['CNAME'], mutationIds: ['LIVE-02'] },
+    { name: 'mail.asorin.ai', types: ['TXT'], mutationIds: ['LIVE-03'] },
+  ],
+  scenarios: {
+    'LIVE-01': { host: 'www.asorin.ai', expectedSignal: 'REDIRECT_TOPOLOGY_REGRESSION' },
+    'LIVE-02': { host: 'asorin.ai', expectedSignal: 'HOMEPAGE_INDEXABILITY_REGRESSION' },
+    'LIVE-03': { host: 'mail.asorin.ai', expectedSignal: 'MAIL_DNS_CONFIGURATION_REGRESSION' },
+  },
+};
+
+type StoreRun = {
+  id: string;
+  mutationId: string;
+  recordName: string;
+  status: string;
+  requesterActor: string;
+  confirmerActor: string | null;
+  recoveryArtifact: string | null;
+  runnerMessage: string | null;
+  tenantId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/** In-memory store mirroring the drill_run_open_unique partial unique index. */
+function createMemoryStore(): DrillRunStore & { rows: StoreRun[] } {
+  const rows: StoreRun[] = [];
+  let nextId = 1;
+  return {
+    rows,
+    async list(tenantId) {
+      return rows
+        .filter((row) => row.tenantId === tenantId)
+        .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())
+        .slice(0, 20);
+    },
+    async insert(data) {
+      if (rows.some((row) => (OPEN_RUN_STATUSES as readonly string[]).includes(row.status))) {
+        throw Object.assign(new Error('duplicate open drill'), { code: '23505' });
+      }
+      const now = new Date();
+      const row: StoreRun = {
+        id: `run-${nextId}`,
+        mutationId: String(data.mutationId),
+        recordName: String(data.recordName),
+        status: 'requested',
+        requesterActor: String(data.requesterActor),
+        confirmerActor: null,
+        recoveryArtifact: null,
+        runnerMessage: null,
+        tenantId: String(data.tenantId),
+        createdAt: now,
+        updatedAt: now,
+      };
+      rows.push(row);
+      nextId += 1;
+      return row;
+    },
+    async transition(id, fromStatus, patch) {
+      const row = rows.find((candidate) => candidate.id === id);
+      if (!row || row.status !== fromStatus) return null;
+      Object.assign(row, patch, { updatedAt: new Date() });
+      return row;
+    },
+  };
+}
+
+interface Harness {
+  app: Hono<Env>;
+  store: ReturnType<typeof createMemoryStore>;
+  runnerCalls: Array<{ runnerPath: string; args: string[] }>;
+  setRunnerOutcome: (outcome: RunnerOutcome) => void;
+  setActor: (actorId: string) => void;
+  artifactsDir: string;
+}
+
+function createHarness(tenantId: string, actorId: string): Harness {
+  const dir = mkdtempSync(join(tmpdir(), 'drills-test-'));
+  const manifestPath = join(dir, 'manifest.json');
+  writeFileSync(manifestPath, JSON.stringify(MANIFEST));
+  const runnerPath = join(dir, 'runner.mjs');
+  writeFileSync(runnerPath, '// fail-closed runner stub\n');
+
+  const store = createMemoryStore();
+  const runnerCalls: Array<{ runnerPath: string; args: string[] }> = [];
+  let runnerOutcome: RunnerOutcome = { code: 0, stderrTail: '' };
+  const spawnRunner: SpawnRunner = async (path, args) => {
+    runnerCalls.push({ runnerPath: path, args });
+    return runnerOutcome;
+  };
+  const artifactsDir = join(dir, 'artifacts');
+  let currentActor = actorId;
+
+  const routes = createDrillRoutes({
+    manifestPath,
+    runnerPath,
+    artifactsDir,
+    spawnRunner,
+    store,
+  });
+  const app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    // AuditEventRepository uses the simple-adapter insert; the drill tables
+    // themselves go through the injected in-memory store.
+    c.set('db', {
+      getDrizzle: () => ({}),
+      insert: async (_table: unknown, values: Record<string, unknown>) => ({
+        id: 'audit-1',
+        ...values,
+      }),
+    } as unknown as Env['Variables']['db']);
+    c.set('tenantId', tenantId);
+    c.set('actorId', currentActor);
+    await next();
+  });
+  app.route('/api/drills', routes);
+  return {
+    app,
+    store,
+    runnerCalls,
+    artifactsDir,
+    setRunnerOutcome(outcome) {
+      runnerOutcome = outcome;
+    },
+    setActor(actorId) {
+      currentActor = actorId;
+    },
+  };
+}
+
+async function post(
+  app: Harness['app'],
+  path: string,
+  body?: Record<string, unknown>
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const response = await app.request(path, {
+    method: 'POST',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: response.status, json: (await response.json()) as Record<string, unknown> };
+}
+
+async function settle(store: ReturnType<typeof createMemoryStore>): Promise<StoreRun> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const run = store.rows[0];
+    if (run && ['fault_applied', 'failed'].includes(run.status)) return run;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+  }
+  throw new Error('drill run never settled');
+}
+
+describe('parseDrillManifest', () => {
+  it('extracts the LIVE-01–03 tuples with their pinned record names', () => {
+    const parsed = parseDrillManifest(MANIFEST);
+    expect(parsed.zone).toBe('asorin.ai');
+    expect(parsed.tuples).toHaveLength(3);
+    expect(parsed.tuples.map((tuple) => tuple.name)).toEqual([
+      'www.asorin.ai',
+      'asorin.ai',
+      'mail.asorin.ai',
+    ]);
+  });
+
+  it('fails closed on unknown mutation IDs or missing allowlist', () => {
+    expect(() =>
+      parseDrillManifest({
+        ...MANIFEST,
+        allowlist: [{ name: 'x.asorin.ai', types: ['TXT'], mutationIds: ['LIVE-99'] }],
+      })
+    ).toThrow(/outside LIVE-01–03/);
+    expect(() => parseDrillManifest({ ...MANIFEST, allowlist: [] })).toThrow(/no LIVE-01–03/);
+  });
+});
+
+describe('planDrillStart', () => {
+  it('plans the exact fail-closed runner invocations per scenario', () => {
+    expect(planDrillStart('LIVE-01', '/artifacts')).toEqual([
+      ['fixture-apply', 'LIVE-01', join('/artifacts', 'live-01-recovery.json')],
+    ]);
+    const live03 = planDrillStart('LIVE-03', '/artifacts');
+    expect(live03).toHaveLength(2);
+    expect(live03[0]).toEqual(['bootstrap', join('/artifacts', 'live-03-bootstrap.json')]);
+    expect(live03[1]).toEqual([
+      'apply',
+      join('/artifacts', 'live-03-bootstrap.json'),
+      join('/artifacts', 'live-03-recovery.json'),
+    ]);
+  });
+});
+
+describe('live drill routes', () => {
+  it('lists allowlisted tuples and rejects non-allowlisted mutation requests', async () => {
+    const harness = createHarness(TENANT_A, 'actor-a');
+    const listResponse = await harness.app.request('/api/drills');
+    const list = (await listResponse.json()) as Record<string, unknown>;
+    expect(listResponse.status).toBe(200);
+    expect(list.harness).toMatchObject({ available: true, zone: 'asorin.ai' });
+    expect((list.tuples as unknown[]).length).toBe(3);
+    expect((list.runs as unknown[]).length).toBe(0);
+
+    const rejected = await post(harness.app, '/api/drills', { mutationId: 'LIVE-04' });
+    expect(rejected.status).toBe(400);
+  });
+
+  it('requires a second distinct operator before a start is allowed', async () => {
+    const harness = createHarness(TENANT_A, 'actor-a');
+
+    const created = await post(harness.app, '/api/drills', { mutationId: 'LIVE-01' });
+    expect(created.status).toBe(201);
+    const runId = (created.json.run as { id: string }).id;
+
+    const selfConfirm = await post(harness.app, `/api/drills/${runId}/confirm`);
+    expect(selfConfirm.status).toBe(403);
+
+    const earlyStart = await post(harness.app, `/api/drills/${runId}/start`);
+    expect(earlyStart.status).toBe(409);
+
+    harness.setActor('actor-b');
+    const confirm = await post(harness.app, `/api/drills/${runId}/confirm`);
+    expect(confirm.status).toBe(200);
+    expect((confirm.json.run as { status: string }).status).toBe('approved');
+    expect((confirm.json.run as { confirmerActor: string }).confirmerActor).toBe('actor-b');
+  });
+
+  it('starts an approved drill with the manifest-pinned argv and records failure fail-closed', async () => {
+    const harness = createHarness(TENANT_A, 'actor-a');
+    const created = await post(harness.app, '/api/drills', { mutationId: 'LIVE-01' });
+    const runId = (created.json.run as { id: string }).id;
+    harness.setActor('actor-b');
+    await post(harness.app, `/api/drills/${runId}/confirm`);
+
+    harness.setRunnerOutcome({ code: 1, stderrTail: 'fixture control token missing' });
+    const started = await post(harness.app, `/api/drills/${runId}/start`);
+    expect(started.status).toBe(202);
+
+    const settled = await settle(harness.store);
+    expect(settled.status).toBe('failed');
+    expect(settled.runnerMessage).toContain('exited 1');
+    expect(harness.runnerCalls).toHaveLength(1);
+    expect(harness.runnerCalls[0].args[0]).toBe('fixture-apply');
+    expect(harness.runnerCalls[0].args[1]).toBe('LIVE-01');
+    expect(harness.runnerCalls[0].args[2].endsWith('live-01-recovery.json')).toBe(true);
+    // The record name is the manifest pin, never client input.
+    expect(settled.recordName).toBe('www.asorin.ai');
+  });
+
+  it('marks a successful fault phase with the recovery artifact for operator restore', async () => {
+    const harness = createHarness(TENANT_A, 'actor-a');
+    const created = await post(harness.app, '/api/drills', { mutationId: 'LIVE-02' });
+    const runId = (created.json.run as { id: string }).id;
+    harness.setActor('actor-b');
+    await post(harness.app, `/api/drills/${runId}/confirm`);
+    const started = await post(harness.app, `/api/drills/${runId}/start`);
+    expect(started.status).toBe(202);
+
+    const settled = await settle(harness.store);
+    expect(settled.status).toBe('fault_applied');
+    expect(settled.recoveryArtifact?.endsWith('live-02-recovery.json')).toBe(true);
+  });
+
+  it('enforces a single open drill and keeps tenants isolated', async () => {
+    const harnessA = createHarness(TENANT_A, 'actor-a');
+    const created = await post(harnessA.app, '/api/drills', { mutationId: 'LIVE-03' });
+    expect(created.status).toBe(201);
+    const runId = (created.json.run as { id: string }).id;
+    harnessA.setActor('actor-b');
+    await post(harnessA.app, `/api/drills/${runId}/confirm`);
+
+    const duplicate = await post(harnessA.app, '/api/drills', { mutationId: 'LIVE-01' });
+    expect(duplicate.status).toBe(409);
+
+    // Another tenant can neither confirm nor start tenant A's run.
+    const harnessB = createHarness(TENANT_B, 'actor-b');
+    const foreignConfirm = await post(harnessB.app, `/api/drills/${runId}/confirm`);
+    expect(foreignConfirm.status).toBe(404);
+    const foreignStart = await post(harnessB.app, `/api/drills/${runId}/start`);
+    expect(foreignStart.status).toBe(404);
+  });
+
+  it('fails closed when the harness or manifest is unavailable', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'drills-test-'));
+    const store = createMemoryStore();
+    const routes = createDrillRoutes({
+      manifestPath: join(dir, 'missing-manifest.json'),
+      runnerPath: join(dir, 'missing-runner.mjs'),
+      artifactsDir: join(dir, 'artifacts'),
+      spawnRunner: async () => ({ code: 0, stderrTail: '' }),
+      store,
+    });
+    const app = new Hono<Env>();
+    app.use('*', async (c, next) => {
+      c.set('db', {
+        getDrizzle: () => ({}),
+        insert: async (_table: unknown, values: Record<string, unknown>) => ({
+          id: 'audit-1',
+          ...values,
+        }),
+      } as unknown as Env['Variables']['db']);
+      c.set('tenantId', TENANT_A);
+      c.set('actorId', 'actor-a');
+      await next();
+    });
+    app.route('/api/drills', routes);
+
+    const list = await app.request('/api/drills');
+    const listJson = (await list.json()) as Record<string, unknown>;
+    expect(listJson.harness).toMatchObject({ available: false });
+    expect(listJson.tuples).toEqual([]);
+
+    const requested = await post(app, '/api/drills', { mutationId: 'LIVE-01' });
+    expect(requested.status).toBe(409);
+  });
+});

--- a/apps/web/hono/routes/drills.ts
+++ b/apps/web/hono/routes/drills.ts
@@ -1,0 +1,435 @@
+/**
+ * Live Drill Routes - Issue #62
+ *
+ * Two-person-confirmed starts of the fail-closed controlled-live harness
+ * (tools/controlled-live-harness/runner.mjs) for the asorin.ai tuples pinned
+ * in the checked-in mutation manifest. Non-allowlisted domains stay
+ * observation-only: the record name always comes from the manifest, never
+ * from the request. This module never touches provider or fixture secrets —
+ * the runner resolves its own runtime credentials and revalidates the
+ * manifest allowlist before every operation, so any missing secret or
+ * unauthorized tuple fails closed inside the harness.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CONTROLLED_FAULT_RECORD_TYPES,
+  LIVE_FAULT_MUTATION_IDS,
+  type LiveFaultMutationId,
+} from '@dns-ops/contracts';
+import { AuditEventRepository, type DrillRun, type NewDrillRun } from '@dns-ops/db';
+import { drillRuns } from '@dns-ops/db/schema';
+import { and, desc, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { requireAuth, requireWritePermission } from '../middleware/authorization.js';
+import { enumValue, validateBody, validationErrorResponse } from '../middleware/validation.js';
+import type { Env } from '../types.js';
+
+/** Statuses that hold the single open-drill slot (mirrors drill_run_open_unique). */
+export const OPEN_RUN_STATUSES = ['requested', 'approved', 'started'] as const;
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/** A manifest-approved drill tuple narrowed to the LIVE mutation IDs. */
+export interface DrillTuple {
+  name: string;
+  types: string[];
+  mutationIds: LiveFaultMutationId[];
+}
+
+export interface ParsedDrillManifest {
+  manifestId: string;
+  zone: string;
+  tuples: DrillTuple[];
+  scenarios: Record<string, { host: string; expectedSignal: string }>;
+}
+
+/**
+ * Parses the checked-in mutation manifest into the drill tuples an operator
+ * may start. Fails closed: unknown mutation IDs, record types outside the
+ * contracts allowlist, or duplicate LIVE coverage abort the parse.
+ */
+export function parseDrillManifest(raw: unknown): ParsedDrillManifest {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('live drill manifest must be a JSON object');
+  }
+  const manifest = raw as Record<string, unknown>;
+  const manifestId = typeof manifest.manifestId === 'string' ? manifest.manifestId : '';
+  const zone = typeof manifest.zone === 'string' ? manifest.zone : '';
+  if (!manifestId || !zone) {
+    throw new Error('live drill manifest is missing manifestId or zone');
+  }
+  if (!Array.isArray(manifest.allowlist)) {
+    throw new Error('live drill manifest is missing its allowlist');
+  }
+
+  const tuples: DrillTuple[] = [];
+  for (const entry of manifest.allowlist) {
+    if (typeof entry !== 'object' || entry === null) {
+      throw new Error('live drill allowlist entries must be objects');
+    }
+    const record = entry as Record<string, unknown>;
+    const name = typeof record.name === 'string' ? record.name : '';
+    const types = Array.isArray(record.types) ? record.types : [];
+    const mutationIds = Array.isArray(record.mutationIds) ? record.mutationIds : [];
+    if (!name || types.length === 0 || mutationIds.length === 0) {
+      throw new Error('live drill allowlist entries must pin name, types, and mutationIds');
+    }
+    for (const type of types) {
+      if (!CONTROLLED_FAULT_RECORD_TYPES.includes(type as never)) {
+        throw new Error(`live drill allowlist record type is not permitted: ${String(type)}`);
+      }
+    }
+    const liveIds = mutationIds.filter((id): id is LiveFaultMutationId =>
+      (LIVE_FAULT_MUTATION_IDS as readonly string[]).includes(id as string)
+    );
+    if (liveIds.length !== mutationIds.length) {
+      throw new Error(`live drill allowlist entry has a mutation ID outside LIVE-01–03: ${name}`);
+    }
+    if (liveIds.length > 0) {
+      tuples.push({ name, types: [...types], mutationIds: liveIds });
+    }
+  }
+  if (tuples.length === 0) {
+    throw new Error('live drill manifest has no LIVE-01–03 allowlist entries');
+  }
+
+  const scenarios: ParsedDrillManifest['scenarios'] = {};
+  const rawScenarios =
+    typeof manifest.scenarios === 'object' && manifest.scenarios !== null
+      ? (manifest.scenarios as Record<string, unknown>)
+      : {};
+  for (const id of LIVE_FAULT_MUTATION_IDS) {
+    const scenario = rawScenarios[id];
+    if (typeof scenario !== 'object' || scenario === null) continue;
+    const record = scenario as Record<string, unknown>;
+    scenarios[id] = {
+      host: typeof record.host === 'string' ? record.host : '',
+      expectedSignal: typeof record.expectedSignal === 'string' ? record.expectedSignal : '',
+    };
+  }
+
+  return { manifestId, zone, tuples, scenarios };
+}
+
+function readParsedManifest(manifestPath: string): ParsedDrillManifest | null {
+  try {
+    return parseDrillManifest(JSON.parse(readFileSync(manifestPath, 'utf8')));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Exact fail-closed runner invocations for the fault phase of one scenario.
+ * Restore stays an explicit operator action using the recorded recovery
+ * artifact; the harness remains the only mutation path.
+ */
+export function planDrillStart(mutationId: LiveFaultMutationId, artifactsDir: string): string[][] {
+  switch (mutationId) {
+    case 'LIVE-01':
+      return [['fixture-apply', 'LIVE-01', join(artifactsDir, 'live-01-recovery.json')]];
+    case 'LIVE-02':
+      return [['fixture-apply', 'LIVE-02', join(artifactsDir, 'live-02-recovery.json')]];
+    case 'LIVE-03':
+      return [
+        ['bootstrap', join(artifactsDir, 'live-03-bootstrap.json')],
+        [
+          'apply',
+          join(artifactsDir, 'live-03-bootstrap.json'),
+          join(artifactsDir, 'live-03-recovery.json'),
+        ],
+      ];
+  }
+}
+
+export type RunnerOutcome = { code: number; stderrTail: string };
+
+export type SpawnRunner = (runnerPath: string, args: string[]) => Promise<RunnerOutcome>;
+
+function defaultSpawnRunner(runnerPath: string, args: string[]): Promise<RunnerOutcome> {
+  return new Promise((resolvePromise) => {
+    // Arguments are a fixed array built from the manifest — no shell, no user
+    // input in argv, and the runner reads its own secrets from its own files.
+    const child = spawn(process.execPath, [runnerPath, ...args], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (stderr.length > 4096) stderr = stderr.slice(-4096);
+    });
+    child.on('error', (error) => resolvePromise({ code: -1, stderrTail: error.message }));
+    child.on('close', (code) =>
+      resolvePromise({ code: code ?? -1, stderrTail: stderr.slice(-1024) })
+    );
+  });
+}
+
+/**
+ * Persistence for drill runs. The production store uses Drizzle; tests inject
+ * an in-memory store with the same open-run uniqueness as the partial unique
+ * index `drill_run_open_unique`.
+ */
+export interface DrillRunStore {
+  list(tenantId: string): Promise<DrillRun[]>;
+  insert(data: NewDrillRun): Promise<DrillRun>;
+  /** Applies patch only when the run is currently in fromStatus. */
+  transition(id: string, fromStatus: string, patch: Partial<NewDrillRun>): Promise<DrillRun | null>;
+}
+
+function createDrizzleRunStore(db: Env['Variables']['db']): DrillRunStore {
+  type DrillDrizzle = {
+    query: {
+      drillRuns: {
+        findMany(args: { where?: unknown; orderBy?: unknown; limit?: number }): Promise<DrillRun[]>;
+      };
+    };
+    insert(table: unknown): {
+      values(data: NewDrillRun): { returning(): Promise<DrillRun[]> };
+    };
+    update(table: unknown): {
+      set(patch: Record<string, unknown>): {
+        where(condition: unknown): { returning(): Promise<DrillRun[]> };
+      };
+    };
+  };
+  // The env database is the Postgres drizzle client at runtime; the union with
+  // the legacy D1 client makes writes uncallable without this narrow cast
+  // (same pattern as hono/routes/signup.ts AuthDrizzle).
+  const drizzle = db.getDrizzle() as unknown as DrillDrizzle;
+  return {
+    async list(tenantId) {
+      return drizzle.query.drillRuns.findMany({
+        where: eq(drillRuns.tenantId, tenantId),
+        orderBy: [desc(drillRuns.createdAt)],
+        limit: 20,
+      });
+    },
+    async insert(data) {
+      const [row] = await drizzle.insert(drillRuns).values(data).returning();
+      return row;
+    },
+    async transition(id, fromStatus, patch) {
+      const [row] = await drizzle
+        .update(drillRuns)
+        .set({ ...patch, updatedAt: new Date() })
+        .where(and(eq(drillRuns.id, id), eq(drillRuns.status, fromStatus)))
+        .returning();
+      return row ?? null;
+    },
+  };
+}
+
+export interface DrillRouteOptions {
+  manifestPath?: string;
+  runnerPath?: string;
+  artifactsDir?: string;
+  spawnRunner?: SpawnRunner;
+  store?: DrillRunStore;
+}
+
+export function createDrillRoutes(options: DrillRouteOptions = {}) {
+  const manifestPath =
+    options.manifestPath ??
+    process.env.DNSOPS_LIVE_MANIFEST_PATH ??
+    join(repoRoot, 'docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json');
+  const runnerPath =
+    options.runnerPath ?? join(repoRoot, 'tools/controlled-live-harness/runner.mjs');
+  const artifactsDir =
+    options.artifactsDir ?? process.env.DNSOPS_DRILL_ARTIFACT_DIR ?? join(repoRoot, '.live-drills');
+  const execRunner = options.spawnRunner ?? defaultSpawnRunner;
+
+  const routes = new Hono<Env>();
+
+  routes.use('*', requireAuth);
+
+  routes.get('/', async (c) => {
+    const db = c.get('db');
+    const tenantId = c.get('tenantId');
+    if (!db || !tenantId) {
+      return c.json({ error: 'Database unavailable' }, 503);
+    }
+
+    const manifest = readParsedManifest(manifestPath);
+    const runs = manifest ? await (options.store ?? createDrizzleRunStore(db)).list(tenantId) : [];
+    return c.json({
+      harness: {
+        available: manifest !== null && existsSync(runnerPath),
+        manifestId: manifest?.manifestId ?? null,
+        zone: manifest?.zone ?? null,
+      },
+      tuples: manifest?.tuples ?? [],
+      scenarios: manifest?.scenarios ?? {},
+      runs,
+    });
+  });
+
+  routes.post('/', requireWritePermission, async (c) => {
+    const db = c.get('db');
+    const tenantId = c.get('tenantId');
+    const actorId = c.get('actorId');
+    if (!db || !tenantId || !actorId) {
+      return c.json({ error: 'Database unavailable' }, 503);
+    }
+
+    const validation = await validateBody(c, {
+      mutationId: enumValue('mutationId', LIVE_FAULT_MUTATION_IDS),
+    });
+    if (!validation.success) {
+      return validationErrorResponse(c, validation.error);
+    }
+    const mutationId = validation.data.mutationId;
+    if (mutationId === undefined) {
+      return c.json({ error: 'mutationId is required' }, 400);
+    }
+
+    const manifest = readParsedManifest(manifestPath);
+    if (!manifest || !existsSync(runnerPath)) {
+      return c.json({ error: 'Live drill harness is not available in this deployment' }, 409);
+    }
+    const tuple = manifest.tuples.find((entry) => entry.mutationIds.includes(mutationId));
+    if (!tuple) {
+      // Not on the allowlist: the requested mutation has no pinned record.
+      return c.json({ error: 'Mutation is not allowlisted for this zone' }, 403);
+    }
+
+    const store = options.store ?? createDrizzleRunStore(db);
+    try {
+      const run = await store.insert({
+        mutationId,
+        recordName: tuple.name,
+        status: 'requested',
+        requesterActor: actorId,
+        tenantId,
+      });
+      await new AuditEventRepository(db).create({
+        action: 'live_drill_requested',
+        entityType: 'drill_run',
+        entityId: run.id,
+        newValue: { mutationId, recordName: tuple.name },
+        actorId,
+        tenantId,
+      });
+      return c.json({ run }, 201);
+    } catch (error) {
+      if ((error as { code?: string }).code === '23505') {
+        return c.json({ error: 'Another drill is already open' }, 409);
+      }
+      throw error;
+    }
+  });
+
+  routes.post('/:id/confirm', requireWritePermission, async (c) => {
+    const db = c.get('db');
+    const tenantId = c.get('tenantId');
+    const actorId = c.get('actorId');
+    if (!db || !tenantId || !actorId) {
+      return c.json({ error: 'Database unavailable' }, 503);
+    }
+
+    const store = options.store ?? createDrizzleRunStore(db);
+    const runs = await store.list(tenantId);
+    const run = runs.find((candidate) => candidate.id === c.req.param('id'));
+    if (!run) {
+      return c.json({ error: 'Drill run not found' }, 404);
+    }
+    if (run.requesterActor === actorId) {
+      return c.json({ error: 'A second operator must confirm the drill' }, 403);
+    }
+    const confirmed = await store.transition(run.id, 'requested', {
+      status: 'approved',
+      confirmerActor: actorId,
+    });
+    if (!confirmed) {
+      return c.json({ error: 'Drill run is not awaiting confirmation' }, 409);
+    }
+    await new AuditEventRepository(db).create({
+      action: 'live_drill_confirmed',
+      entityType: 'drill_run',
+      entityId: run.id,
+      newValue: { confirmerActor: actorId },
+      actorId,
+      tenantId,
+    });
+    return c.json({ run: confirmed });
+  });
+
+  routes.post('/:id/start', requireWritePermission, async (c) => {
+    const db = c.get('db');
+    const tenantId = c.get('tenantId');
+    const actorId = c.get('actorId');
+    if (!db || !tenantId || !actorId) {
+      return c.json({ error: 'Database unavailable' }, 503);
+    }
+    if (!existsSync(runnerPath) || !readParsedManifest(manifestPath)) {
+      return c.json({ error: 'Live drill harness is not available in this deployment' }, 409);
+    }
+
+    const store = options.store ?? createDrizzleRunStore(db);
+    const runs = await store.list(tenantId);
+    const run = runs.find((candidate) => candidate.id === c.req.param('id'));
+    if (!run) {
+      return c.json({ error: 'Drill run not found' }, 404);
+    }
+    if (!(LIVE_FAULT_MUTATION_IDS as readonly string[]).includes(run.mutationId)) {
+      return c.json({ error: 'Mutation is not allowlisted for this zone' }, 403);
+    }
+    // Conditional transition doubles as the concurrency guard: exactly one
+    // start wins even if two operators click simultaneously.
+    const started = await store.transition(run.id, 'approved', { status: 'started' });
+    if (!started) {
+      return c.json({ error: 'Drill run is not approved for start' }, 409);
+    }
+    await new AuditEventRepository(db).create({
+      action: 'live_drill_started',
+      entityType: 'drill_run',
+      entityId: run.id,
+      newValue: { startedBy: actorId },
+      actorId,
+      tenantId,
+    });
+
+    const steps = planDrillStart(run.mutationId as LiveFaultMutationId, artifactsDir);
+    mkdirSync(artifactsDir, { recursive: true });
+    void (async () => {
+      let recoveryArtifact: string | null = null;
+      for (const args of steps) {
+        const outcome = await execRunner(runnerPath, args);
+        if (outcome.code !== 0) {
+          await store.transition(run.id, 'started', {
+            status: 'failed',
+            runnerMessage: `runner ${args[0]} exited ${outcome.code}: ${outcome.stderrTail}`.slice(
+              0,
+              1024
+            ),
+          });
+          return;
+        }
+        const artifactArg = args.at(-1);
+        if (artifactArg?.endsWith('recovery.json')) recoveryArtifact = artifactArg;
+      }
+      await store.transition(run.id, 'started', {
+        status: 'fault_applied',
+        recoveryArtifact,
+        runnerMessage: 'Fault phase applied; restore required before the next drill',
+      });
+    })().catch(async (error) => {
+      await store.transition(run.id, 'started', {
+        status: 'failed',
+        runnerMessage: `drill execution failed: ${String(error)}`.slice(0, 1024),
+      });
+    });
+
+    return c.json({ run: started }, 202);
+  });
+
+  return routes;
+}
+
+export const drillRoutes = createDrillRoutes();

--- a/apps/web/hono/routes/portfolio.ts
+++ b/apps/web/hono/routes/portfolio.ts
@@ -33,11 +33,16 @@ import {
   validationErrorResponse,
 } from '../middleware/validation.js';
 import type { Env } from '../types.js';
+import { drillRoutes } from './drills.js';
 
 export const portfolioRoutes = new Hono<Env>();
 
 // Apply authentication to all portfolio routes
 portfolioRoutes.use('*', requireAuth);
+
+// Live drills (issue #62): two-person-confirmed starts of the fail-closed
+// controlled-live harness for the allowlisted asorin.ai tuples.
+portfolioRoutes.route('/drills', drillRoutes);
 
 // =============================================================================
 // PORTFOLIO SEARCH

--- a/packages/db/src/migrations/0022_live_drill_runs.sql
+++ b/packages/db/src/migrations/0022_live_drill_runs.sql
@@ -1,0 +1,30 @@
+-- Issue #62: two-person-confirmed starts of the fail-closed controlled-live
+-- harness for the allowlisted asorin.ai tuples. drill_runs is the durable
+-- approval/run trail; a partial unique index enforces a single open drill
+-- (requested/approved/started) at any time so fault phases cannot overlap.
+
+CREATE TABLE IF NOT EXISTS "drill_runs" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "record_name" varchar(253) NOT NULL,
+  "mutation_id" varchar(20) NOT NULL,
+  "status" varchar(20) NOT NULL DEFAULT 'requested',
+  "requester_actor" varchar(100) NOT NULL,
+  "confirmer_actor" varchar(100),
+  "recovery_artifact" text,
+  "runner_message" text,
+  "tenant_id" uuid NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "drill_run_tenant_idx" ON "drill_runs" ("tenant_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "drill_run_mutation_idx" ON "drill_runs" ("mutation_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "drill_run_open_unique" ON "drill_runs" ((1)) WHERE "status" IN ('requested', 'approved', 'started');
+--> statement-breakpoint
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'live_drill_requested';
+--> statement-breakpoint
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'live_drill_confirmed';
+--> statement-breakpoint
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'live_drill_started';

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -625,6 +625,9 @@ export const auditActionEnum = pgEnum('audit_action', [
   'domain_profile_updated',
   'operational_baseline_accepted',
   'mcp_case_disposition_set',
+  'live_drill_requested',
+  'live_drill_confirmed',
+  'live_drill_started',
 ]);
 
 export const auditEvents = pgTable(
@@ -1291,3 +1294,46 @@ export const sessions = pgTable('sessions', {
 
 export type Session = typeof sessions.$inferSelect;
 export type NewSession = typeof sessions.$inferInsert;
+
+// =============================================================================
+// LIVE DRILL RUNS (Issue #62)
+//
+// Durable two-person approval + run trail for starting the fail-closed
+// controlled-live harness against the allowlisted asorin.ai tuples. The
+// harness (tools/controlled-live-harness) remains the only component that may
+// touch the provider; this table only gates and records operator intent.
+// =============================================================================
+
+export const drillRuns = pgTable(
+  'drill_runs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    // Allowlisted scenario: LIVE-01 | LIVE-02 | LIVE-03 with its pinned record
+    recordName: varchar('record_name', { length: 253 }).notNull(),
+    mutationId: varchar('mutation_id', { length: 20 }).notNull(),
+
+    // requested → approved (second operator) → started → fault_applied | failed
+    status: varchar('status', { length: 20 }).notNull().default('requested'),
+
+    // Two-person confirm: confirmer must differ from requester
+    requesterActor: varchar('requester_actor', { length: 100 }).notNull(),
+    confirmerActor: varchar('confirmer_actor', { length: 100 }),
+
+    // Redacted harness outputs (artifact path + fail-closed error summary)
+    recoveryArtifact: text('recovery_artifact'),
+    runnerMessage: text('runner_message'),
+
+    tenantId: uuid('tenant_id').notNull(),
+
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tenantIdx: index('drill_run_tenant_idx').on(table.tenantId),
+    mutationIdx: index('drill_run_mutation_idx').on(table.mutationId),
+  })
+);
+
+export type DrillRun = typeof drillRuns.$inferSelect;
+export type NewDrillRun = typeof drillRuns.$inferInsert;

--- a/verification/receipts/20260903-234759Z-ac43b22-issue62-portfolio-search--domain.overview.md
+++ b/verification/receipts/20260903-234759Z-ac43b22-issue62-portfolio-search--domain.overview.md
@@ -1,0 +1,44 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-234759Z-ac43b22-issue62-portfolio-search
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 1f39ce5cc08dfce4c11b74ca640750cbde055742
+code_digest: 7de3be972652e1cbb2dd7db97a82735958b14daca1e786fdc22432f003cf5646
+dirty: true
+untracked: 0
+status: blocked
+reason: "Domain 360 was not driven in this run; the only mapped-path change is the additive drill_runs table and audit enum values in packages/db/src/schema/index.ts, which do not alter Domain 360 behavior. Verified instead: drills route tests (19 passing), schema migration applied cleanly on Postgres, verify-migrations parity green, and a live portfolio.search drive at this tree."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search
+created_at: 2026-09-03T23:51:07.724Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/console.log | log | aux · unrecognized .log | fb1c5280b2ded51c27990451770a18fece409e5a72096e5e6bbf6df0e68a84d0 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/failed-requests.log | log | aux · unrecognized .log | f6402713f7645cc2822734ae80ff55f3e237097309b38674aad3e11e501ffb0a |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/observations.md | md | aux · unrecognized .md | 90753d8d899ba27cb29a3fd66607c8c869920522d8c6681311b08bb8cc6b3566 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/portfolio-search.png | png | evidence · 1280x5587 | 08c43762553de90390a6484068c49566202c6f3330b1dae7f75cfede4c805778 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/trace.zip | trace | evidence · playwright trace | 6371bf15539509ed4a9ebcbff7c445eef15d19a9081e2ae3a6d106597c3dcf09 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/video/eb84b68ea3e333ae2d5a6119d0ad48cf.webm | video | evidence | e9fa31096d64e6b4f45e719b9e012117fe27f3b9d2851f1d75f3fe54a98c0848 |

--- a/verification/receipts/20260903-234759Z-ac43b22-issue62-portfolio-search--portfolio.search.md
+++ b/verification/receipts/20260903-234759Z-ac43b22-issue62-portfolio-search--portfolio.search.md
@@ -1,0 +1,51 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-234759Z-ac43b22-issue62-portfolio-search
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 1f39ce5cc08dfce4c11b74ca640750cbde055742
+code_digest: 7de3be972652e1cbb2dd7db97a82735958b14daca1e786fdc22432f003cf5646
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search
+created_at: 2026-09-03T23:50:24.132Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` showed **Portfolio workflows**, **Portfolio Search**, **Built-in views**, and the new **Live drills** panel (10 panels in the workspace) → confirmed by the live drive on port 3312.
+- Query accepted `example.com` and completed a real `POST /api/portfolio/search` returning HTTP 200 JSON with `domains` → recorded in `readback/portfolio-search.json`.
+- Built-in **Mail broken**, **Expiring evidence**, and **Incomplete coverage** buttons each issued a real POST with their exact view criteria; active Incomplete coverage exposed `aria-pressed="true"`; re-click cleared its criteria → recorded in `readback/built-in-view-requests.json`.
+- Expiry fixture rendered: observed RDAP `WITHIN_90` bucket and no-evidence `UNKNOWN` in the Expiry column; selecting **Within 90 days** sent `expirationWithinDays: 90` and retained only the observed fixture → recorded in `readback/portfolio-expiry.json`.
+- Live drills read API returned the real manifest surface: `available: true`, manifest `ASORIN-AI-CONTROLLED-LIVE-01-03`, zone `asorin.ai`, five allowlisted tuples; unauthenticated request returned 401 (verified out-of-band via curl before the drive).
+- Browser screenshot, video, and Playwright trace captured; doctor-equivalent health check returned HTTP 200 healthy.
+
+## Forbidden (… → confirmed absent)
+- Sign-in warning used as success → absent; local e2e tenant/actor headers returned authenticated seeded results.
+- Class selectors → harness uses semantic roles/labels only.
+- Expiry derived from findings or `DOMAIN_EXPIRING_SOON` → response projection came from RDAP expiration evidence.
+- Non-allowlisted domains offered for drills → tuples come only from the checked-in manifest; drill POST body carries only `mutationId`.
+
+## Read-back
+- `readback/portfolio-search.json`, `readback/built-in-view-requests.json`, and `readback/portfolio-expiry.json` contain real response JSON.
+- `trace.zip`, `portfolio-search.png`, `video/*.webm`, `console.log`, and `failed-requests.log` are present.
+- Ancillary: one transient superseded `POST /api/portfolio/search` abort occurred during the first drive attempt (cleared-view step) and the retried drive completed cleanly; a missing `/_build/assets/client.css` and blocked external font CORS requests in the log did not affect any verified assertion.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/console.log | log | aux · unrecognized .log | fb1c5280b2ded51c27990451770a18fece409e5a72096e5e6bbf6df0e68a84d0 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/failed-requests.log | log | aux · unrecognized .log | f6402713f7645cc2822734ae80ff55f3e237097309b38674aad3e11e501ffb0a |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/observations.md | md | aux · unrecognized .md | 90753d8d899ba27cb29a3fd66607c8c869920522d8c6681311b08bb8cc6b3566 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/portfolio-search.png | png | evidence · 1280x5587 | 08c43762553de90390a6484068c49566202c6f3330b1dae7f75cfede4c805778 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/trace.zip | trace | evidence · playwright trace | 6371bf15539509ed4a9ebcbff7c445eef15d19a9081e2ae3a6d106597c3dcf09 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/video/eb84b68ea3e333ae2d5a6119d0ad48cf.webm | video | evidence | e9fa31096d64e6b4f45e719b9e012117fe27f3b9d2851f1d75f3fe54a98c0848 |

--- a/verification/receipts/20260904-002348Z-39b92eb-fresh--portfolio.search.md
+++ b/verification/receipts/20260904-002348Z-39b92eb-fresh--portfolio.search.md
@@ -1,0 +1,57 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-002348Z-39b92eb-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 39b92ebe76f97f0faab7309c87746266adb89428
+code_digest: 0c7d40a23d0f64163d763851a867425c61890a6efcd01233b84994d2c444099d
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-002348Z-39b92eb-fresh
+created_at: 2026-09-04T00:28:13.951Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` loaded from the exact checkout at HEAD `39b92ebe76f97f0faab7309c87746266adb89428`; headings `Portfolio workflows`, `Portfolio Search`, and `Built-in views` were visible.
+- The labeled `Query` field accepted `example.com`; the resulting valid empty set was accepted by the drive. Independent POST read-back with the same e2e session returned HTTP 200 and 3 tenant domains for `{}`.
+- Browser-driven built-in view requests returned HTTP 200 and carried the expected request bodies: Mail broken `{findingTypePrefix:"mail.",severities:["high","critical"]}`, Expiring evidence `{snapshotOlderThanDays:30}`, Incomplete coverage `{coverage:"incomplete"}`. The active Incomplete coverage button exposed `aria-pressed="true"`; clicking it again sent `{}`.
+- Independent direct POST read-back (`readback/view-result-sets.json`) confirmed server-side result subsets: all/cleared IDs `...001,...002,...003`; Mail broken IDs `...001,...003` with `mail.no-dmarc-record` high on `mailbroken.example` and unevaluated `unevaluated.example` retained; Expiring evidence ID `...002` (`stale.example`); Incomplete coverage ID `...003` (`unevaluated.example`).
+
+## Forbidden (expected → confirmed absent)
+- Unauthenticated POST returned HTTP 401 `{error:"Unauthorized",message:"Authentication required."}`; no sign-in warning was treated as a successful search.
+- A different `X-Dev-Tenant` returned HTTP 200 with `domains:[]`; tenant A domain IDs were not exposed to tenant B.
+- No class selectors or test-only endpoints were used.
+
+## Read-back
+- `readback/adversarial-search.json` records two identical authenticated searches (`status:200`, same three IDs), other-tenant isolation, malformed-input responses, unauthenticated denial, an aborted request, and a successful post-abort request.
+- Malformed `coverage:"unsupported"`, `snapshotOlderThanDays:0`, and a 254-character query returned HTTP 400 with explicit validation errors; no write side effect exists for this read-only search.
+- Repeated request after an immediately aborted request returned HTTP 200 with only the incomplete-coverage domain ID `...003`, showing the service remained usable and no dangling search state.
+- `doctor.txt` records healthy web readiness (`/api/health` HTTP 200, `status:"healthy"`).
+
+## Notes
+- The dev server emitted a non-feature `/_build/assets/client.css` 404 and two superseded browser POSTs were aborted during rapid view toggles; the required requests completed with HTTP 200 and the page rendered/functioned.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-002348Z-39b92eb-fresh/console.log | log | aux · unrecognized .log | a0cab3bf0f0596bc8ea77a62a530e64af97583143d4dd910637770cd11f5eac4 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260904-002348Z-39b92eb-fresh/env.txt | env | aux | 98d2bbe790c116bd247d6e04cdf03df797197755ffba1ee255c55434565c4c21 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/failed-requests.log | log | aux · unrecognized .log | ab8f547fb490fa005c9f1858de97011a35675e186f0a5874eda1b645fbc6db7b |
+| verification/runs/20260904-002348Z-39b92eb-fresh/observations.md | md | aux · unrecognized .md | ea53d8bbc1a40856ebc54feef47f40bdad0e486ac3c424eca7f4852c70862a47 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/portfolio-search.png | png | evidence · 1280x5795 | fe0969ec327a37936dbe2189b11a78966e7bc223e68de9ed8025f3234275854b |
+| verification/runs/20260904-002348Z-39b92eb-fresh/readback/adversarial-search.json | readback | evidence | 0998b4e7ed142965ba4f47a3dec541a3afdef68a8dcc38e83466fb223177ea77 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260904-002348Z-39b92eb-fresh/readback/view-result-sets.json | readback | evidence | c30dfbece9ef36eddf3d36d09191f828366c0e841d09cbd507126b095f2a2120 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/trace.zip | trace | evidence · playwright trace | ac4eec6fd692a01abaae71f1b51052045d934e2cb3b9c5fa899e6cb4933272ee |
+| verification/runs/20260904-002348Z-39b92eb-fresh/video/4d248482624ce1c8a21e3d9eb50974a1.webm | video | evidence | 78a727cb7c73d071fdefb62345dda791e071c032a273721abc3f3ecd5976d3ae |
+| verification/runs/20260904-002348Z-39b92eb-fresh/video/7390f8e6054b44363147c470e7ffe300.webm | video | evidence | 95f8fcd9d53ad22b26b6c712d4b43b99d1f8394eddd55d471646d651c302c599 |

--- a/verification/receipts/20260904-003544Z-aa11034-fresh--portfolio.search.md
+++ b/verification/receipts/20260904-003544Z-aa11034-fresh--portfolio.search.md
@@ -1,0 +1,62 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-003544Z-aa11034-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: aa11034198f5dc0d924ad1aa74daf0a4936b140f
+code_digest: c0856c1cf56ae1049c482cc6e3dd6bacd407b9ae2636a13efb5d4b5c738a5f37
+dirty: false
+untracked: 1
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-003544Z-aa11034-fresh
+created_at: 2026-09-04T00:43:35.219Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` rendered headings `Portfolio workflows`, `Portfolio Search`, and `Built-in views`; screenshot `portfolio-search.png` shows Query and all three buttons.
+- Query `example.com` was accepted and POST `/api/portfolio/search` returned HTTP 200 JSON with `domains: []` (valid empty set).
+- Button-driven POST request bodies were captured in `readback/built-in-view-requests.json`: Mail broken `{severities:["high","critical"],findingTypePrefix:"mail."}`, Expiring evidence `{snapshotOlderThanDays:30}`, Incomplete coverage `{coverage:"incomplete"}`. Incomplete button reported `aria-pressed="true"`; re-click produced `{limit:20,offset:0}` with no view criteria.
+- Direct same-session HTTP read-back requests are in `http/`; all returned HTTP 200. Results: baseline/cleared 3 domains (`mailbroken.example`, `stale.example`, `unevaluated.example`), mail-broken 2 (`mailbroken.example`, `unevaluated.example`), expiring 1 (`stale.example`), incomplete 1 (`unevaluated.example`). `readback/portfolio-direct-audit.json` confirms every filtered result is a baseline subset, mail findings match `mail.`, stale snapshot is >30 days old, incomplete result is unevaluated, and clearing equals baseline.
+
+## Forbidden (expected → confirmed absent)
+- No sign-in warning was shown for the authenticated local e2e session; authenticated search returned real tenant domains.
+- Direct unauthenticated POST returned HTTP 401 `{"error":"Unauthorized","message":"Authentication required."}` (`http/unauth.json`), not a successful search.
+- Alternate tenant header returned HTTP 200 with `domains:[]` (`http/another-tenant.json`), with no cross-tenant domains.
+- Invalid coverage returned HTTP 400 `{"error":"coverage must be \"incomplete\""}` (`http/malformed.response.json`); no write operation occurred.
+- No class selectors were used; harness uses ARIA roles/labels.
+
+## Read-back
+- `http/*.response.json` are direct API responses from the same session headers, independent of rendered results.
+- `readback/portfolio-direct-audit.json` contains concrete subset and criteria checks, all `true`.
+- `trace.zip`, `portfolio-search.png`, `console.log`, and `failed-requests.log` capture the browser drive. One static dev asset request (`/_build/assets/client.css`) returned 404; it did not prevent the flow or API responses. External font requests were not relied upon.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-003544Z-aa11034-fresh/console.log | log | aux · unrecognized .log | a0cab3bf0f0596bc8ea77a62a530e64af97583143d4dd910637770cd11f5eac4 |
+| verification/runs/20260904-003544Z-aa11034-fresh/doctor-no-collector.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260904-003544Z-aa11034-fresh/doctor.txt | txt | aux · unrecognized .txt | 3abc85b8454ea084d025b3bb153b5558678d58b6fcafa54bf8698b7f45e5034b |
+| verification/runs/20260904-003544Z-aa11034-fresh/env.txt | env | aux | 5c83667d37437afb15906dd40dd62d771cfb5c8fcc1c764a237313c6ccce6df7 |
+| verification/runs/20260904-003544Z-aa11034-fresh/failed-requests.log | log | aux · unrecognized .log | ab8f547fb490fa005c9f1858de97011a35675e186f0a5874eda1b645fbc6db7b |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/another-tenant.json | http | evidence | eb77506aacbf32543c4ebfc912fee50c17339a2628611305b479892cf3164774 |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/baseline.json | http | evidence | c7d6884ab83c12ee3991b65894a945fd746c14732304d0ec9ce65213cbe2b50c |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/cleared.json | http | evidence | c7d6884ab83c12ee3991b65894a945fd746c14732304d0ec9ce65213cbe2b50c |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/expiring.json | http | evidence | 44de69bae25af81661d5084c559ff28abe786c2946d461fa89266f2f9982a4bc |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/incomplete.json | http | evidence | f804dbdaa5404687a90afc2ad521fb1542254538fdaafbbef6764c0932fd19c9 |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/mail-broken.json | http | evidence | c23f0efb5a8ea2b114ce1210169a34e63bd14d82f021513f191d39a561d05e66 |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/malformed.json | http | evidence | 6e8275cf9645ac8987032397a2bcb3dac4b144e6edb9bd79b99a902ee1827b22 |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/unauth.json | http | evidence | ca753a0b0289fd814b62750a9051b83812dc5eb9a173fba7ded52b8f9ac30004 |
+| verification/runs/20260904-003544Z-aa11034-fresh/observations.md | md | aux · unrecognized .md | b9335b920cac03bd0a6205df400c280ab6e5844b8d7eebef46c74e3986aff07e |
+| verification/runs/20260904-003544Z-aa11034-fresh/portfolio-search.png | png | evidence · 1280x5795 | 7d9ec52804abfad317c4af37a4eb9e00a45ad4ed989585732cecceb08736fa9c |
+| verification/runs/20260904-003544Z-aa11034-fresh/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260904-003544Z-aa11034-fresh/readback/portfolio-direct-audit.json | readback | evidence | e4299f270221e8f9d17c74878812175fed649fd8fe4c7aa397b8a06bf1b84432 |
+| verification/runs/20260904-003544Z-aa11034-fresh/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260904-003544Z-aa11034-fresh/trace.zip | trace | evidence · playwright trace | f9b0d31609de0212ed40275d16dfcf9609c69a6301bb1b70484a45e156adbea1 |
+| verification/runs/20260904-003544Z-aa11034-fresh/video/4252f4f7b120d7951e845a4c0777976c.webm | video | evidence | 626211b3de0755178d14c6bd49f03c4cff51850b61a1eee2596059500ece00a1 |


### PR DESCRIPTION
Closes #62. Operator confirm UI for starting the fail-closed controlled-live harness (LIVE-01–03) restricted to the allowlisted asorin.ai tuples pinned in the checked-in mutation manifest. Two distinct operators required (request + confirm), single open drill enforced by partial unique index, durable audit trail, record names always manifest-pinned (never client input), no secrets in the repo — the runner resolves its own credentials and revalidates the allowlist fail-closed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two-person-confirmed starts of the fail-closed controlled-live harness so operators can run LIVE-01–03 fault scenarios against allowlisted asorin.ai records from the portfolio (closes #62). Previously the portfolio was observation-only; now a first operator requests a drill and a second, distinct operator must confirm before the harness runs.

**New Features**
- Live Drills panel lists the manifest-pinned tuples and recent run history with request, confirm, and start actions.
- Record names always come from the checked-in mutation manifest, never from the request body.
- A partial unique index enforces a single open drill, and every transition writes an audit event.
- The runner resolves its own credentials and revalidates the allowlist fail-closed, so no secrets are stored in the repo.
- E2E coverage and verification receipts span the expiry column and the new live drill panel.

**Migration**
- Apply `0022_live_drill_runs.sql` to create `drill_runs` and extend the `audit_action` enum with three values.
- Drills stay unavailable until the runner and mutation manifest are provisioned on the deployment.

<sup>Written for commit b1bf8e316c281c37fd70ecc62ff01d9361e71cc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

