### PR TITLE
fix(ci): restore GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   ci:
     name: Build & Test
-    runs-on: [self-hosted, linux, x64, computindev-vps]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
       postgres:
@@ -154,7 +154,7 @@ jobs:
 
   verify-kit:
     name: verify-kit
-    runs-on: [self-hosted, linux, x64, computindev-vps]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- restore both CI jobs to GitHub-hosted `ubuntu-latest` runners
- remove dependency on the unavailable `computindev-vps` self-hosted label

## Scope
- `.github/workflows/ci.yml` only
- no product, test, service, timeout, dependency, or command changes

## Validation
- `git diff --check` passed
- YAML parse and exact two-line diff assertions passed
- verify-kit `check-commit --working-tree` passed
- UBS ran; YAML-only diff has no supported language scanner

This enables fresh hosted CI execution; merge requires the exact-head checks to pass and fresh review.