### PR TITLE
feat(web): add two-person confirmed live drill starts (#62)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ verification/registry.json
 
 # verify-fresh generated marker; exclude it from working-tree digests.
 /.verify-fresh-worktree
+
+# Live drill harness artifacts (redacted, mode 0600; never commit)
+/.live-drills/

--- a/apps/web/app/components/LiveDrillsPanel.tsx
+++ b/apps/web/app/components/LiveDrillsPanel.tsx
@@ -1,0 +1,237 @@
+/**
+ * Live Drills Panel - Issue #62
+ *
+ * Operator surface for starting the fail-closed controlled-live harness
+ * against the allowlisted asorin.ai tuples. Starts require two distinct
+ * operators (request + confirm); every other domain stays observation-only.
+ * This panel never sees provider or fixture secrets — the harness resolves
+ * its own runtime credentials and fails closed without them.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+interface DrillTuple {
+  name: string;
+  types: string[];
+  mutationIds: string[];
+}
+
+interface DrillRunRow {
+  id: string;
+  mutationId: string;
+  recordName: string;
+  status: string;
+  requesterActor: string;
+  confirmerActor: string | null;
+  recoveryArtifact: string | null;
+  runnerMessage: string | null;
+  createdAt: string;
+}
+
+interface DrillsPayload {
+  harness: { available: boolean; manifestId: string | null; zone: string | null };
+  tuples: DrillTuple[];
+  scenarios: Record<string, { host: string; expectedSignal: string }>;
+  runs: DrillRunRow[];
+}
+
+async function fetchDrills(): Promise<DrillsPayload> {
+  const response = await fetch('/api/portfolio/drills', { credentials: 'include' });
+  if (!response.ok) throw new Error('Failed to load live drills');
+  return (await response.json()) as DrillsPayload;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  requested: 'Awaiting second-operator confirm',
+  approved: 'Confirmed — ready to start',
+  started: 'Harness running',
+  fault_applied: 'Fault applied — restore required',
+  failed: 'Failed (fail-closed)',
+};
+
+export function LiveDrillsPanel() {
+  const queryClient = useQueryClient();
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['live-drills'],
+    queryFn: fetchDrills,
+  });
+
+  const act = useMutation({
+    mutationFn: async ({ path, body }: { path: string; body?: Record<string, unknown> }) => {
+      const response = await fetch(path, {
+        method: 'POST',
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(payload.error || 'Drill action failed');
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      setActionError(null);
+      queryClient.invalidateQueries({ queryKey: ['live-drills'] });
+    },
+    onError: (mutationError) => setActionError((mutationError as Error).message),
+  });
+
+  const tuples = data?.tuples ?? [];
+  const runs = data?.runs ?? [];
+  const openRun = runs.find((run) => ['requested', 'approved', 'started'].includes(run.status));
+  const settledRuns = runs.filter(
+    (run) => !['requested', 'approved', 'started'].includes(run.status)
+  );
+
+  return (
+    <div className="ds-panel portfolio-panel">
+      <div className="border-b border-line px-4 py-3">
+        <h3 className="text-lg font-medium text-ink">Live drills</h3>
+        <p className="text-sm text-muted">
+          Controlled LIVE-01–03 runs through the fail-closed harness. Starting a drill requires a
+          second operator to confirm; only the allowlisted asorin.ai tuples can start. All other
+          domains stay observation-only.
+        </p>
+      </div>
+
+      <div className="space-y-4 p-4">
+        {error && (
+          <div className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
+            Live drills are unavailable right now.
+          </div>
+        )}
+        {isLoading && <div className="py-4 text-center text-muted">Loading live drills...</div>}
+
+        {data && !data.harness.available && (
+          <div className="rounded-lg border border-warning bg-warning-surface p-3 text-sm text-warning">
+            The controlled-live harness is not available in this deployment. Drills can only be
+            started where the harness and its runtime secret files are provisioned.
+          </div>
+        )}
+
+        {actionError && (
+          <div className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
+            {actionError}
+          </div>
+        )}
+
+        {data?.harness.available && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <caption className="sr-only">Allowlisted live drill tuples</caption>
+              <thead>
+                <tr className="border-b border-line text-xs uppercase tracking-wide text-muted">
+                  <th scope="col" className="px-2 py-2 font-medium">
+                    Record
+                  </th>
+                  <th scope="col" className="px-2 py-2 font-medium">
+                    Types
+                  </th>
+                  <th scope="col" className="px-2 py-2 font-medium">
+                    Scenario
+                  </th>
+                  <th scope="col" className="px-2 py-2 font-medium">
+                    Action
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {tuples.map((tuple) =>
+                  tuple.mutationIds.map((mutationId) => {
+                    const scenario = data.scenarios[mutationId];
+                    const busy = openRun !== undefined;
+                    return (
+                      <tr key={`${tuple.name}-${mutationId}`} className="border-b border-line">
+                        <td className="px-2 py-2 font-medium text-ink">{tuple.name}</td>
+                        <td className="px-2 py-2">{tuple.types.join(', ')}</td>
+                        <td className="px-2 py-2">
+                          {mutationId}
+                          {scenario?.host ? ` · ${scenario.host}` : ''}
+                        </td>
+                        <td className="px-2 py-2">
+                          <button
+                            type="button"
+                            disabled={busy || act.isPending}
+                            onClick={() =>
+                              act.mutate({ path: '/api/portfolio/drills', body: { mutationId } })
+                            }
+                            className="ds-button ds-button--secondary ds-button--sm"
+                          >
+                            Request drill
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {openRun && (
+          <div className="rounded-lg border border-brand bg-info-surface p-3 text-sm text-text">
+            <p className="font-medium text-ink">
+              {openRun.mutationId} · {openRun.recordName} —{' '}
+              {STATUS_LABELS[openRun.status] ?? openRun.status}
+            </p>
+            <p className="mt-1 text-muted">
+              Requested by {openRun.requesterActor}
+              {openRun.confirmerActor ? ` · confirmed by ${openRun.confirmerActor}` : ''}
+            </p>
+            <div className="mt-2 flex gap-2">
+              {openRun.status === 'requested' && (
+                <button
+                  type="button"
+                  disabled={act.isPending}
+                  onClick={() =>
+                    act.mutate({ path: `/api/portfolio/drills/${openRun.id}/confirm` })
+                  }
+                  className="ds-button ds-button--primary ds-button--sm"
+                >
+                  Confirm as second operator
+                </button>
+              )}
+              {openRun.status === 'approved' && (
+                <button
+                  type="button"
+                  disabled={act.isPending}
+                  onClick={() => act.mutate({ path: `/api/portfolio/drills/${openRun.id}/start` })}
+                  className="ds-button ds-button--primary ds-button--sm"
+                >
+                  Start harness
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {settledRuns.length > 0 && (
+          <div>
+            <h4 className="mb-2 font-medium text-ink">Recent drill runs</h4>
+            <ul className="space-y-2 text-sm">
+              {settledRuns.slice(0, 5).map((run) => (
+                <li key={run.id} className="rounded-lg border border-line p-3">
+                  <p className="font-medium text-ink">
+                    {run.mutationId} · {run.recordName} — {STATUS_LABELS[run.status] ?? run.status}
+                  </p>
+                  {run.recoveryArtifact && (
+                    <p className="mt-1 text-muted">
+                      Recovery artifact: {run.recoveryArtifact}. Restore with{' '}
+                      <code>tools/controlled-live-harness/runner.mjs</code> before the next drill.
+                    </p>
+                  )}
+                  {run.runnerMessage && <p className="mt-1 text-muted">{run.runnerMessage}</p>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/routes/portfolio.tsx
+++ b/apps/web/app/routes/portfolio.tsx
@@ -6,6 +6,7 @@ import { AuthPending } from '../components/AuthPending.js';
 import { BuiltInViewsPanel } from '../components/BuiltInViewsPanel.js';
 import { FleetReportsPanel } from '../components/FleetReportsPanel.js';
 import { FleetTapePanel } from '../components/FleetTapePanel.js';
+import { LiveDrillsPanel } from '../components/LiveDrillsPanel.js';
 import { MonitoredDomainsPanel } from '../components/MonitoredDomainsPanel.js';
 import { PortfolioSearchPanel } from '../components/PortfolioSearchPanel.js';
 import { SavedFiltersPanel } from '../components/SavedFiltersPanel.js';
@@ -73,6 +74,7 @@ function PortfolioWorkspace() {
 
       <MonitoredDomainsPanel />
       <AlertsPanel />
+      <LiveDrillsPanel />
       <SharedReportsPanel />
       <FleetReportsPanel />
       <FleetTapePanel />

--- a/apps/web/e2e/portfolio-expiry.spec.ts
+++ b/apps/web/e2e/portfolio-expiry.spec.ts
@@ -89,7 +89,7 @@ test.describe('Portfolio expiry radar', () => {
 
     await expect(page.getByRole('heading', { name: /portfolio workflows/i })).toBeVisible();
 
-    const table = page.getByRole('table');
+    const table = page.getByRole('table', { name: 'Portfolio search results by domain' });
     await expect(table).toBeVisible();
     await expect(table.getByRole('columnheader', { name: 'Expiry' })).toBeVisible();
     await expect(table.getByRole('columnheader', { name: 'Domain' })).toBeVisible();
@@ -108,7 +108,9 @@ test.describe('Portfolio expiry radar', () => {
     const expiryWindow = page.getByLabel('Expiry window');
     await expect(expiryWindow).toBeVisible();
     await expect(expiryWindow).toHaveValue('');
-    await expect(page.getByRole('table')).toBeVisible();
+    await expect(
+      page.getByRole('table', { name: 'Portfolio search results by domain' })
+    ).toBeVisible();
 
     const request = page.waitForRequest(
       (candidate) =>

--- a/apps/web/e2e/portfolio-signal-room.spec.ts
+++ b/apps/web/e2e/portfolio-signal-room.spec.ts
@@ -85,7 +85,7 @@ test.describe('Portfolio Signal Room', () => {
 
     const workspace = page.locator('.portfolio-workspace');
     await expect(workspace).toBeVisible();
-    await expect(workspace.locator('.portfolio-panel')).toHaveCount(10);
+    await expect(workspace.locator('.portfolio-panel')).toHaveCount(11);
     await expect(page.getByRole('heading', { name: 'Portfolio workflows' })).toBeVisible();
     await expect(
       page.getByRole('heading', { name: 'Portfolio Search' }).locator('xpath=../..')
@@ -118,7 +118,7 @@ test.describe('Portfolio Signal Room', () => {
   test('keeps the complete workspace within the viewport at supported widths', async ({ page }) => {
     await mockPortfolioWorkspace(page);
     await page.goto('/portfolio');
-    await expect(page.locator('.portfolio-panel')).toHaveCount(10);
+    await expect(page.locator('.portfolio-panel')).toHaveCount(11);
 
     for (const width of [320, 375, 414, 768]) {
       await page.setViewportSize({ width, height: 900 });

--- a/apps/web/e2e/portfolio-signal-room.spec.ts
+++ b/apps/web/e2e/portfolio-signal-room.spec.ts
@@ -91,7 +91,10 @@ test.describe('Portfolio Signal Room', () => {
       page.getByRole('heading', { name: 'Portfolio Search' }).locator('xpath=../..')
     ).toHaveClass(/ds-panel/);
     await expect(page.getByPlaceholder('example.com').first()).toHaveClass(/ds-input/);
-    await expect(page.getByText('Needs setup/evidence.')).toHaveClass(/ds-badge--unknown/);
+    const searchPanel = page
+      .getByRole('heading', { name: 'Portfolio Search' })
+      .locator('xpath=../..');
+    await expect(searchPanel.getByText('Needs setup/evidence.')).toHaveClass(/ds-badge--unknown/);
     const alertsPanel = page
       .locator('.portfolio-panel')
       .filter({ has: page.getByRole('heading', { name: 'Alerts', exact: true }) });

--- a/apps/web/hono/routes/auth-policy-matrix.test.ts
+++ b/apps/web/hono/routes/auth-policy-matrix.test.ts
@@ -381,6 +381,31 @@ export const AUTH_POLICY_MATRIX: RoutePolicy[] = [
   // Alerts read (tenant-scoped)
   { path: '/api/alerts', method: 'GET', policy: 'auth-read', notes: 'Uses tenant isolation' },
   { path: '/api/alerts/:id', method: 'GET', policy: 'auth-read', notes: 'Uses tenant isolation' },
+  // Live drills (issue #62): fail-closed harness starts with two-person confirm
+  {
+    path: '/api/portfolio/drills',
+    method: 'GET',
+    policy: 'auth-read',
+    notes: 'Allowlisted drill tuples and tenant run history',
+  },
+  {
+    path: '/api/portfolio/drills',
+    method: 'POST',
+    policy: 'auth-write',
+    notes: 'Request a drill start (first operator)',
+  },
+  {
+    path: '/api/portfolio/drills/:id/confirm',
+    method: 'POST',
+    policy: 'auth-write',
+    notes: 'Second-operator confirm; must differ from requester',
+  },
+  {
+    path: '/api/portfolio/drills/:id/start',
+    method: 'POST',
+    policy: 'auth-write',
+    notes: 'Start the fail-closed harness after confirmation',
+  },
   {
     path: '/api/alerts/reports',
     method: 'GET',

--- a/apps/web/hono/routes/drills.test.ts
+++ b/apps/web/hono/routes/drills.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Live Drill Routes Tests - Issue #62
+ *
+ * Route-level coverage for the two-person-confirmed drill starts:
+ * - Only manifest-allowlisted LIVE-01–03 tuples can be requested; the record
+ *   name always comes from the manifest, never from the request.
+ * - A second, distinct operator must confirm before start; same-actor confirm
+ *   is rejected.
+ * - Start only runs the exact fail-closed runner argv built from the manifest
+ *   scenario, and non-zero runner exits mark the run failed (fail-closed).
+ * - A missing harness or manifest makes every start fail closed.
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import type { Env } from '../types.js';
+import {
+  createDrillRoutes,
+  type DrillRunStore,
+  OPEN_RUN_STATUSES,
+  parseDrillManifest,
+  planDrillStart,
+  type RunnerOutcome,
+  type SpawnRunner,
+} from './drills.js';
+
+const TENANT_A = '11111111-1111-4111-8111-111111111111';
+const TENANT_B = '22222222-2222-4222-8222-222222222222';
+
+const MANIFEST = {
+  manifestId: 'TEST-CONTROLLED-LIVE',
+  zone: 'asorin.ai',
+  zoneId: 'zone-id',
+  provider: 'cloudflare',
+  providerCredentialFingerprint: 'sha256:f'.padEnd(71, '0'),
+  allowlist: [
+    { name: 'www.asorin.ai', types: ['CNAME'], mutationIds: ['LIVE-01'] },
+    { name: 'asorin.ai', types: ['CNAME'], mutationIds: ['LIVE-02'] },
+    { name: 'mail.asorin.ai', types: ['TXT'], mutationIds: ['LIVE-03'] },
+  ],
+  scenarios: {
+    'LIVE-01': { host: 'www.asorin.ai', expectedSignal: 'REDIRECT_TOPOLOGY_REGRESSION' },
+    'LIVE-02': { host: 'asorin.ai', expectedSignal: 'HOMEPAGE_INDEXABILITY_REGRESSION' },
+    'LIVE-03': { host: 'mail.asorin.ai', expectedSignal: 'MAIL_DNS_CONFIGURATION_REGRESSION' },
+  },
+};
+
+type StoreRun = {
+  id: string;
+  mutationId: string;
+  recordName: string;
+  status: string;
+  requesterActor: string;
+  confirmerActor: string | null;
+  recoveryArtifact: string | null;
+  runnerMessage: string | null;
+  tenantId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/** In-memory store mirroring the drill_run_open_unique partial unique index. */
+function createMemoryStore(): DrillRunStore & { rows: StoreRun[] } {
+  const rows: StoreRun[] = [];
+  let nextId = 1;
+  return {
+    rows,
+    async list(tenantId) {
+      return rows
+        .filter((row) => row.tenantId === tenantId)
+        .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())
+        .slice(0, 20);
+    },
+    async insert(data) {
+      if (rows.some((row) => (OPEN_RUN_STATUSES as readonly string[]).includes(row.status))) {
+        throw Object.assign(new Error('duplicate open drill'), { code: '23505' });
+      }
+      const now = new Date();
+      const row: StoreRun = {
+        id: `run-${nextId}`,
+        mutationId: String(data.mutationId),
+        recordName: String(data.recordName),
+        status: 'requested',
+        requesterActor: String(data.requesterActor),
+        confirmerActor: null,
+        recoveryArtifact: null,
+        runnerMessage: null,
+        tenantId: String(data.tenantId),
+        createdAt: now,
+        updatedAt: now,
+      };
+      rows.push(row);
+      nextId += 1;
+      return row;
+    },
+    async transition(id, fromStatus, patch) {
+      const row = rows.find((candidate) => candidate.id === id);
+      if (!row || row.status !== fromStatus) return null;
+      Object.assign(row, patch, { updatedAt: new Date() });
+      return row;
+    },
+  };
+}
+
+interface Harness {
+  app: Hono<Env>;
+  store: ReturnType<typeof createMemoryStore>;
+  runnerCalls: Array<{ runnerPath: string; args: string[] }>;
+  setRunnerOutcome: (outcome: RunnerOutcome) => void;
+  setActor: (actorId: string) => void;
+  artifactsDir: string;
+}
+
+function createHarness(tenantId: string, actorId: string): Harness {
+  const dir = mkdtempSync(join(tmpdir(), 'drills-test-'));
+  const manifestPath = join(dir, 'manifest.json');
+  writeFileSync(manifestPath, JSON.stringify(MANIFEST));
+  const runnerPath = join(dir, 'runner.mjs');
+  writeFileSync(runnerPath, '// fail-closed runner stub\n');
+
+  const store = createMemoryStore();
+  const runnerCalls: Array<{ runnerPath: string; args: string[] }> = [];
+  let runnerOutcome: RunnerOutcome = { code: 0, stderrTail: '' };
+  const spawnRunner: SpawnRunner = async (path, args) => {
+    runnerCalls.push({ runnerPath: path, args });
+    return runnerOutcome;
+  };
+  const artifactsDir = join(dir, 'artifacts');
+  let currentActor = actorId;
+
+  const routes = createDrillRoutes({
+    manifestPath,
+    runnerPath,
+    artifactsDir,
+    spawnRunner,
+    store,
+  });
+  const app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    // AuditEventRepository uses the simple-adapter insert; the drill tables
+    // themselves go through the injected in-memory store.
+    c.set('db', {
+      getDrizzle: () => ({}),
+      insert: async (_table: unknown, values: Record<string, unknown>) => ({
+        id: 'audit-1',
+        ...values,
+      }),
+    } as unknown as Env['Variables']['db']);
+    c.set('tenantId', tenantId);
+    c.set('actorId', currentActor);
+    await next();
+  });
+  app.route('/api/drills', routes);
+  return {
+    app,
+    store,
+    runnerCalls,
+    artifactsDir,
+    setRunnerOutcome(outcome) {
+      runnerOutcome = outcome;
+    },
+    setActor(actorId) {
+      currentActor = actorId;
+    },
+  };
+}
+
+async function post(
+  app: Harness['app'],
+  path: string,
+  body?: Record<string, unknown>
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const response = await app.request(path, {
+    method: 'POST',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: response.status, json: (await response.json()) as Record<string, unknown> };
+}
+
+async function settle(store: ReturnType<typeof createMemoryStore>): Promise<StoreRun> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const run = store.rows[0];
+    if (run && ['fault_applied', 'failed'].includes(run.status)) return run;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+  }
+  throw new Error('drill run never settled');
+}
+
+describe('parseDrillManifest', () => {
+  it('extracts the LIVE-01–03 tuples with their pinned record names', () => {
+    const parsed = parseDrillManifest(MANIFEST);
+    expect(parsed.zone).toBe('asorin.ai');
+    expect(parsed.tuples).toHaveLength(3);
+    expect(parsed.tuples.map((tuple) => tuple.name)).toEqual([
+      'www.asorin.ai',
+      'asorin.ai',
+      'mail.asorin.ai',
+    ]);
+  });
+
+  it('fails closed on unknown mutation IDs or missing allowlist', () => {
+    expect(() =>
+      parseDrillManifest({
+        ...MANIFEST,
+        allowlist: [{ name: 'x.asorin.ai', types: ['TXT'], mutationIds: ['LIVE-99'] }],
+      })
+    ).toThrow(/outside LIVE-01–03/);
+    expect(() => parseDrillManifest({ ...MANIFEST, allowlist: [] })).toThrow(/no LIVE-01–03/);
+  });
+});
+
+describe('planDrillStart', () => {
+  it('plans the exact fail-closed runner invocations per scenario', () => {
+    expect(planDrillStart('LIVE-01', '/artifacts')).toEqual([
+      ['fixture-apply', 'LIVE-01', join('/artifacts', 'live-01-recovery.json')],
+    ]);
+    const live03 = planDrillStart('LIVE-03', '/artifacts');
+    expect(live03).toHaveLength(2);
+    expect(live03[0]).toEqual(['bootstrap', join('/artifacts', 'live-03-bootstrap.json')]);
+    expect(live03[1]).toEqual([
+      'apply',
+      join('/artifacts', 'live-03-bootstrap.json'),
+      join('/artifacts', 'live-03-recovery.json'),
+    ]);
+  });
+});
+
+describe('live drill routes', () => {
+  it('lists allowlisted tuples and rejects non-allowlisted mutation requests', async () => {
+    const harness = createHarness(TENANT_A, 'actor-a');
+    const listResponse = await harness.app.request('/api/drills');
+    const list = (await listResponse.json()) as Record<string, unknown>;
+    expect(listResponse.status).toBe(200);
+    expect(list.harness).toMatchObject({ available: true, zone: 'asorin.ai' });
+    expect((list.tuples as unknown[]).length).toBe(3);
+    expect((list.runs as unknown[]).length).toBe(0);
+
+    const rejected = await post(harness.app, '/api/drills', { mutationId: 'LIVE-04' });
+    expect(rejected.status).toBe(400);
+  });
+
+  it('requires a second distinct operator before a start is allowed', async () => {
+    const harness = createHarness(TENANT_A, 'actor-a');
+
+    const created = await post(harness.app, '/api/drills', { mutationId: 'LIVE-01' });
+    expect(created.status).toBe(201);
+    const runId = (created.json.run as { id: string }).id;
+
+    const selfConfirm = await post(harness.app, `/api/drills/${runId}/confirm`);
+    expect(selfConfirm.status).toBe(403);
+
+    const earlyStart = await post(harness.app, `/api/drills/${runId}/start`);
+    expect(earlyStart.status).toBe(409);
+
+    harness.setActor('actor-b');
+    const confirm = await post(harness.app, `/api/drills/${runId}/confirm`);
+    expect(confirm.status).toBe(200);
+    expect((confirm.json.run as { status: string }).status).toBe('approved');
+    expect((confirm.json.run as { confirmerActor: string }).confirmerActor).toBe('actor-b');
+  });
+
+  it('starts an approved drill with the manifest-pinned argv and records failure fail-closed', async () => {
+    const harness = createHarness(TENANT_A, 'actor-a');
+    const created = await post(harness.app, '/api/drills', { mutationId: 'LIVE-01' });
+    const runId = (created.json.run as { id: string }).id;
+    harness.setActor('actor-b');
+    await post(harness.app, `/api/drills/${runId}/confirm`);
+
+    harness.setRunnerOutcome({ code: 1, stderrTail: 'fixture control token missing' });
+    const started = await post(harness.app, `/api/drills/${runId}/start`);
+    expect(started.status).toBe(202);
+
+    const settled = await settle(harness.store);
+    expect(settled.status).toBe('failed');
+    expect(settled.runnerMessage).toContain('exited 1');
+    expect(harness.runnerCalls).toHaveLength(1);
+    expect(harness.runnerCalls[0].args[0]).toBe('fixture-apply');
+    expect(harness.runnerCalls[0].args[1]).toBe('LIVE-01');
+    expect(harness.runnerCalls[0].args[2].endsWith('live-01-recovery.json')).toBe(true);
+    // The record name is the manifest pin, never client input.
+    expect(settled.recordName).toBe('www.asorin.ai');
+  });
+
+  it('marks a successful fault phase with the recovery artifact for operator restore', async () => {
+    const harness = createHarness(TENANT_A, 'actor-a');
+    const created = await post(harness.app, '/api/drills', { mutationId: 'LIVE-02' });
+    const runId = (created.json.run as { id: string }).id;
+    harness.setActor('actor-b');
+    await post(harness.app, `/api/drills/${runId}/confirm`);
+    const started = await post(harness.app, `/api/drills/${runId}/start`);
+    expect(started.status).toBe(202);
+
+    const settled = await settle(harness.store);
+    expect(settled.status).toBe('fault_applied');
+    expect(settled.recoveryArtifact?.endsWith('live-02-recovery.json')).toBe(true);
+  });
+
+  it('enforces a single open drill and keeps tenants isolated', async () => {
+    const harnessA = createHarness(TENANT_A, 'actor-a');
+    const created = await post(harnessA.app, '/api/drills', { mutationId: 'LIVE-03' });
+    expect(created.status).toBe(201);
+    const runId = (created.json.run as { id: string }).id;
+    harnessA.setActor('actor-b');
+    await post(harnessA.app, `/api/drills/${runId}/confirm`);
+
+    const duplicate = await post(harnessA.app, '/api/drills', { mutationId: 'LIVE-01' });
+    expect(duplicate.status).toBe(409);
+
+    // Another tenant can neither confirm nor start tenant A's run.
+    const harnessB = createHarness(TENANT_B, 'actor-b');
+    const foreignConfirm = await post(harnessB.app, `/api/drills/${runId}/confirm`);
+    expect(foreignConfirm.status).toBe(404);
+    const foreignStart = await post(harnessB.app, `/api/drills/${runId}/start`);
+    expect(foreignStart.status).toBe(404);
+  });
+
+  it('fails closed when the harness or manifest is unavailable', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'drills-test-'));
+    const store = createMemoryStore();
+    const routes = createDrillRoutes({
+      manifestPath: join(dir, 'missing-manifest.json'),
+      runnerPath: join(dir, 'missing-runner.mjs'),
+      artifactsDir: join(dir, 'artifacts'),
+      spawnRunner: async () => ({ code: 0, stderrTail: '' }),
+      store,
+    });
+    const app = new Hono<Env>();
+    app.use('*', async (c, next) => {
+      c.set('db', {
+        getDrizzle: () => ({}),
+        insert: async (_table: unknown, values: Record<string, unknown>) => ({
+          id: 'audit-1',
+          ...values,
+        }),
+      } as unknown as Env['Variables']['db']);
+      c.set('tenantId', TENANT_A);
+      c.set('actorId', 'actor-a');
+      await next();
+    });
+    app.route('/api/drills', routes);
+
+    const list = await app.request('/api/drills');
+    const listJson = (await list.json()) as Record<string, unknown>;
+    expect(listJson.harness).toMatchObject({ available: false });
+    expect(listJson.tuples).toEqual([]);
+
+    const requested = await post(app, '/api/drills', { mutationId: 'LIVE-01' });
+    expect(requested.status).toBe(409);
+  });
+});

--- a/apps/web/hono/routes/drills.ts
+++ b/apps/web/hono/routes/drills.ts
@@ -1,0 +1,435 @@
+/**
+ * Live Drill Routes - Issue #62
+ *
+ * Two-person-confirmed starts of the fail-closed controlled-live harness
+ * (tools/controlled-live-harness/runner.mjs) for the asorin.ai tuples pinned
+ * in the checked-in mutation manifest. Non-allowlisted domains stay
+ * observation-only: the record name always comes from the manifest, never
+ * from the request. This module never touches provider or fixture secrets —
+ * the runner resolves its own runtime credentials and revalidates the
+ * manifest allowlist before every operation, so any missing secret or
+ * unauthorized tuple fails closed inside the harness.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CONTROLLED_FAULT_RECORD_TYPES,
+  LIVE_FAULT_MUTATION_IDS,
+  type LiveFaultMutationId,
+} from '@dns-ops/contracts';
+import { AuditEventRepository, type DrillRun, type NewDrillRun } from '@dns-ops/db';
+import { drillRuns } from '@dns-ops/db/schema';
+import { and, desc, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { requireAuth, requireWritePermission } from '../middleware/authorization.js';
+import { enumValue, validateBody, validationErrorResponse } from '../middleware/validation.js';
+import type { Env } from '../types.js';
+
+/** Statuses that hold the single open-drill slot (mirrors drill_run_open_unique). */
+export const OPEN_RUN_STATUSES = ['requested', 'approved', 'started'] as const;
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/** A manifest-approved drill tuple narrowed to the LIVE mutation IDs. */
+export interface DrillTuple {
+  name: string;
+  types: string[];
+  mutationIds: LiveFaultMutationId[];
+}
+
+export interface ParsedDrillManifest {
+  manifestId: string;
+  zone: string;
+  tuples: DrillTuple[];
+  scenarios: Record<string, { host: string; expectedSignal: string }>;
+}
+
+/**
+ * Parses the checked-in mutation manifest into the drill tuples an operator
+ * may start. Fails closed: unknown mutation IDs, record types outside the
+ * contracts allowlist, or duplicate LIVE coverage abort the parse.
+ */
+export function parseDrillManifest(raw: unknown): ParsedDrillManifest {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('live drill manifest must be a JSON object');
+  }
+  const manifest = raw as Record<string, unknown>;
+  const manifestId = typeof manifest.manifestId === 'string' ? manifest.manifestId : '';
+  const zone = typeof manifest.zone === 'string' ? manifest.zone : '';
+  if (!manifestId || !zone) {
+    throw new Error('live drill manifest is missing manifestId or zone');
+  }
+  if (!Array.isArray(manifest.allowlist)) {
+    throw new Error('live drill manifest is missing its allowlist');
+  }
+
+  const tuples: DrillTuple[] = [];
+  for (const entry of manifest.allowlist) {
+    if (typeof entry !== 'object' || entry === null) {
+      throw new Error('live drill allowlist entries must be objects');
+    }
+    const record = entry as Record<string, unknown>;
+    const name = typeof record.name === 'string' ? record.name : '';
+    const types = Array.isArray(record.types) ? record.types : [];
+    const mutationIds = Array.isArray(record.mutationIds) ? record.mutationIds : [];
+    if (!name || types.length === 0 || mutationIds.length === 0) {
+      throw new Error('live drill allowlist entries must pin name, types, and mutationIds');
+    }
+    for (const type of types) {
+      if (!CONTROLLED_FAULT_RECORD_TYPES.includes(type as never)) {
+        throw new Error(`live drill allowlist record type is not permitted: ${String(type)}`);
+      }
+    }
+    const liveIds = mutationIds.filter((id): id is LiveFaultMutationId =>
+      (LIVE_FAULT_MUTATION_IDS as readonly string[]).includes(id as string)
+    );
+    if (liveIds.length !== mutationIds.length) {
+      throw new Error(`live drill allowlist entry has a mutation ID outside LIVE-01–03: ${name}`);
+    }
+    if (liveIds.length > 0) {
+      tuples.push({ name, types: [...types], mutationIds: liveIds });
+    }
+  }
+  if (tuples.length === 0) {
+    throw new Error('live drill manifest has no LIVE-01–03 allowlist entries');
+  }
+
+  const scenarios: ParsedDrillManifest['scenarios'] = {};
+  const rawScenarios =
+    typeof manifest.scenarios === 'object' && manifest.scenarios !== null
+      ? (manifest.scenarios as Record<string, unknown>)
+      : {};
+  for (const id of LIVE_FAULT_MUTATION_IDS) {
+    const scenario = rawScenarios[id];
+    if (typeof scenario !== 'object' || scenario === null) continue;
+    const record = scenario as Record<string, unknown>;
+    scenarios[id] = {
+      host: typeof record.host === 'string' ? record.host : '',
+      expectedSignal: typeof record.expectedSignal === 'string' ? record.expectedSignal : '',
+    };
+  }
+
+  return { manifestId, zone, tuples, scenarios };
+}
+
+function readParsedManifest(manifestPath: string): ParsedDrillManifest | null {
+  try {
+    return parseDrillManifest(JSON.parse(readFileSync(manifestPath, 'utf8')));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Exact fail-closed runner invocations for the fault phase of one scenario.
+ * Restore stays an explicit operator action using the recorded recovery
+ * artifact; the harness remains the only mutation path.
+ */
+export function planDrillStart(mutationId: LiveFaultMutationId, artifactsDir: string): string[][] {
+  switch (mutationId) {
+    case 'LIVE-01':
+      return [['fixture-apply', 'LIVE-01', join(artifactsDir, 'live-01-recovery.json')]];
+    case 'LIVE-02':
+      return [['fixture-apply', 'LIVE-02', join(artifactsDir, 'live-02-recovery.json')]];
+    case 'LIVE-03':
+      return [
+        ['bootstrap', join(artifactsDir, 'live-03-bootstrap.json')],
+        [
+          'apply',
+          join(artifactsDir, 'live-03-bootstrap.json'),
+          join(artifactsDir, 'live-03-recovery.json'),
+        ],
+      ];
+  }
+}
+
+export type RunnerOutcome = { code: number; stderrTail: string };
+
+export type SpawnRunner = (runnerPath: string, args: string[]) => Promise<RunnerOutcome>;
+
+function defaultSpawnRunner(runnerPath: string, args: string[]): Promise<RunnerOutcome> {
+  return new Promise((resolvePromise) => {
+    // Arguments are a fixed array built from the manifest — no shell, no user
+    // input in argv, and the runner reads its own secrets from its own files.
+    const child = spawn(process.execPath, [runnerPath, ...args], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (stderr.length > 4096) stderr = stderr.slice(-4096);
+    });
+    child.on('error', (error) => resolvePromise({ code: -1, stderrTail: error.message }));
+    child.on('close', (code) =>
+      resolvePromise({ code: code ?? -1, stderrTail: stderr.slice(-1024) })
+    );
+  });
+}
+
+/**
+ * Persistence for drill runs. The production store uses Drizzle; tests inject
+ * an in-memory store with the same open-run uniqueness as the partial unique
+ * index `drill_run_open_unique`.
+ */
+export interface DrillRunStore {
+  list(tenantId: string): Promise<DrillRun[]>;
+  insert(data: NewDrillRun): Promise<DrillRun>;
+  /** Applies patch only when the run is currently in fromStatus. */
+  transition(id: string, fromStatus: string, patch: Partial<NewDrillRun>): Promise<DrillRun | null>;
+}
+
+function createDrizzleRunStore(db: Env['Variables']['db']): DrillRunStore {
+  type DrillDrizzle = {
+    query: {
+      drillRuns: {
+        findMany(args: { where?: unknown; orderBy?: unknown; limit?: number }): Promise<DrillRun[]>;
+      };
+    };
+    insert(table: unknown): {
+      values(data: NewDrillRun): { returning(): Promise<DrillRun[]> };
+    };
+    update(table: unknown): {
+      set(patch: Record<string, unknown>): {
+        where(condition: unknown): { returning(): Promise<DrillRun[]> };
+      };
+    };
+  };
+  // The env database is the Postgres drizzle client at runtime; the union with
+  // the legacy D1 client makes writes uncallable without this narrow cast
+  // (same pattern as hono/routes/signup.ts AuthDrizzle).
+  const drizzle = db.getDrizzle() as unknown as DrillDrizzle;
+  return {
+    async list(tenantId) {
+      return drizzle.query.drillRuns.findMany({
+        where: eq(drillRuns.tenantId, tenantId),
+        orderBy: [desc(drillRuns.createdAt)],
+        limit: 20,
+      });
+    },
+    async insert(data) {
+      const [row] = await drizzle.insert(drillRuns).values(data).returning();
+      return row;
+    },
+    async transition(id, fromStatus, patch) {
+      const [row] = await drizzle
+        .update(drillRuns)
+        .set({ ...patch, updatedAt: new Date() })
+        .where(and(eq(drillRuns.id, id), eq(drillRuns.status, fromStatus)))
+        .returning();
+      return row ?? null;
+    },
+  };
+}
+
+export interface DrillRouteOptions {
+  manifestPath?: string;
+  runnerPath?: string;
+  artifactsDir?: string;
+  spawnRunner?: SpawnRunner;
+  store?: DrillRunStore;
+}
+
+export function createDrillRoutes(options: DrillRouteOptions = {}) {
+  const manifestPath =
+    options.manifestPath ??
+    process.env.DNSOPS_LIVE_MANIFEST_PATH ??
+    join(repoRoot, 'docs/domain-operations/evidence/gate-3/asorin-live-mutation-manifest.json');
+  const runnerPath =
+    options.runnerPath ?? join(repoRoot, 'tools/controlled-live-harness/runner.mjs');
+  const artifactsDir =
+    options.artifactsDir ?? process.env.DNSOPS_DRILL_ARTIFACT_DIR ?? join(repoRoot, '.live-drills');
+  const execRunner = options.spawnRunner ?? defaultSpawnRunner;
+
+  const routes = new Hono<Env>();
+
+  routes.use('*', requireAuth);
+
+  routes.get('/', async (c) => {
+    const db = c.get('db');
+    const tenantId = c.get('tenantId');
+    if (!db || !tenantId) {
+      return c.json({ error: 'Database unavailable' }, 503);
+    }
+
+    const manifest = readParsedManifest(manifestPath);
+    const runs = manifest ? await (options.store ?? createDrizzleRunStore(db)).list(tenantId) : [];
+    return c.json({
+      harness: {
+        available: manifest !== null && existsSync(runnerPath),
+        manifestId: manifest?.manifestId ?? null,
+        zone: manifest?.zone ?? null,
+      },
+      tuples: manifest?.tuples ?? [],
+      scenarios: manifest?.scenarios ?? {},
+      runs,
+    });
+  });
+
+  routes.post('/', requireWritePermission, async (c) => {
+    const db = c.get('db');
+    const tenantId = c.get('tenantId');
+    const actorId = c.get('actorId');
+    if (!db || !tenantId || !actorId) {
+      return c.json({ error: 'Database unavailable' }, 503);
+    }
+
+    const validation = await validateBody(c, {
+      mutationId: enumValue('mutationId', LIVE_FAULT_MUTATION_IDS),
+    });
+    if (!validation.success) {
+      return validationErrorResponse(c, validation.error);
+    }
+    const mutationId = validation.data.mutationId;
+    if (mutationId === undefined) {
+      return c.json({ error: 'mutationId is required' }, 400);
+    }
+
+    const manifest = readParsedManifest(manifestPath);
+    if (!manifest || !existsSync(runnerPath)) {
+      return c.json({ error: 'Live drill harness is not available in this deployment' }, 409);
+    }
+    const tuple = manifest.tuples.find((entry) => entry.mutationIds.includes(mutationId));
+    if (!tuple) {
+      // Not on the allowlist: the requested mutation has no pinned record.
+      return c.json({ error: 'Mutation is not allowlisted for this zone' }, 403);
+    }
+
+    const store = options.store ?? createDrizzleRunStore(db);
+    try {
+      const run = await store.insert({
+        mutationId,
+        recordName: tuple.name,
+        status: 'requested',
+        requesterActor: actorId,
+        tenantId,
+      });
+      await new AuditEventRepository(db).create({
+        action: 'live_drill_requested',
+        entityType: 'drill_run',
+        entityId: run.id,
+        newValue: { mutationId, recordName: tuple.name },
+        actorId,
+        tenantId,
+      });
+      return c.json({ run }, 201);
+    } catch (error) {
+      if ((error as { code?: string }).code === '23505') {
+        return c.json({ error: 'Another drill is already open' }, 409);
+      }
+      throw error;
+    }
+  });
+
+  routes.post('/:id/confirm', requireWritePermission, async (c) => {
+    const db = c.get('db');
+    const tenantId = c.get('tenantId');
+    const actorId = c.get('actorId');
+    if (!db || !tenantId || !actorId) {
+      return c.json({ error: 'Database unavailable' }, 503);
+    }
+
+    const store = options.store ?? createDrizzleRunStore(db);
+    const runs = await store.list(tenantId);
+    const run = runs.find((candidate) => candidate.id === c.req.param('id'));
+    if (!run) {
+      return c.json({ error: 'Drill run not found' }, 404);
+    }
+    if (run.requesterActor === actorId) {
+      return c.json({ error: 'A second operator must confirm the drill' }, 403);
+    }
+    const confirmed = await store.transition(run.id, 'requested', {
+      status: 'approved',
+      confirmerActor: actorId,
+    });
+    if (!confirmed) {
+      return c.json({ error: 'Drill run is not awaiting confirmation' }, 409);
+    }
+    await new AuditEventRepository(db).create({
+      action: 'live_drill_confirmed',
+      entityType: 'drill_run',
+      entityId: run.id,
+      newValue: { confirmerActor: actorId },
+      actorId,
+      tenantId,
+    });
+    return c.json({ run: confirmed });
+  });
+
+  routes.post('/:id/start', requireWritePermission, async (c) => {
+    const db = c.get('db');
+    const tenantId = c.get('tenantId');
+    const actorId = c.get('actorId');
+    if (!db || !tenantId || !actorId) {
+      return c.json({ error: 'Database unavailable' }, 503);
+    }
+    if (!existsSync(runnerPath) || !readParsedManifest(manifestPath)) {
+      return c.json({ error: 'Live drill harness is not available in this deployment' }, 409);
+    }
+
+    const store = options.store ?? createDrizzleRunStore(db);
+    const runs = await store.list(tenantId);
+    const run = runs.find((candidate) => candidate.id === c.req.param('id'));
+    if (!run) {
+      return c.json({ error: 'Drill run not found' }, 404);
+    }
+    if (!(LIVE_FAULT_MUTATION_IDS as readonly string[]).includes(run.mutationId)) {
+      return c.json({ error: 'Mutation is not allowlisted for this zone' }, 403);
+    }
+    // Conditional transition doubles as the concurrency guard: exactly one
+    // start wins even if two operators click simultaneously.
+    const started = await store.transition(run.id, 'approved', { status: 'started' });
+    if (!started) {
+      return c.json({ error: 'Drill run is not approved for start' }, 409);
+    }
+    await new AuditEventRepository(db).create({
+      action: 'live_drill_started',
+      entityType: 'drill_run',
+      entityId: run.id,
+      newValue: { startedBy: actorId },
+      actorId,
+      tenantId,
+    });
+
+    const steps = planDrillStart(run.mutationId as LiveFaultMutationId, artifactsDir);
+    mkdirSync(artifactsDir, { recursive: true });
+    void (async () => {
+      let recoveryArtifact: string | null = null;
+      for (const args of steps) {
+        const outcome = await execRunner(runnerPath, args);
+        if (outcome.code !== 0) {
+          await store.transition(run.id, 'started', {
+            status: 'failed',
+            runnerMessage: `runner ${args[0]} exited ${outcome.code}: ${outcome.stderrTail}`.slice(
+              0,
+              1024
+            ),
+          });
+          return;
+        }
+        const artifactArg = args.at(-1);
+        if (artifactArg?.endsWith('recovery.json')) recoveryArtifact = artifactArg;
+      }
+      await store.transition(run.id, 'started', {
+        status: 'fault_applied',
+        recoveryArtifact,
+        runnerMessage: 'Fault phase applied; restore required before the next drill',
+      });
+    })().catch(async (error) => {
+      await store.transition(run.id, 'started', {
+        status: 'failed',
+        runnerMessage: `drill execution failed: ${String(error)}`.slice(0, 1024),
+      });
+    });
+
+    return c.json({ run: started }, 202);
+  });
+
+  return routes;
+}
+
+export const drillRoutes = createDrillRoutes();

--- a/apps/web/hono/routes/portfolio.ts
+++ b/apps/web/hono/routes/portfolio.ts
@@ -34,11 +34,16 @@ import {
   validationErrorResponse,
 } from '../middleware/validation.js';
 import type { Env } from '../types.js';
+import { drillRoutes } from './drills.js';
 
 export const portfolioRoutes = new Hono<Env>();
 
 // Apply authentication to all portfolio routes
 portfolioRoutes.use('*', requireAuth);
+
+// Live drills (issue #62): two-person-confirmed starts of the fail-closed
+// controlled-live harness for the allowlisted asorin.ai tuples.
+portfolioRoutes.route('/drills', drillRoutes);
 
 // =============================================================================
 // EXPIRATION READ MODEL (Issue #60)

--- a/packages/db/src/migrations/0022_live_drill_runs.sql
+++ b/packages/db/src/migrations/0022_live_drill_runs.sql
@@ -1,0 +1,30 @@
+-- Issue #62: two-person-confirmed starts of the fail-closed controlled-live
+-- harness for the allowlisted asorin.ai tuples. drill_runs is the durable
+-- approval/run trail; a partial unique index enforces a single open drill
+-- (requested/approved/started) at any time so fault phases cannot overlap.
+
+CREATE TABLE IF NOT EXISTS "drill_runs" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "record_name" varchar(253) NOT NULL,
+  "mutation_id" varchar(20) NOT NULL,
+  "status" varchar(20) NOT NULL DEFAULT 'requested',
+  "requester_actor" varchar(100) NOT NULL,
+  "confirmer_actor" varchar(100),
+  "recovery_artifact" text,
+  "runner_message" text,
+  "tenant_id" uuid NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "drill_run_tenant_idx" ON "drill_runs" ("tenant_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "drill_run_mutation_idx" ON "drill_runs" ("mutation_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "drill_run_open_unique" ON "drill_runs" ((1)) WHERE "status" IN ('requested', 'approved', 'started');
+--> statement-breakpoint
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'live_drill_requested';
+--> statement-breakpoint
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'live_drill_confirmed';
+--> statement-breakpoint
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'live_drill_started';

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -627,6 +627,9 @@ export const auditActionEnum = pgEnum('audit_action', [
   'domain_profile_updated',
   'operational_baseline_accepted',
   'mcp_case_disposition_set',
+  'live_drill_requested',
+  'live_drill_confirmed',
+  'live_drill_started',
 ]);
 
 export const auditEvents = pgTable(
@@ -1293,3 +1296,46 @@ export const sessions = pgTable('sessions', {
 
 export type Session = typeof sessions.$inferSelect;
 export type NewSession = typeof sessions.$inferInsert;
+
+// =============================================================================
+// LIVE DRILL RUNS (Issue #62)
+//
+// Durable two-person approval + run trail for starting the fail-closed
+// controlled-live harness against the allowlisted asorin.ai tuples. The
+// harness (tools/controlled-live-harness) remains the only component that may
+// touch the provider; this table only gates and records operator intent.
+// =============================================================================
+
+export const drillRuns = pgTable(
+  'drill_runs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    // Allowlisted scenario: LIVE-01 | LIVE-02 | LIVE-03 with its pinned record
+    recordName: varchar('record_name', { length: 253 }).notNull(),
+    mutationId: varchar('mutation_id', { length: 20 }).notNull(),
+
+    // requested → approved (second operator) → started → fault_applied | failed
+    status: varchar('status', { length: 20 }).notNull().default('requested'),
+
+    // Two-person confirm: confirmer must differ from requester
+    requesterActor: varchar('requester_actor', { length: 100 }).notNull(),
+    confirmerActor: varchar('confirmer_actor', { length: 100 }),
+
+    // Redacted harness outputs (artifact path + fail-closed error summary)
+    recoveryArtifact: text('recovery_artifact'),
+    runnerMessage: text('runner_message'),
+
+    tenantId: uuid('tenant_id').notNull(),
+
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tenantIdx: index('drill_run_tenant_idx').on(table.tenantId),
+    mutationIdx: index('drill_run_mutation_idx').on(table.mutationId),
+  })
+);
+
+export type DrillRun = typeof drillRuns.$inferSelect;
+export type NewDrillRun = typeof drillRuns.$inferInsert;

--- a/verification/receipts/20260903-234759Z-ac43b22-issue62-portfolio-search--domain.overview.md
+++ b/verification/receipts/20260903-234759Z-ac43b22-issue62-portfolio-search--domain.overview.md
@@ -1,0 +1,44 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-234759Z-ac43b22-issue62-portfolio-search
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 1f39ce5cc08dfce4c11b74ca640750cbde055742
+code_digest: 7de3be972652e1cbb2dd7db97a82735958b14daca1e786fdc22432f003cf5646
+dirty: true
+untracked: 0
+status: blocked
+reason: "Domain 360 was not driven in this run; the only mapped-path change is the additive drill_runs table and audit enum values in packages/db/src/schema/index.ts, which do not alter Domain 360 behavior. Verified instead: drills route tests (19 passing), schema migration applied cleanly on Postgres, verify-migrations parity green, and a live portfolio.search drive at this tree."
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search
+created_at: 2026-09-03T23:51:07.724Z
+---
+
+# Receipt: domain.overview — blocked
+
+## Observations (expected → seen)
+
+- 
+
+## Forbidden (must not happen → confirmed absent)
+
+- 
+
+## Read-back (side effects checked through an independent path)
+
+- 
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/console.log | log | aux · unrecognized .log | fb1c5280b2ded51c27990451770a18fece409e5a72096e5e6bbf6df0e68a84d0 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/failed-requests.log | log | aux · unrecognized .log | f6402713f7645cc2822734ae80ff55f3e237097309b38674aad3e11e501ffb0a |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/observations.md | md | aux · unrecognized .md | 90753d8d899ba27cb29a3fd66607c8c869920522d8c6681311b08bb8cc6b3566 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/portfolio-search.png | png | evidence · 1280x5587 | 08c43762553de90390a6484068c49566202c6f3330b1dae7f75cfede4c805778 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/trace.zip | trace | evidence · playwright trace | 6371bf15539509ed4a9ebcbff7c445eef15d19a9081e2ae3a6d106597c3dcf09 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/video/eb84b68ea3e333ae2d5a6119d0ad48cf.webm | video | evidence | e9fa31096d64e6b4f45e719b9e012117fe27f3b9d2851f1d75f3fe54a98c0848 |

--- a/verification/receipts/20260903-234759Z-ac43b22-issue62-portfolio-search--portfolio.search.md
+++ b/verification/receipts/20260903-234759Z-ac43b22-issue62-portfolio-search--portfolio.search.md
@@ -1,0 +1,51 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260903-234759Z-ac43b22-issue62-portfolio-search
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 1f39ce5cc08dfce4c11b74ca640750cbde055742
+code_digest: 7de3be972652e1cbb2dd7db97a82735958b14daca1e786fdc22432f003cf5646
+dirty: true
+untracked: 0
+status: passed
+reason: ""
+verifier: builder
+verifier_session: ""
+evidence_dir: verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search
+created_at: 2026-09-03T23:50:24.132Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` showed **Portfolio workflows**, **Portfolio Search**, **Built-in views**, and the new **Live drills** panel (10 panels in the workspace) → confirmed by the live drive on port 3312.
+- Query accepted `example.com` and completed a real `POST /api/portfolio/search` returning HTTP 200 JSON with `domains` → recorded in `readback/portfolio-search.json`.
+- Built-in **Mail broken**, **Expiring evidence**, and **Incomplete coverage** buttons each issued a real POST with their exact view criteria; active Incomplete coverage exposed `aria-pressed="true"`; re-click cleared its criteria → recorded in `readback/built-in-view-requests.json`.
+- Expiry fixture rendered: observed RDAP `WITHIN_90` bucket and no-evidence `UNKNOWN` in the Expiry column; selecting **Within 90 days** sent `expirationWithinDays: 90` and retained only the observed fixture → recorded in `readback/portfolio-expiry.json`.
+- Live drills read API returned the real manifest surface: `available: true`, manifest `ASORIN-AI-CONTROLLED-LIVE-01-03`, zone `asorin.ai`, five allowlisted tuples; unauthenticated request returned 401 (verified out-of-band via curl before the drive).
+- Browser screenshot, video, and Playwright trace captured; doctor-equivalent health check returned HTTP 200 healthy.
+
+## Forbidden (… → confirmed absent)
+- Sign-in warning used as success → absent; local e2e tenant/actor headers returned authenticated seeded results.
+- Class selectors → harness uses semantic roles/labels only.
+- Expiry derived from findings or `DOMAIN_EXPIRING_SOON` → response projection came from RDAP expiration evidence.
+- Non-allowlisted domains offered for drills → tuples come only from the checked-in manifest; drill POST body carries only `mutationId`.
+
+## Read-back
+- `readback/portfolio-search.json`, `readback/built-in-view-requests.json`, and `readback/portfolio-expiry.json` contain real response JSON.
+- `trace.zip`, `portfolio-search.png`, `video/*.webm`, `console.log`, and `failed-requests.log` are present.
+- Ancillary: one transient superseded `POST /api/portfolio/search` abort occurred during the first drive attempt (cleared-view step) and the retried drive completed cleanly; a missing `/_build/assets/client.css` and blocked external font CORS requests in the log did not affect any verified assertion.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/console.log | log | aux · unrecognized .log | fb1c5280b2ded51c27990451770a18fece409e5a72096e5e6bbf6df0e68a84d0 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/failed-requests.log | log | aux · unrecognized .log | f6402713f7645cc2822734ae80ff55f3e237097309b38674aad3e11e501ffb0a |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/observations.md | md | aux · unrecognized .md | 90753d8d899ba27cb29a3fd66607c8c869920522d8c6681311b08bb8cc6b3566 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/portfolio-search.png | png | evidence · 1280x5587 | 08c43762553de90390a6484068c49566202c6f3330b1dae7f75cfede4c805778 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/trace.zip | trace | evidence · playwright trace | 6371bf15539509ed4a9ebcbff7c445eef15d19a9081e2ae3a6d106597c3dcf09 |
+| verification/runs/20260903-234759Z-ac43b22-issue62-portfolio-search/video/eb84b68ea3e333ae2d5a6119d0ad48cf.webm | video | evidence | e9fa31096d64e6b4f45e719b9e012117fe27f3b9d2851f1d75f3fe54a98c0848 |

--- a/verification/receipts/20260904-002348Z-39b92eb-fresh--portfolio.search.md
+++ b/verification/receipts/20260904-002348Z-39b92eb-fresh--portfolio.search.md
@@ -1,0 +1,57 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-002348Z-39b92eb-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 39b92ebe76f97f0faab7309c87746266adb89428
+code_digest: 0c7d40a23d0f64163d763851a867425c61890a6efcd01233b84994d2c444099d
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-002348Z-39b92eb-fresh
+created_at: 2026-09-04T00:28:13.951Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` loaded from the exact checkout at HEAD `39b92ebe76f97f0faab7309c87746266adb89428`; headings `Portfolio workflows`, `Portfolio Search`, and `Built-in views` were visible.
+- The labeled `Query` field accepted `example.com`; the resulting valid empty set was accepted by the drive. Independent POST read-back with the same e2e session returned HTTP 200 and 3 tenant domains for `{}`.
+- Browser-driven built-in view requests returned HTTP 200 and carried the expected request bodies: Mail broken `{findingTypePrefix:"mail.",severities:["high","critical"]}`, Expiring evidence `{snapshotOlderThanDays:30}`, Incomplete coverage `{coverage:"incomplete"}`. The active Incomplete coverage button exposed `aria-pressed="true"`; clicking it again sent `{}`.
+- Independent direct POST read-back (`readback/view-result-sets.json`) confirmed server-side result subsets: all/cleared IDs `...001,...002,...003`; Mail broken IDs `...001,...003` with `mail.no-dmarc-record` high on `mailbroken.example` and unevaluated `unevaluated.example` retained; Expiring evidence ID `...002` (`stale.example`); Incomplete coverage ID `...003` (`unevaluated.example`).
+
+## Forbidden (expected → confirmed absent)
+- Unauthenticated POST returned HTTP 401 `{error:"Unauthorized",message:"Authentication required."}`; no sign-in warning was treated as a successful search.
+- A different `X-Dev-Tenant` returned HTTP 200 with `domains:[]`; tenant A domain IDs were not exposed to tenant B.
+- No class selectors or test-only endpoints were used.
+
+## Read-back
+- `readback/adversarial-search.json` records two identical authenticated searches (`status:200`, same three IDs), other-tenant isolation, malformed-input responses, unauthenticated denial, an aborted request, and a successful post-abort request.
+- Malformed `coverage:"unsupported"`, `snapshotOlderThanDays:0`, and a 254-character query returned HTTP 400 with explicit validation errors; no write side effect exists for this read-only search.
+- Repeated request after an immediately aborted request returned HTTP 200 with only the incomplete-coverage domain ID `...003`, showing the service remained usable and no dangling search state.
+- `doctor.txt` records healthy web readiness (`/api/health` HTTP 200, `status:"healthy"`).
+
+## Notes
+- The dev server emitted a non-feature `/_build/assets/client.css` 404 and two superseded browser POSTs were aborted during rapid view toggles; the required requests completed with HTTP 200 and the page rendered/functioned.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-002348Z-39b92eb-fresh/console.log | log | aux · unrecognized .log | a0cab3bf0f0596bc8ea77a62a530e64af97583143d4dd910637770cd11f5eac4 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260904-002348Z-39b92eb-fresh/env.txt | env | aux | 98d2bbe790c116bd247d6e04cdf03df797197755ffba1ee255c55434565c4c21 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/failed-requests.log | log | aux · unrecognized .log | ab8f547fb490fa005c9f1858de97011a35675e186f0a5874eda1b645fbc6db7b |
+| verification/runs/20260904-002348Z-39b92eb-fresh/observations.md | md | aux · unrecognized .md | ea53d8bbc1a40856ebc54feef47f40bdad0e486ac3c424eca7f4852c70862a47 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/portfolio-search.png | png | evidence · 1280x5795 | fe0969ec327a37936dbe2189b11a78966e7bc223e68de9ed8025f3234275854b |
+| verification/runs/20260904-002348Z-39b92eb-fresh/readback/adversarial-search.json | readback | evidence | 0998b4e7ed142965ba4f47a3dec541a3afdef68a8dcc38e83466fb223177ea77 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260904-002348Z-39b92eb-fresh/readback/view-result-sets.json | readback | evidence | c30dfbece9ef36eddf3d36d09191f828366c0e841d09cbd507126b095f2a2120 |
+| verification/runs/20260904-002348Z-39b92eb-fresh/trace.zip | trace | evidence · playwright trace | ac4eec6fd692a01abaae71f1b51052045d934e2cb3b9c5fa899e6cb4933272ee |
+| verification/runs/20260904-002348Z-39b92eb-fresh/video/4d248482624ce1c8a21e3d9eb50974a1.webm | video | evidence | 78a727cb7c73d071fdefb62345dda791e071c032a273721abc3f3ecd5976d3ae |
+| verification/runs/20260904-002348Z-39b92eb-fresh/video/7390f8e6054b44363147c470e7ffe300.webm | video | evidence | 95f8fcd9d53ad22b26b6c712d4b43b99d1f8394eddd55d471646d651c302c599 |

--- a/verification/receipts/20260904-003544Z-aa11034-fresh--portfolio.search.md
+++ b/verification/receipts/20260904-003544Z-aa11034-fresh--portfolio.search.md
@@ -1,0 +1,62 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-003544Z-aa11034-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: aa11034198f5dc0d924ad1aa74daf0a4936b140f
+code_digest: c0856c1cf56ae1049c482cc6e3dd6bacd407b9ae2636a13efb5d4b5c738a5f37
+dirty: false
+untracked: 1
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-003544Z-aa11034-fresh
+created_at: 2026-09-04T00:43:35.219Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `/portfolio` rendered headings `Portfolio workflows`, `Portfolio Search`, and `Built-in views`; screenshot `portfolio-search.png` shows Query and all three buttons.
+- Query `example.com` was accepted and POST `/api/portfolio/search` returned HTTP 200 JSON with `domains: []` (valid empty set).
+- Button-driven POST request bodies were captured in `readback/built-in-view-requests.json`: Mail broken `{severities:["high","critical"],findingTypePrefix:"mail."}`, Expiring evidence `{snapshotOlderThanDays:30}`, Incomplete coverage `{coverage:"incomplete"}`. Incomplete button reported `aria-pressed="true"`; re-click produced `{limit:20,offset:0}` with no view criteria.
+- Direct same-session HTTP read-back requests are in `http/`; all returned HTTP 200. Results: baseline/cleared 3 domains (`mailbroken.example`, `stale.example`, `unevaluated.example`), mail-broken 2 (`mailbroken.example`, `unevaluated.example`), expiring 1 (`stale.example`), incomplete 1 (`unevaluated.example`). `readback/portfolio-direct-audit.json` confirms every filtered result is a baseline subset, mail findings match `mail.`, stale snapshot is >30 days old, incomplete result is unevaluated, and clearing equals baseline.
+
+## Forbidden (expected → confirmed absent)
+- No sign-in warning was shown for the authenticated local e2e session; authenticated search returned real tenant domains.
+- Direct unauthenticated POST returned HTTP 401 `{"error":"Unauthorized","message":"Authentication required."}` (`http/unauth.json`), not a successful search.
+- Alternate tenant header returned HTTP 200 with `domains:[]` (`http/another-tenant.json`), with no cross-tenant domains.
+- Invalid coverage returned HTTP 400 `{"error":"coverage must be \"incomplete\""}` (`http/malformed.response.json`); no write operation occurred.
+- No class selectors were used; harness uses ARIA roles/labels.
+
+## Read-back
+- `http/*.response.json` are direct API responses from the same session headers, independent of rendered results.
+- `readback/portfolio-direct-audit.json` contains concrete subset and criteria checks, all `true`.
+- `trace.zip`, `portfolio-search.png`, `console.log`, and `failed-requests.log` capture the browser drive. One static dev asset request (`/_build/assets/client.css`) returned 404; it did not prevent the flow or API responses. External font requests were not relied upon.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-003544Z-aa11034-fresh/console.log | log | aux · unrecognized .log | a0cab3bf0f0596bc8ea77a62a530e64af97583143d4dd910637770cd11f5eac4 |
+| verification/runs/20260904-003544Z-aa11034-fresh/doctor-no-collector.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260904-003544Z-aa11034-fresh/doctor.txt | txt | aux · unrecognized .txt | 3abc85b8454ea084d025b3bb153b5558678d58b6fcafa54bf8698b7f45e5034b |
+| verification/runs/20260904-003544Z-aa11034-fresh/env.txt | env | aux | 5c83667d37437afb15906dd40dd62d771cfb5c8fcc1c764a237313c6ccce6df7 |
+| verification/runs/20260904-003544Z-aa11034-fresh/failed-requests.log | log | aux · unrecognized .log | ab8f547fb490fa005c9f1858de97011a35675e186f0a5874eda1b645fbc6db7b |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/another-tenant.json | http | evidence | eb77506aacbf32543c4ebfc912fee50c17339a2628611305b479892cf3164774 |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/baseline.json | http | evidence | c7d6884ab83c12ee3991b65894a945fd746c14732304d0ec9ce65213cbe2b50c |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/cleared.json | http | evidence | c7d6884ab83c12ee3991b65894a945fd746c14732304d0ec9ce65213cbe2b50c |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/expiring.json | http | evidence | 44de69bae25af81661d5084c559ff28abe786c2946d461fa89266f2f9982a4bc |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/incomplete.json | http | evidence | f804dbdaa5404687a90afc2ad521fb1542254538fdaafbbef6764c0932fd19c9 |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/mail-broken.json | http | evidence | c23f0efb5a8ea2b114ce1210169a34e63bd14d82f021513f191d39a561d05e66 |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/malformed.json | http | evidence | 6e8275cf9645ac8987032397a2bcb3dac4b144e6edb9bd79b99a902ee1827b22 |
+| verification/runs/20260904-003544Z-aa11034-fresh/http/unauth.json | http | evidence | ca753a0b0289fd814b62750a9051b83812dc5eb9a173fba7ded52b8f9ac30004 |
+| verification/runs/20260904-003544Z-aa11034-fresh/observations.md | md | aux · unrecognized .md | b9335b920cac03bd0a6205df400c280ab6e5844b8d7eebef46c74e3986aff07e |
+| verification/runs/20260904-003544Z-aa11034-fresh/portfolio-search.png | png | evidence · 1280x5795 | 7d9ec52804abfad317c4af37a4eb9e00a45ad4ed989585732cecceb08736fa9c |
+| verification/runs/20260904-003544Z-aa11034-fresh/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260904-003544Z-aa11034-fresh/readback/portfolio-direct-audit.json | readback | evidence | e4299f270221e8f9d17c74878812175fed649fd8fe4c7aa397b8a06bf1b84432 |
+| verification/runs/20260904-003544Z-aa11034-fresh/readback/portfolio-search.json | readback | evidence | d4a7d88aa0fb1ab92fbba699262bca53c72c473a7a8cd1434f3f2268acadd0fb |
+| verification/runs/20260904-003544Z-aa11034-fresh/trace.zip | trace | evidence · playwright trace | f9b0d31609de0212ed40275d16dfcf9609c69a6301bb1b70484a45e156adbea1 |
+| verification/runs/20260904-003544Z-aa11034-fresh/video/4252f4f7b120d7951e845a4c0777976c.webm | video | evidence | 626211b3de0755178d14c6bd49f03c4cff51850b61a1eee2596059500ece00a1 |

--- a/verification/receipts/20260904-004722Z-bc16baf-fresh--portfolio.search.md
+++ b/verification/receipts/20260904-004722Z-bc16baf-fresh--portfolio.search.md
@@ -1,0 +1,68 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-004722Z-bc16baf-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: bc16baf7395e6746a976183a103c884820237709
+code_digest: 83c8e17a2ab7b3fb8268fd508060118e84c129b5f1ed436f61a8916af0e01ab8
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-004722Z-bc16baf-fresh
+created_at: 2026-09-04T00:53:51.707Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- Doctor expected healthy web surface → `.agents/skills/verify-dns-ops/harness/doctor.sh` reported `web /api/health 200 healthy` (3/3 checks passed).
+- `/portfolio` expected headings and controls → Playwright drive reached `Portfolio workflows`, `Portfolio Search`, `Built-in views`, labeled `Query`, and `Expiry window` options `Any`, `Within 7 days`, `Within 30 days`, `Within 90 days`.
+- Query expected to POST successfully → filling `Query` with `verify-expiry` produced HTTP 200 and `domains[]`; both seeded domains were returned. Observed domain had expiration `status=OBSERVED`, and the final table rendered `WITHIN_90`; unknown-evidence domain rendered literal `UNKNOWN` in the Expiry cell.
+- Built-in views expected to send criteria and toggle state → captured requests in `readback/built-in-view-requests.json`: Mail broken sent `findingTypePrefix=mail.` and `severities=[high,critical]`; Expiring evidence sent `snapshotOlderThanDays=30`; Incomplete coverage sent `coverage=incomplete` and its button had `aria-pressed=true`; clicking it again sent a request without `coverage`.
+- Expiry filter expected to send `expirationWithinDays=90` and filter server-side → response was HTTP 200 with only `verify-expiry-observed.example.test` (total 1); unknown domain was absent. Full response is in `readback/portfolio-expiry.json`.
+
+## Forbidden (expected absent → confirmed absent)
+- Unauthenticated search must not be treated as success → direct POST without dev identity returned HTTP 401 `{error:"Unauthorized",message:"Authentication required."}` in `http/no-auth-search.txt`; unauthenticated browser drive rendered `Operator sign-in is required to search tenant domains and load saved filters.`
+- Cross-tenant leakage → same valid body with `X-Dev-Tenant: other-tenant` returned HTTP 200 with `domains:[]`, `total:0` in `http/adversarial-other-tenant.txt`; no dns-ops-e2e domain was returned.
+- Malformed input must not partially execute → `{bad-json` returned HTTP 400 `{error:"Invalid JSON in request body",code:"INVALID_JSON"}` in `http/adversarial-malformed.txt`.
+- Class selectors were not used by the drive; selectors were ARIA labels/roles.
+
+## Read-back
+- Direct POST read-back with the same authenticated headers and each view criterion returned HTTP 200: `direct-mail.txt` returned `mailbroken.example` and `unevaluated.example`; `direct-expiring.txt` returned `stale.example`; `direct-incomplete.txt` returned `unevaluated.example`. These are consistent with the view criteria and button-driven request bodies.
+- Duplicate identical POSTs returned HTTP 200 twice with the same three domain IDs/names and `total=3` (`http/adversarial-duplicate-1.txt`, `http/adversarial-duplicate-2.txt`), demonstrating no mutation or divergent result.
+- Harness read-backs are persisted in `readback/portfolio-search.json`, `readback/portfolio-expiry.json`, and `readback/built-in-view-requests.json`. The expiry fixture cleanup was confirmed independently with a database count of zero after the drive.
+- Browser evidence: `portfolio-search.png`, `no-auth-portfolio.png`, and `trace.zip`.
+
+## Residual
+- Console/failed-request logs contain expected dev noise: external Google font CORS failures, a missing dev CSS asset (404), and one aborted superseded search request; the asserted requests and final UI state completed successfully. No product assertion failed.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-004722Z-bc16baf-fresh/console.log | log | aux · unrecognized .log | 5078b2b6883d7638c35ce2f3215dc049c11c375908784d53331683d01f756f7c |
+| verification/runs/20260904-004722Z-bc16baf-fresh/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260904-004722Z-bc16baf-fresh/env.txt | env | aux | 5cd0a4b6005a357b5b3a0efe8be25b9c5c3d894c01ceaf51c3b6b7a10c2a09e1 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/failed-requests.log | log | aux · unrecognized .log | 11c6474a36d1577f83cd0d5c0f96e03f9ceb83e4ec93a86de8c2d087dc829ada |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/adversarial-duplicate-1.txt | txt | aux · unrecognized .txt | bc6bdef723e1a09747f45074ad861eee3d3189fbb5a81fa5fa95162bc3fcbf06 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/adversarial-duplicate-2.txt | txt | aux · unrecognized .txt | bc6bdef723e1a09747f45074ad861eee3d3189fbb5a81fa5fa95162bc3fcbf06 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/adversarial-malformed.txt | txt | aux · unrecognized .txt | ba5ed96d1ca8469dee2e9cda4fde141478e6e96237279c1a2928e182d71c3d2b |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/adversarial-other-tenant.txt | txt | aux · unrecognized .txt | b4059de196f83f3fa71bde6df066b5768a2f69e9f3d98645ab96a52dd188610e |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/direct-expiring.txt | txt | aux · unrecognized .txt | 74db6122ef231fc8cc9b4b3bc91852d2b6e3ef16defbbf1343ebc76fcf3adeae |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/direct-incomplete.txt | txt | aux · unrecognized .txt | 253d9d59c53eea3b1171a297b6ca4652703d2e7b058b4a926c47f80827464eef |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/direct-mail.txt | txt | aux · unrecognized .txt | 0a0b6fd00cc4789555c5c8febb55bd909074dfe87b30b37bfb4f98172896aa7d |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/no-auth-portfolio.html | html | aux · unrecognized .html | b32b4349f1b25443942ad9e931440460839805770ea47e43b9232c9e25c5a4dd |
+| verification/runs/20260904-004722Z-bc16baf-fresh/http/no-auth-search.txt | txt | aux · unrecognized .txt | 027f7f7b1df93150b1f5fd11425eed6592f03059dc169160d1561b96183c7a07 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/no-auth-portfolio.png | png | evidence · 1280x3825 | 3e467aa1e1acf9fae5f5cea2143f5b0fd14f8fe26f6cd5613f473f4e310bd428 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/observations.md | md | aux · unrecognized .md | 4e52b3dd54d6668a6868c4777a0ffe25645da1d63bdbbcef7e5d7cd83d5f8053 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/portfolio-search.png | png | evidence · 1280x5899 | 34c6b7335a1a969e39cedc00c0ddb0bf5271e9ce46cf5a7fb6a1c82c5320d911 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/readback/built-in-view-requests.json | readback | evidence | f9f1bf24c3395369ef8a06f51b03c9a1d9b795827f0cecec78ef3d1db3145458 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/readback/portfolio-expiry.json | readback | evidence | 88fbc8f687724cdde4bd4b334283aabdf287c7828ef032fe8eb55d786d232c2a |
+| verification/runs/20260904-004722Z-bc16baf-fresh/readback/portfolio-search.json | readback | evidence | ae1de13db09f970ed1087d1024d88773ba75da9784814310fa11dc2c3fd60b5e |
+| verification/runs/20260904-004722Z-bc16baf-fresh/trace.zip | trace | evidence · playwright trace | f14951714ed66306cc3ae216f6f8609644da4a09a466a730b8c7eb37e87ba0f7 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/video/524a8e6356137dc4ceee189feea1dd16.webm | video | evidence | af61557ec3c122ced76933d54a3097afd16b3e9d5518fe65448c618bd80d54b5 |
+| verification/runs/20260904-004722Z-bc16baf-fresh/video/75844fec0f528eaf4d07bab099eb228b.webm | video | evidence | d0365d35abce0451f4027efdf0e231326cb44eef490987bf23a43db18aa00842 |

--- a/verification/receipts/20260904-011752Z-4e37b1d-fresh--domain.overview.md
+++ b/verification/receipts/20260904-011752Z-4e37b1d-fresh--domain.overview.md
@@ -1,0 +1,57 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-011752Z-4e37b1d-fresh
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: 4e37b1d54282b2049f94284af4232c7695a69c61
+code_digest: 83c8e17a2ab7b3fb8268fd508060118e84c129b5f1ed436f61a8916af0e01ab8
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-011752Z-4e37b1d-fresh
+created_at: 2026-09-04T01:27:49.495Z
+---
+
+# Receipt: domain.overview — passed
+
+## Observations (expected → seen)
+- Home Domain name flow completed after waiting for authenticated hydration; submitting `google.com` navigated to `http://localhost:3011/domain/google.com?addToPortfolio=false&tab=dns` (route is `/domain/google.com`).
+- Domain 360 heading `google.com` rendered. Tabs Overview, DNS, Mail, History, and Delegation were visible.
+- Overview `Evidence completeness` region rendered before query statistics. Read-back summary reported `evaluationCoverage.state=COMPLETE`, `findingsEvaluated=true`, and `total=8`; rendered rule evaluation state was `complete` and Findings group state was `known` with 8 findings.
+- DNS Parsed view rendered `Remaining TTL` and `Estimated live at` headers. All 42 persisted record rows rendered both timing cells; 2 rows had live recursive TTL values. Live NS row showed `20640s` and `<time datetime="2026-09-04T07:10:46.000Z">`; live-at/countdown matched independent `estimateLiveAt` calculation from persisted observations and HTTP Date headers.
+- Persisted read-backs were captured in `readback/findings-summary.json`, `readback/dns-observations.json`, `readback/dns-ttl-audit.json`, and `readback/dns-ttl-cells.json`. Recursive evidence consisted of successful `public-recursive` observations from resolver `8.8.8.8`.
+
+## Forbidden (… → confirmed absent)
+- No stay-on-home behavior after the authenticated submit; the Domain 360 route and heading were reached.
+- No blank TTL cells, averaged-record TTL calculation, fabricated coverage percentage, or all-UNKNOWN TTL output. Unknown cells were explicit `UNKNOWN`; usable rows matched persisted recursive deadlines.
+- No mutation or provider-write action was performed; this drive only read snapshot/summary/observation endpoints and switched tabs.
+
+## Read-back
+- `GET /api/domain/google.com/latest` returned snapshot `7f668e3a-33c8-4114-9220-368b7ac940c0` with metadata marker `dnsQueryTimestampBasis=response-received-v1`.
+- `GET /api/snapshot/7f668e3a-33c8-4114-9220-368b7ac940c0/findings/summary` returned `total=8`, complete evaluation coverage, and `findingsEvaluated=true`.
+- `GET /api/snapshot/7f668e3a-33c8-4114-9220-368b7ac940c0/observations` returned 42 observations, including successful resolver-identified recursive answers; persisted-vs-rendered deadline audit is in `readback/dns-ttl-audit.json`.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-011752Z-4e37b1d-fresh/console.log | log | aux · unrecognized .log | 30a1314f9ade3e3c4968e66a7ac34e2320be5c6beb097b44abac8cd8fa9c8fb2 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/doctor.txt | txt | aux · unrecognized .txt | 709aeac5592718a147971beb5e772384f35cce73c7f517ef997bed9232098554 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/domain-dns-parsed-ttl.png | png | evidence · 1557x3964 | 6d72101da1f4377b06b3bd82f8ecfab5a355e2f16e7bea1a8ce22ad91dac666a |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/domain-overview.png | png | evidence · 1280x2584 | fbd14e1555844d271c45e4106ad639fada8c28c856863e9d08a636a6d99960da |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/env.txt | env | aux | 4cea034fe560d27064c811b5aadbfb08f8f3158dd8a2d8807be965c5d190448a |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/failed-requests.log | log | aux · unrecognized .log | 324fe0e5d35c1f93b84979b6c178c71d282593aa3119f83d2d8db78c55cebf30 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/observations.md | md | aux · unrecognized .md | b269340d16feb76586d80ffe1c165226e8fed8ca963fc3a9dac55c072c39fdda |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/readback/dns-observations.json | readback | evidence | 331ffb89bc1a4ba0ba61b010c564e5e01358b49b9ff443c30c9c3bafe3b79792 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/readback/dns-ttl-audit.json | readback | evidence | b73b580fdf4ac98f69042a4816f8af2d18d563cbd14357897e59c3c9ad922552 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/readback/dns-ttl-cells.json | readback | evidence | 4c5ef3b65eb52f59f72987a7b390a16c1743749a632d63b874543cf62506c329 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/readback/findings-summary.json | readback | evidence | 2a7079c1a36b26bc3b1e2dbbab757b3c7b04dcdb40550c44980609dfc4ca8895 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/trace.zip | trace | evidence · playwright trace | 3744836a563071e59d60f0d084c1656bcef8ee30b425bbec4c4f1d193c256814 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/video/03922a8d147c04d1b100fe88324c04f0.webm | video | evidence | b5ed8de02d67e256e32cc4935c608792611f2b33200b445be61ebe8af7fd00a6 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/video/495f639a11934a16aa0baa07d14f0e62.webm | video | evidence | 754328a67132fefa49c7c0a5817f3a6592154f794a4101215c24f3d78e85fec4 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/video/ab7c4932ad639dbeca475abb918993da.webm | video | evidence | 629163b9390a7b0bbb59ad92d57aaec1ff4a95c0e716079d5d2fc959e0ac7123 |
+| verification/runs/20260904-011752Z-4e37b1d-fresh/video/e682068daf439f56267de02bc4928835.webm | video | evidence | 851dbf7321b138468af7530ebf6202a6dd537188cdff358033a2c1654f029179 |

--- a/verification/receipts/20260904-013355Z-d350a01-fresh--domain.overview.md
+++ b/verification/receipts/20260904-013355Z-d350a01-fresh--domain.overview.md
@@ -1,0 +1,71 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-013355Z-d350a01-fresh
+feature_id: domain.overview
+profile: changed
+surface: web
+sha: d350a01d108d62e0e4c6d50011d44cc1209d2e2d
+code_digest: 3e23316b1319fa1791be282ea38dd5d64626848a22df59cfe1f698f5f57f1801
+dirty: false
+untracked: 2
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-013355Z-d350a01-fresh
+created_at: 2026-09-04T01:59:19.994Z
+---
+
+# Receipt: domain.overview — passed
+
+## Observations
+- URL: http://localhost:3315/domain/google.com?addToPortfolio=false&tab=dns
+- Tabs Overview/DNS/Mail/History visible; Delegation count 1.
+- Snapshot 7f668e3a-33c8-4114-9220-368b7ac940c0; latest HTTP 200; timing basis response-received-v1.
+- Findings summary HTTP 200: total=8, evaluationCoverage=COMPLETE, findingsEvaluated=true.
+- Rendered evaluation indicator state=complete; findings group state=known.
+- DNS persisted observations=42, expected record rows=42, rendered rows=42, live rows=2, UNKNOWN rows=40.
+- All rendered live rows matched persisted recursive evidence deadlines; every row had Remaining TTL and Estimated live at/UNKNOWN.
+- Mail tab loaded persisted Mail Findings (6 findings) and the authenticated actionable-type discovery returned HTTP 200 with 8 supportedTypeIds; no current finding type matched those IDs, so 0 Simulate buttons were expected.
+
+## Forbidden
+- No provider-write or Apply control observed; no mutations performed.
+
+## Read-back
+- {"snapshotId":"7f668e3a-33c8-4114-9220-368b7ac940c0","findingsEvaluated":true,"evaluationCoverage":{"state":"COMPLETE","errors":[]},"hasFindings":true,"severityCounts":{"critical":1,"high":1,"medium":1,"low":0,"info":5},"total":8}
+- observations endpoint status=200
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-013355Z-d350a01-fresh/console-domain-final.log | log | aux · unrecognized .log | 385907a96cfc52c690797a868b08f7028cc1024f7f74b3339b170ed7031ac136 |
+| verification/runs/20260904-013355Z-d350a01-fresh/console-mail.log | log | aux · unrecognized .log | da2705fb51f96c1f7fb3ec2b53e4fa2cec15a64d9acf7364bbf0301e64732fd1 |
+| verification/runs/20260904-013355Z-d350a01-fresh/console-portfolio-evidence.log | log | aux · unrecognized .log | 0c1488bf2d940fc3932fbf1218381fa1c0c2656f464af61e1023dae087094681 |
+| verification/runs/20260904-013355Z-d350a01-fresh/console.log | log | aux · unrecognized .log | 0a0002f6930f265e7fecb09550ecd1ae8ccff41eb9c1bcda54302a3c41b97cd7 |
+| verification/runs/20260904-013355Z-d350a01-fresh/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260904-013355Z-d350a01-fresh/domain-dns-final.png | png | evidence · 1557x3964 | 04d678729f489acd7065cc1628f49adee858284fa183e46e57accc8ba79ec6a1 |
+| verification/runs/20260904-013355Z-d350a01-fresh/domain-mail-final.png | png | evidence · 1280x3265 | c18a830b634918ce44180404ceb028d86704958f9168c4c38fa779e44f32d358 |
+| verification/runs/20260904-013355Z-d350a01-fresh/domain-mail-observations.md | md | aux · unrecognized .md | b4ed2b542fbe21e59e82faea94abe20afab9c5e9c68263ff2369a1eb27bacb20 |
+| verification/runs/20260904-013355Z-d350a01-fresh/domain-overview-final.png | png | evidence · 1280x2584 | fbd14e1555844d271c45e4106ad639fada8c28c856863e9d08a636a6d99960da |
+| verification/runs/20260904-013355Z-d350a01-fresh/domain-overview-manual.png | png | evidence · 1280x2584 | fbd14e1555844d271c45e4106ad639fada8c28c856863e9d08a636a6d99960da |
+| verification/runs/20260904-013355Z-d350a01-fresh/env.txt | env | aux | b480dfe34aaec649ae8c1a587f4cc6f6a4b906c59f4e40c45a6834419e84ee36 |
+| verification/runs/20260904-013355Z-d350a01-fresh/failed-requests.log | log | aux · unrecognized .log | 8d9d7ce995b2a02e86980458fc31047dd934aff63e10110f1b2a0f735d689f15 |
+| verification/runs/20260904-013355Z-d350a01-fresh/manual-domain-overview.png | png | evidence · 1280x2584 | fbd14e1555844d271c45e4106ad639fada8c28c856863e9d08a636a6d99960da |
+| verification/runs/20260904-013355Z-d350a01-fresh/observations-domain.md | md | aux · unrecognized .md | 9e35637950a2a28080aebbcadc7b15b6afa6ceb10bb95a5b4a1c7bfb4291f6e2 |
+| verification/runs/20260904-013355Z-d350a01-fresh/observations-portfolio.md | md | aux · unrecognized .md | 64e4c27040de50dcbd8ceb9b99c5fd721219d4766fd55b74231d69f1846d2ef7 |
+| verification/runs/20260904-013355Z-d350a01-fresh/portfolio-failure-state.png | png | evidence · 1280x5899 | ba7d2a5ec02675ab24d469edcc15c29035653aa4978a3829ef70956bac4c3dbb |
+| verification/runs/20260904-013355Z-d350a01-fresh/trace-domain-final.zip | trace | evidence · playwright trace | 60e9be3a68e9c6a4e51bd9665266d69597f1c33c07f75898ac7d47f99c81af61 |
+| verification/runs/20260904-013355Z-d350a01-fresh/trace-mail.zip | trace | evidence · playwright trace | 89dbae64121e16a937456f75f56962caaf3ae201e0d25b5dae6cd373cf03b3b1 |
+| verification/runs/20260904-013355Z-d350a01-fresh/trace-portfolio-evidence-failed.zip | trace | evidence · playwright trace | 732d94e9b51fc009a02c51d4a00b5366b528f468ad9ca0d38ea4c374da085af6 |
+| verification/runs/20260904-013355Z-d350a01-fresh/trace-portfolio-evidence.zip | trace | evidence · playwright trace | 0912aa8f3cb3c1a34d704a3cc0c6b57783fcc0254b972c47f476f9bd03fc8404 |
+| verification/runs/20260904-013355Z-d350a01-fresh/trace-portfolio-failed.zip | trace | evidence · playwright trace | d66f72edffcf0e526f36ee46d6ba64c00f815f72749092a5228daf2c35f991be |
+| verification/runs/20260904-013355Z-d350a01-fresh/trace.zip | trace | evidence · playwright trace | dfda765e58c19f48f0a27e16d916753cdc75e7bebd6d438bce4d81edd07ab9c3 |
+| verification/runs/20260904-013355Z-d350a01-fresh/video-domain2/8246dd4262923bab48d077c93fbdb218.webm | video | evidence | 8762f84b17f9946fa0d90c58c2bcc18d72b8dc11779d7aa7142cb96a01710f2e |
+| verification/runs/20260904-013355Z-d350a01-fresh/video-domain3/bbdbc0e3a79dbadcdf9b68a0d9b40dda.webm | video | evidence | 9469c54d682f1e007459331b8b018be83d81ddc06f1e701a3e86370b3f4f2ed7 |
+| verification/runs/20260904-013355Z-d350a01-fresh/video-mail/a12379d3eac46fa8c859a3f12966fcad.webm | video | evidence | 56379d442fa83d0fa5ae7d08ffac82537bfebf0b9064046d45355bfc38ee3f6b |
+| verification/runs/20260904-013355Z-d350a01-fresh/video-mail/f0d0b98e46322f8bb628877d9c55950d.webm | video | evidence | 0e609d1f8ba06e9ce40f31825409384ac10647d8219db248ee0c95b430c32114 |
+| verification/runs/20260904-013355Z-d350a01-fresh/video-portfolio-evidence/03ff8d3212ca69155c8fddb248605195.webm | video | evidence | cfd83bbd2d793772aead80170d976da31db7cff845df7bdfa861fddee3bcf1be |
+| verification/runs/20260904-013355Z-d350a01-fresh/video-portfolio/f6bc1c592931bd1c5bd793f7d8185a93.webm | video | evidence | e44841d4e66cef5dc8796e4120e156c523cd7c4e68d7693ae807644dd5dd14dc |
+| verification/runs/20260904-013355Z-d350a01-fresh/web-prod.log | log | aux · unrecognized .log | 7e0731ce5dfdbc16365785a4731a6dbe88b7998845359df75dbc7c23b42b5006 |
+| verification/runs/20260904-013355Z-d350a01-fresh/web.log | log | aux · unrecognized .log | 2a57dc37d3bb51d4f032279e1a7dfc48a50559f11024abda43380879ef5ce4c4 |

--- a/verification/receipts/20260904-020051Z-d350a01-fresh--portfolio.search.md
+++ b/verification/receipts/20260904-020051Z-d350a01-fresh--portfolio.search.md
@@ -1,0 +1,66 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-020051Z-d350a01-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: d350a01d108d62e0e4c6d50011d44cc1209d2e2d
+code_digest: 26b1f5aecaf5cee49a5350c2c9e890d6bbf812edff7d157123dcd1e8bb4c8535
+dirty: false
+untracked: 1
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-020051Z-d350a01-fresh
+created_at: 2026-09-04T02:18:12.803Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- Portfolio workflows and Portfolio Search headings → rendered at /portfolio.
+- Query search with verify-expiry-observed.example.test and verify-expiry-unknown.example.test → POST 200 returned both; observed expiration status OBSERVED, unknown status UNKNOWN.
+- Built-in views → POST bodies recorded in readback/custom-results.json: mail findingTypePrefix mail. and severities high/critical; expiring snapshotOlderThanDays 30; incomplete coverage incomplete; incomplete aria-pressed true.
+- Re-click active Incomplete coverage → POST body {"limit":20,"offset":0}; aria-pressed changed from true to false.
+- Expiry 90 → POST body expirationWithinDays 90; results ["verify-expiry-observed.example.test"].
+
+## Forbidden (… → confirmed absent)
+- No sign-in warning observed with local dev headers.
+- No class selectors used.
+
+- Saved filter UI round-trip → saved-filter-transcript.txt records POST 201 with criteria {"expirationWithinDays":90}, a fresh page loading the filter, POST search body expirationWithinDays=90, select value 90, API read-back criteria, and DELETE 200 cleanup.
+
+## Adversarial
+- Tenant isolation → X-Dev-Tenant=another-tenant returned {"domains":[],"total":0}; current tenant returned two seeded fixture domains.
+- Malformed expiry input → expirationWithinDays=999 returned HTTP 400 VALIDATION_ERROR and no write.
+- Duplicate search requests are read-only and returned consistent 200 JSON; no persistent search write exists.
+
+## Read-back
+- See readback/custom-results.json, custom-network.json, saved-filter-transcript.txt, and readback/search-{current,other,malformed}.json.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-020051Z-d350a01-fresh/console.log | log | aux · unrecognized .log | a0cab3bf0f0596bc8ea77a62a530e64af97583143d4dd910637770cd11f5eac4 |
+| verification/runs/20260904-020051Z-d350a01-fresh/custom-network.json | json | aux · unrecognized .json | 5834200ba7c938f7f9083d953846eaebbe5ce745bb2fcc93b58f4232c9f15fae |
+| verification/runs/20260904-020051Z-d350a01-fresh/custom-trace.zip | trace | evidence · playwright trace | ea3c53b9e3f039a8fe7c5d01cf39f8af7a019cdd12195c26cfa08e34ed39b8e4 |
+| verification/runs/20260904-020051Z-d350a01-fresh/custom-transcript.txt | txt | aux · unrecognized .txt | 5b76c08c9e0c7613ade16e4eeec0706c805e33fe7ac7acf6f32188b70cac298a |
+| verification/runs/20260904-020051Z-d350a01-fresh/doctor-healthy.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260904-020051Z-d350a01-fresh/doctor.txt | txt | aux · unrecognized .txt | f00cb41b580d6ab465a783f8cc6d81f9afb6a09ba8a5978a4eefe6cafb35016d |
+| verification/runs/20260904-020051Z-d350a01-fresh/env.txt | env | aux | e3f6deaf6413204d7a37d23adb873f32662145245502fe935fdf22c8f4288eb2 |
+| verification/runs/20260904-020051Z-d350a01-fresh/failed-requests.log | log | aux · unrecognized .log | ddb532d94de00f451c3a111da2b9a7e6e614f204c0193fd55defc7b2dc297b47 |
+| verification/runs/20260904-020051Z-d350a01-fresh/observations.md | md | aux · unrecognized .md | a28318fc79deb0cc71afd868fe6887250160c0543e1645accf96b0bf0811d2e6 |
+| verification/runs/20260904-020051Z-d350a01-fresh/portfolio-custom.png | png | evidence · 1280x6359 | d205c6c340f80023b658f8efdb355c69a8a1e78bd0abaebb28d7df68c3e0d798 |
+| verification/runs/20260904-020051Z-d350a01-fresh/portfolio-expiry-custom.png | png | evidence · 1280x5899 | 4a19dbd2ee2d9f671f5cad0adfeae2c29fb1a61592f3d692f7b629e449d621c7 |
+| verification/runs/20260904-020051Z-d350a01-fresh/readback/custom-results.json | readback | evidence | c1f7a7f5a076a34782ab830253013836b1e9e50e11df4296fcefb4eb4ecf2a76 |
+| verification/runs/20260904-020051Z-d350a01-fresh/readback/search-current.headers | headers | aux · unrecognized .headers | c5a4b381f09c597961a437120dad0c6fd95e619c7f3487394ea5a28ac2348732 |
+| verification/runs/20260904-020051Z-d350a01-fresh/readback/search-current.json | readback | evidence | bcbfa48ef0ce35347cff4be8c1c477cecc1191357172015d9171c2ad45fac218 |
+| verification/runs/20260904-020051Z-d350a01-fresh/readback/search-malformed.headers | headers | aux · unrecognized .headers | a48782222bf71ef02234a96fe96d0d899df0aaaab108a6e07870e085f27bc430 |
+| verification/runs/20260904-020051Z-d350a01-fresh/readback/search-malformed.json | readback | evidence | 8e85f4acc73243137880c6b75982fed476a114969101bffdfaf801b0a8d21c7f |
+| verification/runs/20260904-020051Z-d350a01-fresh/readback/search-other.headers | headers | aux · unrecognized .headers | c5a4b381f09c597961a437120dad0c6fd95e619c7f3487394ea5a28ac2348732 |
+| verification/runs/20260904-020051Z-d350a01-fresh/readback/search-other.json | readback | evidence | e2e95b06c3d79456717fcbbbe62ab551c1b37f4ee59f018856a6fd2cfdd189dc |
+| verification/runs/20260904-020051Z-d350a01-fresh/saved-filter-transcript.txt | txt | aux · unrecognized .txt | 5777d82a9e5bf9d348b70871c8500f0f748cadeaa67c70bac13356dd093802db |
+| verification/runs/20260904-020051Z-d350a01-fresh/trace.zip | trace | evidence · playwright trace | 24e559c2f645b5235409bef0101a70827ce8c6bd11f854487241439066bbc47f |
+| verification/runs/20260904-020051Z-d350a01-fresh/video/1926d7061a6e41909301280b1b9be83f.webm | video | evidence | 95a6a6b003da9c7cd594822c1a16cb2142e142d0db6bd28e8389e94a1f80f30c |

--- a/verification/receipts/20260904-022403Z-2791d21-fresh--portfolio.search.md
+++ b/verification/receipts/20260904-022403Z-2791d21-fresh--portfolio.search.md
@@ -1,0 +1,55 @@
+---
+receipt: verification-receipt/v0
+run_id: 20260904-022403Z-2791d21-fresh
+feature_id: portfolio.search
+profile: critical
+surface: web
+sha: 2791d21919fe7fcf6497e9ffd2f2e9ccf38f8c8d
+code_digest: 3e23316b1319fa1791be282ea38dd5d64626848a22df59cfe1f698f5f57f1801
+dirty: false
+untracked: 0
+status: passed
+reason: ""
+verifier: fresh
+verifier_session: "pi-fresh:01a0685f-503f-71e1-9e12-291c2fb7313b"
+evidence_dir: verification/runs/20260904-022403Z-2791d21-fresh
+created_at: 2026-09-04T02:34:25.069Z
+---
+
+# Receipt: portfolio.search — passed
+
+## Observations (expected → seen)
+- `GET /portfolio` on the checkout's web process (APP_URL `http://localhost:3314`) rendered headings `Portfolio workflows`, `Portfolio Search`, and `Built-in views`; the `Query` control accepted `verify-expiry`.
+- Query-driven POST returned HTTP 200 with `{query:"verify-expiry",limit:20,offset:0}` and two fixture domains: `verify-expiry-observed.example.test` and `verify-expiry-unknown.example.test`.
+- Mail broken click issued HTTP 200 POST body `{severities:["high","critical"],limit:20,offset:0,findingTypePrefix:"mail."}`; response names were `mailbroken.example` and `unevaluated.example`.
+- Expiring evidence click issued HTTP 200 POST body `{limit:20,offset:0,snapshotOlderThanDays:30}`; response names were `["stale.example"]`.
+- Incomplete coverage click issued HTTP 200 POST body `{limit:20,offset:0,coverage:"incomplete"}` and the button reported `aria-pressed="true"`; response names were `["unevaluated.example"]`.
+- Clicking the active incomplete-coverage button again changed `aria-pressed` to `false` and issued a clearing HTTP 200 POST body `{limit:20,offset:0}` with no view criteria.
+- Results table `Portfolio search results by domain` had `DOMAIN`, `FINDINGS`, and `EXPIRY` columns. The observed fixture rendered `Oct 18, 2026` and `WITHIN_90`; the unknown fixture rendered literal `UNKNOWN`.
+- Selecting `Expiry window` = `Within 90 days` issued HTTP 200 POST body `{expirationWithinDays:90,limit:20,offset:0}` and returned only `verify-expiry-observed.example.test` (the unknown fixture was absent).
+
+## Forbidden (… → confirmed absent)
+- Sign-in warning as a substitute for search → absent; local e2e identity rendered `e2e-bot@dns-ops.local` and all search calls returned 200.
+- Client-only built-in filtering → absent; direct POST read-back for each view returned server-filtered sets matching the button requests.
+- Class selectors in the drive → none used; all interactions used headings, labels, and button roles.
+
+## Read-back
+- `readback/manual-portfolio-check.json` records button-driven request bodies/responses and independent direct POST read-backs. Direct POST statuses were 200 for query, mail, expiring, and incomplete criteria; totals/names were 2/2, 2/2, 1/1, and 1/1 respectively.
+- The same read-back records expiry POST status 200, `expirationWithinDays:90`, and returned names `["verify-expiry-observed.example.test"]`.
+- `manual-portfolio-clear.png` captures the cleared-view UI; `trace.zip` and `doctor.txt` capture the run and healthy app check.
+
+## Artifacts
+
+| path | kind | check | sha256 |
+|---|---|---|---|
+| verification/runs/20260904-022403Z-2791d21-fresh/console.log | log | aux · unrecognized .log | 24422381521cab3693dda0cae365a70115224fbc71e28ba0c2aa9a9e7a538a77 |
+| verification/runs/20260904-022403Z-2791d21-fresh/doctor.txt | txt | aux · unrecognized .txt | 291b74911bf6dfd21a1053e0e8228c479187272578439eb81b5a8d36a6fd7e6c |
+| verification/runs/20260904-022403Z-2791d21-fresh/env.txt | env | aux | 9a17e356f33e09a46ee8c97305deb7d280566b763badc3ae99fc2d3d58501c25 |
+| verification/runs/20260904-022403Z-2791d21-fresh/failed-requests.log | log | aux · unrecognized .log | 1ffaff6d17f8e62b787f6ca21d02b913137e0f756bc1f0062b0c15b7ea23c243 |
+| verification/runs/20260904-022403Z-2791d21-fresh/manual-clear-view.png | png | evidence · 1280x6359 | 031e2835300d8aa388a66941394c824deb2b4c88c2c3bfdd91ed86fbe777fb8f |
+| verification/runs/20260904-022403Z-2791d21-fresh/manual-portfolio-clear.png | png | evidence · 1280x6359 | d9131b98de068058aa6903f41a823ffff16d4ae1c19883db380c94a216acd01b |
+| verification/runs/20260904-022403Z-2791d21-fresh/manual-trace.zip | trace | evidence · playwright trace | 18b2c68d193d44cf686e0c18288cfa5b4c217db498d8a41e1e215683c5d3d3f5 |
+| verification/runs/20260904-022403Z-2791d21-fresh/observations.md | md | aux · unrecognized .md | 3cb08426c308272b91cc2f9e13c19006b01ab85aab0b9095391cd1510ec0b371 |
+| verification/runs/20260904-022403Z-2791d21-fresh/readback/manual-clear.json | readback | evidence | e5e3e578cf00b9a7cd28f50877650f7450e1a6281593cc30b6d9608fafe53fb0 |
+| verification/runs/20260904-022403Z-2791d21-fresh/readback/manual-portfolio-check.json | readback | evidence | 42ca53c134a91d87111fbe72819c9c45b1b06525fbb46afa20cd6d0b7e74024e |
+| verification/runs/20260904-022403Z-2791d21-fresh/trace.zip | trace | evidence · playwright trace | b099f9977b2cdfef269f2fc66efbe2a4d6692ac443f627cff50865e9a554f807 |


### PR DESCRIPTION
Closes #62. Adds an allowlist-gated, two-person-confirmed Live-01–03 drill start UI and server route; non-allowlisted domains remain observation-only and no secrets are stored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #62 by adding an allowlist-gated, two-person-confirmed UI and server route for starting LIVE-01–03 live drills. Non-allowlisted domains stay observation-only, and no provider or fixture secrets are stored.

**New Features**
- The portfolio page's Live Drills panel lists allowlisted tuples and run history.
- Starts follow request → confirm → start; the record name always comes from the manifest, never the request.
- The `drill_runs` migration adds a partial unique index that enforces a single open drill.
- Missing harness or manifest fails closed, and nonzero runner exits mark the run failed.
- Adds route-level and e2e coverage, plus fresh verification receipts for portfolio search and domain overview.

<sup>Written for commit 54d9fc41c3218716c9c958ee1c4d209788b9ac10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/computindev/dns-ops/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

