### PR TITLE
ci: use org self-hosted runner computindev-vps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   ci:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, computindev-vps]
     timeout-minutes: 20
     services:
       postgres:
@@ -154,7 +154,7 @@ jobs:
 
   verify-kit:
     name: verify-kit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, computindev-vps]
     timeout-minutes: 5
     steps:
       - name: Checkout


### PR DESCRIPTION
Blacksmith is gone. Route Linux GitHub Actions jobs to the org runner `chief-staff-gha-01`.

```yaml
runs-on: [self-hosted, linux, x64, computindev-vps]
```

macOS/Windows jobs are unchanged. One VPS runner: jobs serialize.
